### PR TITLE
Fix indentation of heredoc terminators in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,7 +130,7 @@ jobs:
               }
             ]
           }
-POLICY
+          POLICY
 
           aws s3api put-bucket-policy --bucket "${DEPLOY_BUCKET}" --policy "file://${POLICY_FILE}"
           rm -f "${POLICY_FILE}"
@@ -214,7 +214,7 @@ POLICY
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
             }
           }
-JSON
+          JSON
 
           CREATE_OUTPUT=$(aws cloudfront create-distribution --distribution-config "file://${CONFIG_FILE}")
           rm -f "${CONFIG_FILE}"


### PR DESCRIPTION
## Summary
- indent the POLICY and JSON heredoc terminators so they remain inside the run script block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfb735ab34832ba548c48288eab203