### PR TITLE
Add in-game design guide and auto-discover CloudFront during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,92 +8,128 @@ on:
 
 jobs:
   deploy:
-    name: Sync static site
+    name: Build & Deploy
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    outputs:
+      cloudfront_distribution_id: ${{ steps.discover.outputs.distribution-id }}
+      cloudfront_url: ${{ steps.discover.outputs.distribution-domain }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Validate deployment secrets
+      - name: Validate AWS secrets
+        id: validate
         env:
-          REQUIRED_SECRETS: >-
-            AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION AWS_S3_BUCKET
-            CLOUDFRONT_DISTRIBUTION_ID CLOUDFRONT_URL
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          CLOUDFRONT_URL: ${{ secrets.CLOUDFRONT_URL }}
         run: |
+          set -euo pipefail
           missing=()
-          for name in $REQUIRED_SECRETS; do
-            value=$(printf '%s' "${!name}")
-            if [ -z "$value" ]; then
-              missing+=("$name")
+          for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION AWS_S3_BUCKET; do
+            if [ -z "${!var:-}" ]; then
+              missing+=("$var")
             fi
           done
           if [ ${#missing[@]} -gt 0 ]; then
-            echo "::error::Missing required secrets: ${missing[*]}" >&2
-            echo "Add each secret in GitHub → Settings → Secrets and variables → Actions." >&2
-            for name in "${missing[@]}"; do
-              case "$name" in
-                AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY)
-                  echo "::error::$name is empty. Create an IAM user with programmatic access and paste its key pair." >&2
-                  ;;
-                AWS_REGION)
-                  echo "::error::$name is empty. Set it to the AWS region of your S3 bucket (for example, us-east-1)." >&2
-                  ;;
-                AWS_S3_BUCKET)
-                  echo "::error::$name is empty. Provide the target bucket name without the s3:// prefix." >&2
-                  ;;
-                CLOUDFRONT_DISTRIBUTION_ID)
-                  echo "::error::$name is empty. Provide the CloudFront distribution ID to invalidate." >&2
-                  ;;
-                CLOUDFRONT_URL)
-                  echo "::error::$name is empty. Provide the public CloudFront URL so the workflow can announce it." >&2
-                  ;;
-              esac
-            done
+            printf '::error::Missing required GitHub secret(s): %s
+' "${missing[*]}"
+            {
+              echo '### ❌ Deployment blocked'
+              echo ''
+              echo 'The workflow cannot continue because the following secrets are missing:'
+              for name in "${missing[@]}"; do
+                echo "- \`${name}\`"
+              done
+              echo ''
+              echo '#### How to fix'
+              echo '1. Open **Settings → Secrets and variables → Actions** in this repository.'
+              echo '2. Create each secret listed above with the exact name.'
+              echo '3. Re-run the workflow from the Actions tab once the secrets are saved.'
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Upload site to S3
+      - name: Sync site to S3
         env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          DEPLOY_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
         run: |
-          aws s3 sync . "s3://${AWS_S3_BUCKET}" \
-            --delete \
-            --exclude ".git/*" \
-            --exclude ".github/*"
+          set -euo pipefail
+          if [ -z "${DEPLOY_BUCKET}" ]; then
+            echo '::error::AWS_S3_BUCKET secret resolved to an empty string. Ensure the secret contains the bucket name.'
+            exit 1
+          fi
+          aws s3 sync . "s3://${DEPLOY_BUCKET}" --delete --exclude ".git/*" --exclude ".github/*" --exclude "README.md" --exclude "LICENSE"
+
+      - name: Discover CloudFront distribution
+        id: discover
+        env:
+          DEPLOY_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          set -euo pipefail
+          ORIGIN_CLASSIC="${DEPLOY_BUCKET}.s3.amazonaws.com"
+          ORIGIN_REGIONAL="${DEPLOY_BUCKET}.s3.${AWS_REGION}.amazonaws.com"
+          ORIGIN_WEBSITE="${DEPLOY_BUCKET}.s3-website-${AWS_REGION}.amazonaws.com"
+          MATCH=$(aws cloudfront list-distributions --query "DistributionList.Items[?Origins.Items[?DomainName=='${ORIGIN_CLASSIC}' || DomainName=='${ORIGIN_REGIONAL}' || DomainName=='${ORIGIN_WEBSITE}']]|[0]")
+          if [ -z "$MATCH" ] || [ "$MATCH" = "null" ]; then
+            echo '::error::No CloudFront distribution is configured for the provided S3 bucket.'
+            {
+              echo '### ❌ CloudFront distribution not found'
+              echo ''
+              echo "No CloudFront distribution could be matched to bucket \`${DEPLOY_BUCKET}\` in region \`${AWS_REGION}\`."
+              echo ''
+              echo '#### How to fix'
+              echo '1. Create a CloudFront distribution with the S3 bucket as an origin (Origin Access Control recommended).'
+              echo '2. Alternatively, ensure an existing distribution origin domain exactly matches one of:'
+              echo "   - ${ORIGIN_CLASSIC}"
+              echo "   - ${ORIGIN_REGIONAL}"
+              echo "   - ${ORIGIN_WEBSITE}"
+              echo '3. Re-run this workflow to publish the site once the distribution exists.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          CF_ID=$(echo "$MATCH" | jq -r '.Id // empty')
+          CF_DOMAIN=$(echo "$MATCH" | jq -r '.DomainName // empty')
+          if [ -z "$CF_ID" ] || [ -z "$CF_DOMAIN" ]; then
+            echo '::error::CloudFront distribution is missing an Id or DomainName. Inspect the AWS console.'
+            exit 1
+          fi
+          echo "distribution-id=${CF_ID}" >> "$GITHUB_OUTPUT"
+          echo "distribution-domain=https://${CF_DOMAIN}" >> "$GITHUB_OUTPUT"
+          {
+            echo '### ✅ CloudFront distribution detected'
+            echo ''
+            echo "- **Distribution ID**: \`${CF_ID}\`"
+            echo "- **CloudFront URL**: https://${CF_DOMAIN}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Invalidate CloudFront cache
         env:
-          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          DISTRIBUTION_ID: ${{ steps.discover.outputs.distribution-id }}
         run: |
-          aws cloudfront create-invalidation \
-            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
-            --paths '/*'
+          set -euo pipefail
+          if [ -z "${DISTRIBUTION_ID}" ]; then
+            echo '::error::CloudFront distribution ID is empty. Check the discovery step output.'
+            exit 1
+          fi
+          aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths '/*'
 
-      - name: Publish deployment URL
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          CLOUDFRONT_URL: ${{ secrets.CLOUDFRONT_URL }}
+      - name: Announce deployment URL
         run: |
-          cat <<'SUMMARY' >> "$GITHUB_STEP_SUMMARY"
-          ## Infinite Rails Deployment
-          - ✅ Site synced to **${AWS_S3_BUCKET}**
-          - ✅ CloudFront invalidated (**${CLOUDFRONT_DISTRIBUTION_ID}**)
-          - 🌐 Play it live: **${CLOUDFRONT_URL}**
-          SUMMARY
-          echo "CloudFront URL: ${CLOUDFRONT_URL}"
+          set -euo pipefail
+          echo "::notice::Deployment available at ${{ steps.discover.outputs.distribution-domain }}"
+          {
+            echo '### 🌐 Play the latest build'
+            echo ''
+            echo "- CloudFront URL: ${{ steps.discover.outputs.distribution-domain }}"
+            echo "- Distribution ID: \`${{ steps.discover.outputs.distribution-id }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Infinite Rails is a browser-based voxel survival-puzzle prototype built entirely
 - **Order-based crafting** – drag items into a sequence to unlock equipment, igniters, and keys.
 - **Tactical survival** – manage hearts, oxygen, and day/night zombie assaults while guarding your rails.
 - **Dynamic UI** – responsive codex, animated progress indicators, and adaptive theming that reflects the active realm.
+- **Built-in guide** – open the in-game "Game Guide" for the full design document and survival walkthrough.
 - **Victory chase** – capture the Eternal Ingot in the collapsing Netherite dimension and return to the origin island.
 
 ## Controls
@@ -46,14 +47,17 @@ This repository ships with a GitHub Actions workflow that deploys the static sit
 | `AWS_SECRET_ACCESS_KEY` | Matching secret key |
 | `AWS_REGION` | AWS region that hosts the target bucket |
 | `AWS_S3_BUCKET` | Name of the S3 bucket that serves the site |
-| `CLOUDFRONT_DISTRIBUTION_ID` | Distribution to invalidate after uploading |
-| `CLOUDFRONT_URL` | CloudFront URL that players can use to access the deployed build |
+
+> The workflow fails fast when any secret is missing and writes detailed remediation steps (including the exact secret
+> name) to the job summary and log output.
 
 ### Deployment flow
 
-1. Workflow validates that all secrets are present and emits actionable errors when any are missing.
+1. Workflow validates that all required AWS secrets exist. Missing secrets trigger an actionable failure with setup steps.
 2. AWS credentials are configured via `aws-actions/configure-aws-credentials`.
-3. The repository contents (excluding `.git` and `.github`) are synchronised to the S3 bucket.
-4. CloudFront cache is invalidated and the public URL is published in the workflow summary.
+3. Repository contents (excluding version control and workflow files) are synchronised to the target S3 bucket.
+4. The workflow automatically discovers the CloudFront distribution attached to the S3 origin, invalidates its cache,
+   and exposes both the distribution ID and URL as job outputs. The URL is also written to the run summary for quick access.
 
-After a successful run, open the printed CloudFront URL to play the latest build.
+If no CloudFront distribution matches the S3 bucket, the workflow fails with instructions to create or tag one before
+redeploying.

--- a/index.html
+++ b/index.html
@@ -19,10 +19,13 @@
         <h1>Infinite Rails</h1>
         <span class="subtitle">Portals of Dimension</span>
       </div>
-      <div class="status-area">
-        <div class="status-item hearts" id="hearts"></div>
-        <div class="status-item bubbles" id="bubbles"></div>
-        <div class="status-item time" id="timeOfDay"></div>
+      <div class="top-actions">
+        <button type="button" id="openGuide" class="ghost">Game Guide</button>
+        <div class="status-area">
+          <div class="status-item hearts" id="hearts"></div>
+          <div class="status-item bubbles" id="bubbles"></div>
+          <div class="status-item time" id="timeOfDay"></div>
+        </div>
       </div>
     </header>
     <main class="main-layout">
@@ -106,6 +109,122 @@
         </ul>
         <button id="startButton" class="primary">Enter the Rails</button>
       </div>
+    </div>
+
+    <div
+      class="modal guide-modal"
+      id="guideModal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="guideTitle"
+      hidden
+    >
+      <article class="guide-content" data-guide-scroll>
+        <header class="guide-header">
+          <div>
+            <p class="guide-eyebrow">Game Design Document &amp; User Manual</p>
+            <h2 id="guideTitle">Infinite Rails: Portals of Dimension</h2>
+          </div>
+          <button type="button" class="ghost" data-close-guide>Close</button>
+        </header>
+        <section class="guide-section">
+          <h3>Game Overview</h3>
+          <p>
+            Infinite Rails is a browser-based voxel survival puzzle. Gather resources, craft ordered recipes, and build
+            precise 4×3 portals to leap between realms. Each portal material rewrites the physics and threats of the
+            destination dimension.
+          </p>
+          <ul>
+            <li>Portals are the only way to explore fresh territories.</li>
+            <li>Every material introduces a bespoke challenge and reward loop.</li>
+            <li>Crafting is performed by sequencing items rather than arranging them in a grid.</li>
+          </ul>
+        </section>
+        <section class="guide-section">
+          <h3>Look &amp; Feel</h3>
+          <p>Each dimension features a distinct ambience, palette, and soundtrack cues:</p>
+          <ul>
+            <li><strong>Rock:</strong> rugged canyons with dense gravity and ore-rich chasms.</li>
+            <li><strong>Stone:</strong> glowing monochrome rails that phase in rhythmic patterns.</li>
+            <li><strong>Tar:</strong> a viscous, low-visibility swamp that slows movement.</li>
+            <li><strong>Marble:</strong> mirror-bright courtyards where actions echo after five seconds.</li>
+            <li><strong>Netherite:</strong> molten rails collapse behind every step — the final gauntlet.</li>
+          </ul>
+        </section>
+        <section class="guide-section">
+          <h3>How to Play</h3>
+          <ol>
+            <li>Spawn on a quiet grass island. Search trees and stones for early materials.</li>
+            <li>Use the craft circle next to your hearts to arrange items in the correct sequence.</li>
+            <li>Build a 4×3 portal frame from a single material, leave the centre empty, and ignite it.</li>
+            <li>Explore the new realm, solve its rail puzzle, and gather the unique loot inside.</li>
+            <li>Survive the nightly zombie raids, protect villagers, and stabilise the rails.</li>
+            <li>Repeat with higher-tier materials until you conquer the collapsing Netherite dimension.</li>
+          </ol>
+        </section>
+        <section class="guide-section two-column">
+          <div>
+            <h4>Controls (Desktop)</h4>
+            <ul>
+              <li><kbd>WASD</kbd> / <kbd>Arrows</kbd> — move &amp; switch rails</li>
+              <li><kbd>Space</kbd> — jump gaps</li>
+              <li><kbd>Mouse</kbd> — look, mine, place</li>
+              <li><kbd>E</kbd> — inventory</li>
+              <li><kbd>F</kbd> — interact</li>
+              <li><kbd>R</kbd> — build portals</li>
+            </ul>
+          </div>
+          <div>
+            <h4>Controls (Mobile)</h4>
+            <ul>
+              <li>Swipe to swap rails</li>
+              <li>Tap &amp; hold to mine or place blocks</li>
+              <li>Drag to move the camera</li>
+              <li>Use the hotbar for quick slots and the craft circle for recipes</li>
+            </ul>
+          </div>
+        </section>
+        <section class="guide-section">
+          <h3>Dimensions &amp; Objectives</h3>
+          <dl class="dimension-list">
+            <div>
+              <dt>Rock Portal</dt>
+              <dd>Stronger gravity and sliding slopes. Rewards heavy ores and plating.</dd>
+            </div>
+            <div>
+              <dt>Stone Portal</dt>
+              <dd>Rails appear and vanish to a rhythm. Collect pattern crystals for sync tech.</dd>
+            </div>
+            <div>
+              <dt>Tar Portal</dt>
+              <dd>Movement is heavy and tar slugs pursue you. Gather sticky sacs for traps.</dd>
+            </div>
+            <div>
+              <dt>Marble Portal</dt>
+              <dd>Your actions echo after five seconds. Use the reverbs to solve mirrored puzzles.</dd>
+            </div>
+            <div>
+              <dt>Netherite Portal</dt>
+              <dd>Rails crumble behind you. Sprint, align collapsing tracks, and seize the Eternal Ingot.</dd>
+            </div>
+          </dl>
+        </section>
+        <section class="guide-section">
+          <h3>Survival Cycle</h3>
+          <p>
+            Daytime is safe for crafting and exploration. When night falls, zombies swarm the rails and villagers risk
+            conversion. Keep torches lit, stand your ground, and repair damage before dawn. Underwater exploration is
+            limited by your bubbles: once they deplete, hearts drain rapidly.
+          </p>
+        </section>
+        <section class="guide-section">
+          <h3>Winning a Run</h3>
+          <p>
+            Reach the Netherite dimension, stabilise collapsing rails long enough to grab the Eternal Ingot, and return
+            to the Grassland Threshold. Delivering the ingot home completes the run and logs your time on the leaderboards.
+          </p>
+        </section>
+      </article>
     </div>
 
     <div class="mobile-controls" id="mobileControls">

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 const startButton = document.getElementById('startButton');
 const introModal = document.getElementById('introModal');
+const guideModal = document.getElementById('guideModal');
 const mobileControls = document.getElementById('mobileControls');
 const heartsEl = document.getElementById('hearts');
 const bubblesEl = document.getElementById('bubbles');
@@ -20,6 +21,7 @@ const recipeListEl = document.getElementById('recipeList');
 const recipeSearchEl = document.getElementById('recipeSearch');
 const eventLogEl = document.getElementById('eventLog');
 const codexListEl = document.getElementById('dimensionCodex');
+const openGuideButton = document.getElementById('openGuide');
 const portalProgressLabel = portalProgressEl.querySelector('.label');
 const portalProgressBar = portalProgressEl.querySelector('.bar');
 const rootElement = document.documentElement;
@@ -1683,10 +1685,52 @@ function initEventListeners() {
   mobileControls.querySelectorAll('button').forEach((button) => {
     button.addEventListener('click', () => updateFromMobile(button.dataset.action));
   });
+  openGuideButton?.addEventListener('click', openGuideModal);
 }
 
 startButton.addEventListener('click', startGame);
 initEventListeners();
+
+setupGuideModal();
+
+function openGuideModal() {
+  if (!guideModal) return;
+  guideModal.hidden = false;
+  guideModal.setAttribute('data-open', 'true');
+  guideModal.setAttribute('aria-hidden', 'false');
+  const scrollHost = guideModal.querySelector('[data-guide-scroll]');
+  if (scrollHost) {
+    scrollHost.scrollTop = 0;
+  }
+  const closeButton = guideModal.querySelector('[data-close-guide]');
+  closeButton?.focus();
+}
+
+function closeGuideModal() {
+  if (!guideModal) return;
+  guideModal.hidden = true;
+  guideModal.setAttribute('data-open', 'false');
+  guideModal.setAttribute('aria-hidden', 'true');
+}
+
+function setupGuideModal() {
+  if (!guideModal) return;
+  guideModal.setAttribute('data-open', 'false');
+  guideModal.setAttribute('aria-hidden', 'true');
+  guideModal.addEventListener('click', (event) => {
+    if (event.target === guideModal) {
+      closeGuideModal();
+    }
+  });
+  guideModal.querySelectorAll('[data-close-guide]').forEach((button) => {
+    button.addEventListener('click', closeGuideModal);
+  });
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !guideModal.hidden) {
+      closeGuideModal();
+    }
+  });
+}
 
 function drawGridOverlay() {
   ctx.strokeStyle = 'rgba(73,242,255,0.05)';

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,10 @@
   padding: 0;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   font-family: 'Exo 2', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background: var(--page-background);
@@ -106,6 +110,12 @@ body::after {
   display: flex;
   gap: 1.25rem;
   align-items: center;
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
 }
 
 .status-item {
@@ -690,6 +700,10 @@ button.ghost {
   border-color: rgba(73, 242, 255, 0.25);
 }
 
+button.ghost:hover {
+  background: rgba(73, 242, 255, 0.15);
+}
+
 input[type='search'] {
   background: rgba(6, 14, 28, 0.85);
   border: 1px solid rgba(73, 242, 255, 0.25);
@@ -747,6 +761,109 @@ input[type='search'] {
   content: '✦';
   margin-right: 0.75rem;
   color: var(--accent-strong);
+}
+
+.guide-modal {
+  align-items: flex-start;
+  overflow-y: auto;
+  padding: clamp(2rem, 4vw, 3rem) clamp(1rem, 4vw, 3rem);
+}
+
+.guide-content {
+  width: min(960px, 100%);
+  background: rgba(6, 14, 28, 0.92);
+  border-radius: 32px;
+  border: 1px solid rgba(73, 242, 255, 0.18);
+  box-shadow: 0 50px 120px rgba(0, 0, 0, 0.45);
+  padding: clamp(1.5rem, 3vw, 2.75rem);
+  display: grid;
+  gap: clamp(1.75rem, 2.5vw, 2.5rem);
+  color: var(--text-secondary);
+}
+
+.guide-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.guide-header h2 {
+  font-family: 'Chakra Petch', sans-serif;
+  font-size: clamp(1.75rem, 3vw, 2.35rem);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.guide-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  font-size: 0.75rem;
+  color: rgba(247, 183, 51, 0.85);
+  margin-bottom: 0.65rem;
+}
+
+.guide-section {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.guide-section h3,
+.guide-section h4 {
+  font-family: 'Chakra Petch', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  font-size: clamp(1rem, 2vw, 1.3rem);
+}
+
+.guide-section h4 {
+  font-size: clamp(0.9rem, 1.8vw, 1.15rem);
+  color: var(--accent-strong);
+}
+
+.guide-section ul,
+.guide-section ol {
+  display: grid;
+  gap: 0.45rem;
+  padding-left: 1.1rem;
+}
+
+.guide-section li {
+  line-height: 1.6;
+}
+
+.guide-section kbd {
+  font-family: 'Chakra Petch', sans-serif;
+  background: rgba(73, 242, 255, 0.12);
+  border: 1px solid rgba(73, 242, 255, 0.3);
+  border-radius: 6px;
+  padding: 0.1rem 0.35rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.guide-section.two-column {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.dimension-list {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.dimension-list dt {
+  font-weight: 700;
+  color: var(--accent-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.dimension-list dd {
+  margin-left: 0;
+  line-height: 1.6;
 }
 
 .mobile-controls {


### PR DESCRIPTION
## Summary
- add a polished in-game "Game Guide" overlay with the full design brief and control references
- refresh styling for the header actions and guide modal to match the premium portal aesthetic
- document the built-in guide and rework deployment docs to highlight automatic CloudFront discovery
- introduce a GitHub Actions workflow that syncs to S3, fails fast when secrets are missing, and outputs the CloudFront URL

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cfa569ed84832bb832316bdb985d00