### PR TITLE
Improve layout responsiveness and player guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,15 @@
       </div>
       <div class="top-actions">
         <button type="button" id="openGuide" class="ghost">Game Guide</button>
+        <button
+          type="button"
+          id="toggleSidebar"
+          class="ghost mobile-sidebar-toggle"
+          aria-expanded="false"
+          aria-controls="sidePanel"
+        >
+          Player Panels
+        </button>
         <div class="status-area">
           <div class="status-item hearts" id="hearts"></div>
           <div class="status-item bubbles" id="bubbles"></div>
@@ -51,11 +60,15 @@
           <span class="bar"></span>
         </div>
         <div class="victory-banner" id="victoryBanner" role="status" aria-live="assertive"></div>
+        <div class="player-hint" id="playerHint" role="status" aria-live="assertive" tabindex="0"></div>
       </section>
-      <aside class="side-panel">
+      <aside class="side-panel" id="sidePanel" tabindex="-1">
         <section class="player-panel" aria-label="Player profile">
           <header class="player-panel__header">
             <h2>Player Hub</h2>
+            <button type="button" class="ghost small side-panel-close" data-close-sidebar aria-label="Close player panels">
+              Close
+            </button>
             <button type="button" id="googleSignOut" class="ghost small" hidden>Sign out</button>
           </header>
           <div class="player-panel__content">
@@ -114,6 +127,7 @@
         </section>
       </aside>
     </main>
