### PR TITLE
Add Three.js voxel renderer for gameplay canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,10 @@
       <div class="controls">
         <div>
           <h3>Desktop Controls</h3>
-          <p>WASD/Arrows move · Space interact · Q place block · E inventory · R build portal · F use · Shift sprint</p>
+          <p>
+            WASD/Arrows move · Space interact · Q place block · E inventory · R build portal · F use · Shift sprint · Drag to
+            orbit · Scroll to zoom
+          </p>
         </div>
         <div>
           <h3>Mobile Controls</h3>


### PR DESCRIPTION
## Summary
- replace the 2D canvas renderer with a Three.js scene that adds lighting, orbit camera controls, and fog
- rebuild tiles, portals, and entities as animated voxel meshes to display the overworld in 3D
- document the new drag and scroll camera controls in the desktop control footer

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfbd6e67d4832b98e777cee4eccff5