### PR TITLE
Handle WebGL init failures gracefully

### DIFF
--- a/script.js
+++ b/script.js
@@ -521,8 +521,21 @@
     }
 
     function initRenderer() {
-      if (renderer) return;
-      renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+      if (renderer) return true;
+      try {
+        renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+        const gl = renderer.getContext();
+        if (!gl || typeof gl.getParameter !== 'function') {
+          throw new Error('WebGL context unavailable');
+        }
+      } catch (error) {
+        renderer = null;
+        showDependencyError(
+          'Your browser could not initialise the 3D renderer. Please ensure WebGL is enabled and refresh to try again.',
+          error
+        );
+        return false;
+      }
       renderer.setPixelRatio(window.devicePixelRatio ?? 1);
       handleResize();
 
@@ -548,6 +561,7 @@
       updateWorldTarget();
       createPlayerMesh();
       createPlayerLocator();
+      return true;
     }
 
     function updateWorldTarget() {


### PR DESCRIPTION
## Summary
- handle WebGL renderer creation failures by surfacing a modal error instead of silently failing
- fall back gracefully when WebGL context creation fails so the start button is disabled with guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cff5cbedb4832b99aa2277935e85ae