+    <div class="side-panel__scrim" id="sidePanelScrim" hidden></div>
     <footer class="footer">
       <div class="controls">
         <div>

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,7 @@ body {
   display: grid;
   grid-template-rows: auto 1fr auto;
   transition: background 1s ease;
+  overflow-x: hidden;
 }
 
 .background-sheen {
@@ -74,6 +75,21 @@ body::after {
   50% {
     transform: scale(1.08);
     opacity: 0.85;
+  }
+}
+
+@keyframes overlay-pop {
+  0% {
+    opacity: 0;
+    transform: translateY(-18px);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(4px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
@@ -153,6 +169,10 @@ body::after {
   display: flex;
   align-items: center;
   gap: clamp(1rem, 3vw, 1.75rem);
+}
+
+.mobile-sidebar-toggle {
+  display: none;
 }
 
 .status-item {
@@ -263,9 +283,12 @@ body::after {
 
 .main-layout {
   display: grid;
-  grid-template-columns: 3fr minmax(320px, 400px);
-  gap: 1.5rem;
-  padding: 1.5rem 2.5rem 2rem;
+  grid-template-columns: minmax(0, 7fr) minmax(280px, 360px);
+  gap: clamp(1rem, 2.5vw, 2rem);
+  padding: clamp(1rem, 2.5vw, 2.5rem);
+  height: 100%;
+  align-items: stretch;
+  position: relative;
 }
 
 .primary-panel {
@@ -277,8 +300,10 @@ body::after {
   border: 1px solid rgba(73, 242, 255, 0.18);
   display: grid;
   grid-template-areas: 'viewport';
-  min-height: clamp(420px, 58vh, 680px);
-  aspect-ratio: 16 / 10;
+  grid-template-rows: minmax(0, 1fr);
+  min-height: var(--primary-panel-min-height, clamp(420px, 70vh, 820px));
+  height: var(--primary-panel-min-height, auto);
+  transition: min-height 0.3s ease;
 }
 
 #gameCanvas {
@@ -305,6 +330,20 @@ body::after {
   display: grid;
   gap: 0.4rem;
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transform: translateY(-12px);
+  pointer-events: none;
+  transition: opacity 0.35s ease, transform 0.35s ease;
+}
+
+.overlay-panel.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.overlay-panel.pop {
+  animation: overlay-pop 0.45s ease;
 }
 
 .overlay-panel strong {
@@ -423,6 +462,40 @@ body::after {
 .side-panel {
   display: grid;
   gap: 1.25rem;
+}
+
+.side-panel-close {
+  display: none;
+}
+
+.side-panel__scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 16, 0.65);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 24;
+}
+
+body.sidebar-open .side-panel__scrim {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+body.sidebar-open {
+  overflow: hidden;
+}
+
+body.sidebar-open .mobile-controls {
+  opacity: 0;
+  pointer-events: none;
+}
+
+body.sidebar-open .player-hint {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .side-panel section {
@@ -1061,6 +1134,45 @@ input[type='search'] {
   color: #021521;
 }
 
+.player-hint {
+  position: absolute;
+  top: clamp(1.25rem, 6vh, 3rem);
+  left: 50%;
+  transform: translate(-50%, -16px);
+  background: linear-gradient(145deg, rgba(6, 14, 28, 0.95), rgba(6, 14, 28, 0.65));
+  border-radius: 20px;
+  padding: 0.9rem 1.4rem;
+  border: 1px solid rgba(73, 242, 255, 0.25);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  max-width: min(90%, 420px);
+  text-align: center;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  letter-spacing: 0.02em;
+  color: var(--text-primary);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 22;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  cursor: pointer;
+}
+
+.player-hint::after {
+  content: 'Tap, click, or press Enter to dismiss';
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--text-secondary);
+}
+
+.player-hint.visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  pointer-events: auto;
+}
+
 @media (max-width: 1180px) {
   .main-layout {
     grid-template-columns: 1fr;
@@ -1076,6 +1188,20 @@ input[type='search'] {
     font-size: 15px;
   }
 
+  .main-layout {
+    grid-template-columns: 1fr;
+    padding: clamp(0.75rem, 5vw, 1.5rem);
+  }
+
+  .primary-panel {
+    border-radius: 20px;
+  }
+
+  .player-hint {
+    top: clamp(1rem, 8vh, 3.5rem);
+    max-width: min(92%, 420px);
+  }
+
   .top-bar {
     flex-direction: column;
     align-items: flex-start;
@@ -1089,8 +1215,53 @@ input[type='search'] {
     gap: 0.75rem;
   }
 
+  .mobile-sidebar-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
   .user-identity {
     text-align: left;
+  }
+
+  .side-panel {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 30;
+    grid-template-columns: minmax(0, 1fr);
+    max-height: min(80vh, 720px);
+    overflow-y: auto;
+    padding: 1.75rem clamp(1rem, 8vw, 2.25rem) calc(2.75rem + env(safe-area-inset-bottom, 0px));
+    background: rgba(4, 9, 22, 0.96);
+    border-radius: 28px 28px 0 0;
+    border: 1px solid rgba(73, 242, 255, 0.15);
+    box-shadow: 0 -18px 40px rgba(0, 0, 0, 0.45);
+    transform: translateY(calc(100% + 2rem));
+    transition: transform 0.4s ease;
+    backdrop-filter: blur(12px);
+    overscroll-behavior: contain;
+  }
+
+  .side-panel.open {
+    transform: translateY(0);
+  }
+
+  .side-panel section {
+    margin: 0 auto;
+    max-width: 640px;
+  }
+
+  .side-panel-close {
+    display: inline-flex;
+    margin-left: auto;
+  }
+
+  .player-panel__header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
 
   .footer {
@@ -1105,6 +1276,7 @@ input[type='search'] {
 
   .mobile-controls {
     display: flex;
+    bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   }
 
   .victory-banner {
@@ -1139,5 +1311,11 @@ input[type='search'] {
 
   .footer {
     padding: 1.25rem 1rem 1.75rem;
+  }
+}
+
+@media (min-width: 861px) {
+  .side-panel__scrim {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary
- stretch the main viewport to fill the screen and add a mobile drawer toggle for the side panels
- add a pulsating locator ring and contextual hint popups so players can see their avatar and current objectives
- polish mobile styling with safe-area padding, dismissible hints, and sidebar scrim overlay

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cfc9104230832ba6eea7be62b671ba