### PR TITLE
Enhance health feedback and defeat presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,20 @@
         </div>
         <div class="victory-banner" id="victoryBanner" role="status" aria-live="assertive"></div>
         <div class="player-hint" id="playerHint" role="status" aria-live="assertive" tabindex="0"></div>
+        <div class="drowning-vignette" id="drowningVignette" aria-hidden="true"></div>
+        <div
+          class="defeat-overlay"
+          id="defeatOverlay"
+          aria-hidden="true"
+          tabindex="-1"
+        >
+          <div class="defeat-overlay__content" role="dialog" aria-modal="true" aria-labelledby="defeatTitle">
+            <h3 id="defeatTitle">Respawn Imminent</h3>
+            <p class="defeat-overlay__message" id="defeatMessage"></p>
+            <div class="defeat-overlay__inventory" id="defeatInventory" aria-live="polite"></div>
+            <p class="defeat-overlay__countdown" id="defeatCountdown"></p>
+          </div>
+        </div>
       </section>
       <aside class="side-panel" id="sidePanel" tabindex="-1">
         <section class="player-panel" aria-label="Player profile">

--- a/styles.css
+++ b/styles.css
@@ -129,6 +129,84 @@ body::after {
   }
 }
 
+@keyframes meter-damage {
+  0% {
+    transform: scale(1);
+    filter: saturate(1);
+  }
+  45% {
+    transform: scale(0.86);
+    filter: saturate(0.5);
+  }
+  100% {
+    transform: scale(1);
+    filter: saturate(1);
+  }
+}
+
+@keyframes meter-regen {
+  0% {
+    transform: scale(0.9);
+    filter: saturate(0.7);
+  }
+  50% {
+    transform: scale(1.1);
+    filter: saturate(1.15);
+  }
+  100% {
+    transform: scale(1);
+    filter: saturate(1);
+  }
+}
+
+@keyframes meter-critical {
+  0%,
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  50% {
+    transform: scale(1.12);
+    filter: brightness(1.35);
+  }
+}
+
+@keyframes meter-low {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(-2px);
+    opacity: 0.7;
+  }
+}
+
+@keyframes meter-drowning {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(0.8) rotate(-6deg);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes drowning-flash {
+  0% {
+    opacity: 0;
+  }
+  40% {
+    opacity: 0.6;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 .top-bar {
   display: flex;
   justify-content: space-between;
@@ -211,29 +289,59 @@ body::after {
   display: none;
 }
 
+
 .status-item {
   display: flex;
-  align-items: center;
-  gap: 0.35rem;
+  align-items: flex-start;
+  gap: 0.5rem;
   font-weight: 600;
   letter-spacing: 0.05em;
   color: var(--text-secondary);
 }
 
 .status-item .meter {
-  display: flex;
-  gap: 0.15rem;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 18px));
+  gap: 0.2rem 0.35rem;
   align-items: center;
 }
+
+.status-item .meter.meter--stacked {
+  justify-items: center;
+}
+
+.status-item .meter.meter--damage .heart:not(.empty),
+.status-item .meter.meter--damage .bubble:not(.empty) {
+  animation: meter-damage 0.6s ease;
+}
+
+.status-item .meter.meter--regen .heart:not(.empty),
+.status-item .meter.meter--regen .bubble:not(.empty) {
+  animation: meter-regen 0.8s ease;
+}
+
+.status-item .meter.meter--critical .heart:not(.empty) {
+  animation: meter-critical 1.1s ease-in-out infinite;
+}
+
+.status-item .meter.meter--low .bubble:not(.empty) {
+  animation: meter-low 1.2s ease-in-out infinite;
+}
+
+.status-item .meter.meter--drowning .bubble {
+  animation: meter-drowning 0.75s ease;
+}
+
 
 .heart,
 .bubble {
   display: inline-block;
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   border-radius: 6px;
   box-shadow: 0 0 6px rgba(73, 242, 255, 0.25);
   position: relative;
+  transition: transform 0.25s ease, filter 0.25s ease, opacity 0.2s ease;
 }
 
 .heart::after {
@@ -242,11 +350,16 @@ body::after {
   inset: 3px;
   border-radius: 5px;
   background: radial-gradient(circle at 50% 30%, #ff6b9a, #b02245 75%);
-  opacity: var(--fill, 1);
+  opacity: clamp(var(--fill, 1), 0, 1);
+  transition: opacity 0.25s ease;
 }
 
 .heart.empty::after {
   opacity: 0.15;
+}
+
+.heart.partial::after {
+  opacity: calc(0.35 + clamp(var(--fill, 0.5), 0, 1) * 0.65);
 }
 
 .bubble::after {
@@ -255,11 +368,16 @@ body::after {
   inset: 3px;
   border-radius: 50%;
   background: radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.85), rgba(73, 242, 255, 0.4));
-  opacity: var(--fill, 1);
+  opacity: clamp(var(--fill, 1), 0, 1);
+  transition: opacity 0.25s ease;
 }
 
 .bubble.empty::after {
   opacity: 0.08;
+}
+
+.bubble.partial::after {
+  opacity: calc(0.2 + clamp(var(--fill, 0.5), 0, 1) * 0.7);
 }
 
 .time-track {
@@ -1325,6 +1443,135 @@ input[type='search'] {
   opacity: 1;
   transform: translate(-50%, 0);
   pointer-events: auto;
+}
+
+.drowning-vignette {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 35%, rgba(63, 132, 255, 0.15), rgba(3, 9, 18, 0.92) 80%);
+  mix-blend-mode: screen;
+  opacity: 0;
+  transition: opacity 0.45s ease;
+  z-index: 24;
+}
+
+.drowning-vignette[data-active='true'] {
+  opacity: 0.55;
+}
+
+.drowning-vignette.drowning-vignette--flash {
+  animation: drowning-flash 0.7s ease-out;
+}
+
+.defeat-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.45s ease;
+  z-index: 40;
+}
+
+.defeat-overlay::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(3, 8, 18, 0.9), rgba(16, 35, 60, 0.65));
+  opacity: 0;
+  transition: opacity 0.45s ease;
+}
+
+.defeat-overlay[data-visible='true'] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.defeat-overlay[data-visible='true']::before {
+  opacity: 0.9;
+}
+
+.defeat-overlay__content {
+  position: relative;
+  z-index: 1;
+  padding: 2rem 2.4rem;
+  border-radius: 20px;
+  background: linear-gradient(160deg, rgba(6, 14, 30, 0.96), rgba(6, 14, 30, 0.82));
+  border: 1px solid rgba(73, 242, 255, 0.25);
+  box-shadow: 0 26px 60px rgba(0, 0, 0, 0.6);
+  transform: translateY(26px) scale(0.96);
+  transition: transform 0.45s ease, opacity 0.45s ease;
+  display: grid;
+  gap: 0.85rem;
+  text-align: center;
+  max-width: min(92%, 420px);
+}
+
+.defeat-overlay[data-visible='true'] .defeat-overlay__content {
+  transform: translateY(0) scale(1);
+}
+
+.defeat-overlay__message {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.defeat-overlay__inventory {
+  background: rgba(12, 22, 42, 0.75);
+  border: 1px solid rgba(73, 242, 255, 0.18);
+  border-radius: 16px;
+  padding: 0.85rem 1.25rem;
+  max-height: 200px;
+  overflow: auto;
+}
+
+.defeat-overlay__inventory-label {
+  margin: 0 0 0.45rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.defeat-overlay__inventory[data-empty='true'] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.defeat-overlay__inventory-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.defeat-overlay__inventory-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.defeat-overlay__inventory-item span:last-child {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.defeat-overlay__countdown {
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
 }
 
 @media (max-width: 1180px) {


### PR DESCRIPTION
## Summary
- Rework the heart and air meters into stacked layouts that animate for damage, regeneration, and low-resource warnings.
- Add drowning feedback with a vignette flash and a generated bubble-pop audio cue when oxygen is lost.
- Introduce a respawn overlay that fades in on defeat, shows an inventory snapshot with a countdown, and respawns the player after the timer.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d0202d5800832b83badf8762bff997