### PR TITLE
Add HUD score overlay and progression scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,20 @@
           <span class="label"></span>
           <span class="bar"></span>
         </div>
+        <div class="score-overlay" id="scorePanel" role="status" aria-live="polite">
+          <span class="score-overlay__label">Score</span>
+          <span class="score-overlay__value" id="scoreTotal">0</span>
+          <ul class="score-overlay__breakdown">
+            <li>
+              <span class="score-overlay__metric-label">Recipes</span>
+              <span class="score-overlay__metric-value" id="scoreRecipes">0 (+0 pts)</span>
+            </li>
+            <li>
+              <span class="score-overlay__metric-label">Dimensions</span>
+              <span class="score-overlay__metric-value" id="scoreDimensions">0 (+0 pts)</span>
+            </li>
+          </ul>
+        </div>
         <div class="victory-banner" id="victoryBanner" role="status" aria-live="assertive"></div>
         <div class="player-hint" id="playerHint" role="status" aria-live="assertive" tabindex="0"></div>
       </section>

--- a/styles.css
+++ b/styles.css
@@ -440,6 +440,94 @@ body.game-active #gameCanvas {
   box-shadow: 0 0 8px rgba(247, 183, 51, 0.6);
 }
 
+.score-overlay {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1.1rem;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(5, 12, 26, 0.82), rgba(7, 16, 32, 0.58));
+  border: 1px solid rgba(73, 242, 255, 0.2);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(10px);
+  color: var(--text-secondary);
+  min-width: 220px;
+  z-index: 6;
+  pointer-events: none;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
+}
+
+.score-overlay__label {
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.7rem;
+  color: rgba(242, 245, 250, 0.65);
+}
+
+.score-overlay__value {
+  font-size: clamp(1.6rem, 2.6vw, 2rem);
+  font-weight: 700;
+  color: var(--accent);
+  text-shadow: 0 8px 24px rgba(73, 242, 255, 0.35);
+}
+
+.score-overlay__breakdown {
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  padding: 0;
+  margin: 0;
+}
+
+.score-overlay__breakdown li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.score-overlay__metric-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(242, 245, 250, 0.62);
+}
+
+.score-overlay__metric-label::after {
+  content: ':';
+  margin-left: 0.15rem;
+  opacity: 0.6;
+}
+
+.score-overlay__metric-value {
+  font-weight: 600;
+  color: rgba(242, 245, 250, 0.9);
+  white-space: nowrap;
+}
+
+.score-overlay--flash {
+  animation: score-overlay-flash 0.65s ease;
+}
+
+@keyframes score-overlay-flash {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  }
+  35% {
+    transform: scale(1.04);
+    box-shadow: 0 24px 60px rgba(73, 242, 255, 0.4);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  }
+}
+
 .portal-progress {
   position: absolute;
   bottom: 1.5rem;
@@ -1272,6 +1360,15 @@ input[type='search'] {
     border-radius: 20px;
   }
 
+  .score-overlay {
+    top: auto;
+    right: 1rem;
+    left: 1rem;
+    bottom: 1rem;
+    min-width: unset;
+    width: auto;
+  }
+
   .player-hint {
     top: clamp(1rem, 8vh, 3.5rem);
     max-width: min(92%, 420px);
@@ -1378,6 +1475,17 @@ input[type='search'] {
 
   .main-layout {
     padding: 1rem;
+  }
+
+  .score-overlay {
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: calc(0.85rem + env(safe-area-inset-bottom, 0px));
+    padding: 0.75rem 0.9rem;
+  }
+
+  .score-overlay__value {
+    font-size: clamp(1.4rem, 6vw, 1.8rem);
   }
 
   .top-bar {


### PR DESCRIPTION
## Summary
- add a persistent in-game score overlay with total and recipe/dimension breakdown markup
- track recipe unlocks and first-time dimension visits to award points and flash the HUD panel
- align victory snapshot scoring with the new progression totals and refine responsive styling for the score display

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d009367cb0832b9ad5905d4b378a49