### PR TITLE
Add responsive Manu creator logo overlay

### DIFF
--- a/assets/manu-logo.svg
+++ b/assets/manu-logo.svg
@@ -1,0 +1,29 @@
+<svg width="220" height="80" viewBox="0 0 220 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="manuGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5EE7FF" />
+      <stop offset="50%" stop-color="#49B5FF" />
+      <stop offset="100%" stop-color="#F7B733" />
+    </linearGradient>
+    <linearGradient id="plateGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(12, 26, 48, 0.95)" />
+      <stop offset="100%" stop-color="rgba(7, 16, 32, 0.9)" />
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-50%" width="140%" height="200%" filterUnits="objectBoundingBox">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <g filter="url(#glow)">
+    <rect x="6" y="10" width="208" height="60" rx="18" fill="url(#plateGradient)" stroke="rgba(94, 231, 255, 0.45)" stroke-width="2" />
+    <rect x="14" y="18" width="64" height="44" rx="12" fill="rgba(73, 242, 255, 0.14)" stroke="rgba(94, 231, 255, 0.4)" stroke-width="1.5" />
+    <path d="M30 56L30 32L40 44L50 32L50 56" stroke="url(#manuGradient)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M72 24L90 56" stroke="rgba(247, 183, 51, 0.85)" stroke-width="3" stroke-linecap="round" />
+    <path d="M90 24L108 56" stroke="rgba(73, 242, 255, 0.9)" stroke-width="3" stroke-linecap="round" />
+    <text x="116" y="42" fill="url(#manuGradient)" font-family="'Chakra Petch', 'Exo 2', sans-serif" font-weight="600" font-size="20" letter-spacing="0.12em">Created by</text>
+    <text x="116" y="60" fill="#F2F5FA" font-family="'Exo 2', sans-serif" font-weight="700" font-size="24" letter-spacing="0.2em">MANU</text>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
   </head>
   <body>
     <div class="background-sheen"></div>
+    <div class="manu-logo" aria-hidden="false">
+      <img src="assets/manu-logo.svg" alt="Created by Manu" class="manu-logo__image" />
+    </div>
     <header class="top-bar">
       <div class="logo-area">
         <img src="assets/infinite-dimension-logo.svg" alt="Infinite Dimension logo" class="brand-logo" />
@@ -142,7 +145,6 @@
           <p>Swipe to move · Tap hold to interact · Tap buttons for craft/build</p>
         </div>
       </div>
-      <div class="signature">Created by Manu</div>
     </footer>
 
     <div class="modal" id="introModal" role="dialog" aria-modal="true" aria-labelledby="introTitle">

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,36 @@ body.game-active {
   min-height: 100vh;
 }
 
+.manu-logo {
+  position: fixed;
+  inset: auto 1.5rem 1.5rem auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 0.75rem;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(6, 14, 28, 0.88), rgba(6, 14, 28, 0.6));
+  border: 1px solid rgba(73, 242, 255, 0.35);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.4), 0 0 18px rgba(73, 242, 255, 0.35);
+  backdrop-filter: blur(10px);
+  z-index: 120;
+  opacity: 0.92;
+  transition: transform 0.35s ease, opacity 0.3s ease;
+}
+
+.manu-logo:hover,
+.manu-logo:focus-visible {
+  transform: translateY(-4px) scale(1.04);
+  opacity: 1;
+  outline: none;
+}
+
+.manu-logo__image {
+  display: block;
+  width: clamp(160px, 22vw, 220px);
+  height: auto;
+}
+
 .background-sheen {
   position: fixed;
   inset: 0;
@@ -929,13 +959,6 @@ body.sidebar-open .player-hint {
   gap: 2rem;
 }
 
-.signature {
-  text-transform: uppercase;
-  letter-spacing: 0.4em;
-  color: var(--accent-strong);
-  font-weight: 700;
-}
-
 button {
   background: rgba(73, 242, 255, 0.1);
   border: 1px solid rgba(73, 242, 255, 0.3);
@@ -1230,6 +1253,16 @@ input[type='search'] {
     font-size: 15px;
   }
 
+  .manu-logo {
+    inset: auto 1rem 1rem auto;
+    border-radius: 16px;
+    padding: 0.5rem 0.6rem;
+  }
+
+  .manu-logo__image {
+    width: clamp(140px, 40vw, 190px);
+  }
+
   .main-layout {
     grid-template-columns: 1fr;
     padding: clamp(0.75rem, 5vw, 1.5rem);
@@ -1331,6 +1364,16 @@ input[type='search'] {
 @media (max-width: 640px) {
   :root {
     font-size: 14px;
+  }
+
+  .manu-logo {
+    inset: auto 0.75rem calc(0.75rem + env(safe-area-inset-bottom, 0px)) auto;
+    padding: 0.45rem 0.5rem;
+    border-radius: 14px;
+  }
+
+  .manu-logo__image {
+    width: clamp(120px, 56vw, 160px);
   }
 
   .main-layout {


### PR DESCRIPTION
## Summary
- add a branded "Created by Manu" logo element that renders across all screens
- introduce dedicated styling for the floating logo, including responsive behavior, and remove the old footer watermark
- add an SVG logo asset that matches the updated branding requirements

## Testing
- npm test
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d006b95374832ba36048bd0dcecc64