### PR TITLE
Fix focus handling after starting the game

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,6 +15,9 @@ if (!scoreboardUtils) {
 const { normalizeScoreEntries, upsertScoreEntry, formatScoreNumber, formatRunTime, formatLocationLabel } = scoreboardUtils;
 
 const canvas = document.getElementById('gameCanvas');
+if (canvas && !canvas.hasAttribute('tabindex')) {
+  canvas.setAttribute('tabindex', '0');
+}
 const startButton = document.getElementById('startButton');
 const introModal = document.getElementById('introModal');
 const guideModal = document.getElementById('guideModal');
@@ -2155,7 +2158,19 @@ function logEvent(message) {
 }
 
 function startGame() {
-  introModal.style.display = 'none';
+  if (state.isRunning) return;
+  if (introModal) {
+    introModal.hidden = true;
+    introModal.setAttribute('aria-hidden', 'true');
+    introModal.style.display = 'none';
+  }
+  if (startButton) {
+    startButton.disabled = true;
+    startButton.setAttribute('aria-hidden', 'true');
+    startButton.setAttribute('tabindex', '-1');
+    startButton.blur();
+  }
+  canvas?.focus();
   updateLayoutMetrics();
   state.isRunning = true;
   state.player.effects = {};

--- a/styles.css
+++ b/styles.css
@@ -314,6 +314,11 @@ body::after {
   background: linear-gradient(180deg, rgba(10, 24, 48, 0.9), rgba(6, 14, 28, 0.9));
 }
 
+#gameCanvas:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .overlay-panel {
   position: absolute;
   top: 1.5rem;


### PR DESCRIPTION
## Summary
- make the main canvas keyboard focusable and add a visible focus outline
- hide and disable the intro modal start button after launch and move focus to the canvas to prevent accidental restarts

## Testing
- npm test
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68cfe47978c4832baa852a0f0f219850