### PR TITLE
Handle empty world array when reading tiles

### DIFF
--- a/script.js
+++ b/script.js
@@ -2435,7 +2435,7 @@ function applyDamage(amount) {
 
 function getTile(x, y) {
   if (x < 0 || y < 0 || x >= state.width || y >= state.height) return null;
-  return state.world[y][x];
+  return state.world?.[y]?.[x] ?? null;
 }
 
 function isWalkable(x, y) {


### PR DESCRIPTION
## Summary
- guard the tile lookup helper against missing world rows so initialization runs before the world grid exists

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfd8f1a7ac832b887ad75ec0c10b62