### PR TITLE
Add centered Google sign-in and AWS serverless backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Infinite Dimension is a browser-based voxel survival-puzzle prototype built enti
 - **Google-powered sign-in** – authenticate with Google to unlock the shared scorecard and sync your metadata.
 - **DynamoDB-ready APIs** – the frontend posts user/device/location telemetry to `/users` and reads/writes scores at `/scores`.
 - **Live scoreboard** – explore top multiverse runs, complete with dimension counts, run time, inventory haul, and location tags.
+- **Serverless backend** – deployable AWS Lambda handlers and DynamoDB tables now live in `serverless/` for `/users` and `/scores`.
 
 ## Game Highlights
 
@@ -48,6 +49,20 @@ Expose an `APP_CONFIG` object before loading `script.js` to wire up Google SSO a
 - **User metadata** – on sign-in the app POSTs to `${apiBaseUrl}/users` with the player’s Google ID, preferred name, device snapshot, and geolocation (if permission is granted). The handler can write directly to a DynamoDB table keyed by Google ID.
 - **Scoreboard** – the app loads scores via `GET ${apiBaseUrl}/scores` and upserts the player’s run with `POST ${apiBaseUrl}/scores`. The payload mirrors the UI fields: `name`, `score`, `dimensionCount`, `runTimeSeconds`, `inventoryCount`, plus optional `location` or `locationLabel` fields.
 - **Offline-friendly** – when `apiBaseUrl` is absent the UI persists identities and scores to `localStorage` and displays sample leaderboard entries so the page remains fully interactive.
+
+### Deploying the AWS backend
+
+Provision the serverless API and DynamoDB tables with the provided AWS SAM template:
+
+```bash
+cd serverless
+sam build
+sam deploy --guided
+```
+
+- The stack creates a `/users` Lambda (for Google profile sync) and a `/scores` Lambda (for leaderboard reads/writes) behind an API Gateway stage.
+- DynamoDB tables `UsersTable` and `ScoresTable` are configured for on-demand billing with encryption enabled. The scoreboard table includes a `ScoreIndex` global secondary index that the Lambda uses to return the highest scores first.
+- After deployment, copy the generated API endpoint URL into `window.APP_CONFIG.apiBaseUrl` so the frontend will sync identities and victories to DynamoDB.
 
 ### Google SSO configuration
 

--- a/index.html
+++ b/index.html
@@ -112,7 +112,9 @@
             <button type="button" class="ghost small side-panel-close" data-close-sidebar aria-label="Close player panels">
               Close
             </button>
-            <button type="button" id="googleSignOut" class="ghost small" hidden>Sign out</button>
+            <button type="button" id="googleSignOut" class="ghost small" data-google-sign-out hidden>
+              Sign out
+            </button>
           </header>
           <div class="player-panel__content">
             <div class="identity-pill" id="userNameDisplay">Guest Explorer</div>
@@ -120,8 +122,8 @@
               <span id="userLocationDisplay">Location unavailable</span>
               <span id="userDeviceDisplay">Device details pending</span>
             </div>
-            <div id="googleButtonContainer" class="gsi-container" hidden></div>
-            <button type="button" id="googleFallbackSignIn" class="primary">Sign in with Google</button>
+            <div class="gsi-container" data-google-button-container hidden></div>
+            <button type="button" class="primary" data-google-fallback-signin>Sign in with Google</button>
             <p class="player-panel__hint">
               Sign in to capture your location badge, sync your device fingerprint, and compete on the Infinite Dimension scorecard.
             </p>
@@ -179,6 +181,18 @@
           Survive, craft, and weave portals across dimensions. Gather resources from each world, solve rail puzzles,
           and bring home the Eternal Ingot.
         </p>
+        <section class="signin-callout" id="landingSignInPanel" aria-label="Link your explorer profile">
+          <h3>Sync your journey before you depart</h3>
+          <p class="signin-callout__summary">
+            Sign in with Google to unlock the shared scoreboard, capture your location badge, and mirror your progress across
+            every device.
+          </p>
+          <div class="signin-callout__actions">
+            <div class="gsi-container" data-google-button-container hidden></div>
+            <button type="button" class="primary" data-google-fallback-signin>Sign in with Google</button>
+            <p class="signin-callout__note">Prefer to explore as a guest? You can connect later from the Player Hub.</p>
+          </div>
+        </section>
         <ul class="modal-highlights">
           <li>Build 4×3 portals with unique materials to unlock new rules.</li>
           <li>Craft using ordered sequences and uncover hidden recipes.</li>

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -1,0 +1,42 @@
+# Infinite Dimension Serverless Backend
+
+This directory packages the optional AWS backend that powers Google-authenticated explorer profiles and the multiverse scoreboard. It is built with [AWS Serverless Application Model (SAM)](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) and deploys two Lambda functions alongside DynamoDB tables.
+
+## Architecture overview
+
+- **UsersFunction (`/users`, POST)** – Accepts signed-in Google profile metadata plus device and geolocation snapshots. Records the latest explorer state in the `UsersTable` keyed by `googleId`.
+- **ScoresFunction (`/scores`, GET & POST)** – Reads leaderboard entries from the `ScoreIndex` global secondary index and upserts victories. The handler preserves a player's best score while updating run statistics and location metadata.
+- **UsersTable** – Pay-per-request DynamoDB table storing explorer profiles.
+- **ScoresTable** – Pay-per-request DynamoDB table storing leaderboard entries. A GSI named `ScoreIndex` keeps the highest scores at the top by sorting on the negated score.
+
+All endpoints respond with permissive CORS headers so the static frontend can call them directly from any origin.
+
+## Deployment
+
+```bash
+cd serverless
+sam build
+sam deploy --guided
+```
+
+During the guided deployment you can keep the default stack name and allow SAM to create the necessary IAM roles. When the deployment completes SAM prints the API endpoint URL—copy it into `window.APP_CONFIG.apiBaseUrl` so the browser client can sync to DynamoDB.
+
+## Environment variables
+
+The SAM template injects the following environment variables into each Lambda at deploy time:
+
+| Variable | Purpose |
+| --- | --- |
+| `USERS_TABLE` | Name of the DynamoDB table for explorer profiles. |
+| `SCORES_TABLE` | Name of the DynamoDB table for leaderboard entries. |
+| `SCORES_INDEX_NAME` | Name of the GSI (`ScoreIndex`) used to read the leaderboard in score order. |
+
+## Local testing
+
+Install the SAM CLI and start a local API instance:
+
+```bash
+sam local start-api
+```
+
+The local gateway proxies requests to the Lambda handlers, allowing you to validate Google payload parsing and DynamoDB writes with [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) or a provisioned test table.

--- a/serverless/handlers/scores.js
+++ b/serverless/handlers/scores.js
@@ -1,0 +1,217 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const { createResponse, parseJsonBody, handleOptions } = require('../lib/http');
+
+const dynamo = new AWS.DynamoDB.DocumentClient();
+const SCORES_TABLE = process.env.SCORES_TABLE;
+const SCORE_INDEX = process.env.SCORES_INDEX_NAME || 'ScoreIndex';
+const SCORE_BUCKET = 'all';
+
+function sanitizeNumber(value, defaultValue = 0) {
+  if (value === null || value === undefined || value === '') {
+    return defaultValue;
+  }
+  const asNumber = Number(value);
+  return Number.isFinite(asNumber) ? asNumber : defaultValue;
+}
+
+function sanitizeLocation(location) {
+  if (location === null) {
+    return null;
+  }
+  if (!location || typeof location !== 'object') {
+    return undefined;
+  }
+  const clean = {};
+  if (typeof location.latitude === 'number') clean.latitude = location.latitude;
+  if (typeof location.longitude === 'number') clean.longitude = location.longitude;
+  if (typeof location.accuracy === 'number') clean.accuracy = location.accuracy;
+  if (location.error) clean.error = String(location.error);
+  if (location.label) clean.label = String(location.label);
+  if (location.timestamp) clean.timestamp = location.timestamp;
+  return Object.keys(clean).length ? clean : null;
+}
+
+function encodeNextToken(key) {
+  if (!key) return null;
+  return Buffer.from(JSON.stringify(key), 'utf8').toString('base64');
+}
+
+function decodeNextToken(token) {
+  if (!token) return null;
+  try {
+    const json = Buffer.from(token, 'base64').toString('utf8');
+    return JSON.parse(json);
+  } catch (error) {
+    const err = new Error('Invalid nextToken value');
+    err.code = 'INVALID_TOKEN';
+    throw err;
+  }
+}
+
+async function getScores(event) {
+  if (!SCORES_TABLE) {
+    return createResponse(500, { message: 'SCORES_TABLE environment variable is not configured.' });
+  }
+
+  const limitParam = event?.queryStringParameters?.limit;
+  const limit = Math.min(Math.max(sanitizeNumber(limitParam, 25), 1), 100);
+  const tokenParam = event?.queryStringParameters?.nextToken;
+
+  let exclusiveStartKey;
+  try {
+    exclusiveStartKey = decodeNextToken(tokenParam);
+  } catch (error) {
+    return createResponse(400, { message: error.message });
+  }
+
+  const params = {
+    TableName: SCORES_TABLE,
+    IndexName: SCORE_INDEX,
+    KeyConditionExpression: '#bucket = :bucket',
+    ExpressionAttributeNames: {
+      '#bucket': 'scoreBucket',
+      '#name': 'name',
+      '#gid': 'googleId',
+    },
+    ExpressionAttributeValues: {
+      ':bucket': SCORE_BUCKET,
+    },
+    ProjectionExpression:
+      '#gid, #name, score, dimensionCount, runTimeSeconds, inventoryCount, location, locationLabel, updatedAt, bestScoreAt',
+    Limit: limit,
+    ScanIndexForward: true,
+  };
+
+  if (exclusiveStartKey) {
+    params.ExclusiveStartKey = exclusiveStartKey;
+  }
+
+  let result;
+  try {
+    result = await dynamo.query(params).promise();
+  } catch (error) {
+    console.error('Failed to load scoreboard entries.', error);
+    return createResponse(500, { message: 'Failed to load scoreboard entries.' });
+  }
+
+  const responseBody = {
+    items: result.Items ?? [],
+  };
+
+  if (result.LastEvaluatedKey) {
+    responseBody.nextToken = encodeNextToken(result.LastEvaluatedKey);
+  }
+
+  return createResponse(200, responseBody);
+}
+
+async function upsertScore(event) {
+  if (!SCORES_TABLE) {
+    return createResponse(500, { message: 'SCORES_TABLE environment variable is not configured.' });
+  }
+
+  let payload;
+  try {
+    payload = parseJsonBody(event) || {};
+  } catch (error) {
+    return createResponse(400, { message: error.message });
+  }
+
+  const googleId = typeof payload.googleId === 'string' ? payload.googleId.trim() : '';
+  if (!googleId) {
+    return createResponse(400, { message: 'googleId is required.' });
+  }
+
+  const submittedScore = sanitizeNumber(payload.score, undefined);
+  if (submittedScore === undefined) {
+    return createResponse(400, { message: 'score must be a number.' });
+  }
+
+  let existing;
+  try {
+    const current = await dynamo
+      .get({
+        TableName: SCORES_TABLE,
+        Key: { googleId },
+      })
+      .promise();
+    existing = current.Item || null;
+  } catch (error) {
+    console.error('Failed to load existing score entry.', error);
+    return createResponse(500, { message: 'Unable to load existing score entry.' });
+  }
+
+  const now = new Date().toISOString();
+  const previousScore = sanitizeNumber(existing?.score, 0);
+  const finalScore = Math.max(previousScore, submittedScore);
+
+  const dimensionCount = sanitizeNumber(payload.dimensionCount, existing?.dimensionCount ?? 0);
+  const runTimeSeconds = sanitizeNumber(payload.runTimeSeconds, existing?.runTimeSeconds ?? 0);
+  const inventoryCount = sanitizeNumber(payload.inventoryCount, existing?.inventoryCount ?? 0);
+
+  const sanitizedLocation =
+    payload.location !== undefined ? sanitizeLocation(payload.location) : existing?.location ?? null;
+  const locationLabel =
+    payload.locationLabel !== undefined
+      ? payload.locationLabel && typeof payload.locationLabel === 'string'
+        ? payload.locationLabel
+        : null
+      : existing?.locationLabel ?? null;
+
+  const item = {
+    googleId,
+    name:
+      (typeof payload.name === 'string' && payload.name.trim()) || existing?.name || 'Explorer',
+    score: finalScore,
+    scoreBucket: SCORE_BUCKET,
+    scoreSort: -finalScore,
+    dimensionCount,
+    runTimeSeconds,
+    inventoryCount,
+    location: sanitizedLocation,
+    locationLabel,
+    updatedAt: now,
+    lastSubmittedScore: submittedScore,
+    attempts: sanitizeNumber(existing?.attempts, 0) + 1,
+    bestScoreAt: finalScore > previousScore ? now : existing?.bestScoreAt || now,
+  };
+
+  if (item.location === undefined) {
+    delete item.location;
+  }
+
+  try {
+    await dynamo
+      .put({
+        TableName: SCORES_TABLE,
+        Item: item,
+      })
+      .promise();
+  } catch (error) {
+    console.error('Failed to persist score entry.', error);
+    return createResponse(500, { message: 'Failed to persist score entry.' });
+  }
+
+  return createResponse(200, {
+    message: 'Score recorded.',
+    item,
+  });
+}
+
+exports.handler = async (event) => {
+  if (event?.httpMethod === 'OPTIONS') {
+    return handleOptions();
+  }
+
+  if (event?.httpMethod === 'GET') {
+    return getScores(event);
+  }
+
+  if (event?.httpMethod === 'POST') {
+    return upsertScore(event);
+  }
+
+  return createResponse(405, { message: 'Method Not Allowed' });
+};

--- a/serverless/handlers/users.js
+++ b/serverless/handlers/users.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const { createResponse, parseJsonBody, handleOptions } = require('../lib/http');
+
+const dynamo = new AWS.DynamoDB.DocumentClient();
+const USERS_TABLE = process.env.USERS_TABLE;
+
+function sanitizeDevice(device) {
+  if (!device || typeof device !== 'object') {
+    return null;
+  }
+  const allowedKeys = ['userAgent', 'platform', 'language', 'screen'];
+  const snapshot = allowedKeys.reduce((acc, key) => {
+    if (device[key] !== undefined) {
+      acc[key] = device[key];
+    }
+    return acc;
+  }, {});
+  return Object.keys(snapshot).length ? snapshot : null;
+}
+
+function sanitizeLocation(location) {
+  if (!location || typeof location !== 'object') {
+    return null;
+  }
+  const output = {};
+  if (typeof location.latitude === 'number') {
+    output.latitude = location.latitude;
+  }
+  if (typeof location.longitude === 'number') {
+    output.longitude = location.longitude;
+  }
+  if (typeof location.accuracy === 'number') {
+    output.accuracy = location.accuracy;
+  }
+  if (location.error) {
+    output.error = String(location.error);
+  }
+  if (location.label) {
+    output.label = String(location.label);
+  }
+  if (location.timestamp) {
+    output.timestamp = location.timestamp;
+  }
+  return Object.keys(output).length ? output : null;
+}
+
+exports.handler = async (event) => {
+  if (event?.httpMethod === 'OPTIONS') {
+    return handleOptions();
+  }
+
+  if (event?.httpMethod !== 'POST') {
+    return createResponse(405, { message: 'Method Not Allowed' });
+  }
+
+  if (!USERS_TABLE) {
+    return createResponse(500, { message: 'USERS_TABLE environment variable is not configured.' });
+  }
+
+  let payload;
+  try {
+    payload = parseJsonBody(event) || {};
+  } catch (error) {
+    return createResponse(400, { message: error.message });
+  }
+
+  const googleId = typeof payload.googleId === 'string' ? payload.googleId.trim() : '';
+  const name = typeof payload.name === 'string' ? payload.name.trim() : '';
+
+  if (!googleId || !name) {
+    return createResponse(400, { message: 'googleId and name are required fields.' });
+  }
+
+  const timestamp = new Date().toISOString();
+  const item = {
+    googleId,
+    name,
+    email: payload.email && typeof payload.email === 'string' ? payload.email.trim() : null,
+    device: sanitizeDevice(payload.device),
+    location: sanitizeLocation(payload.location),
+    lastSeenAt: payload.lastSeenAt || timestamp,
+    updatedAt: timestamp,
+  };
+
+  if (event?.requestContext?.identity?.sourceIp) {
+    item.sourceIp = event.requestContext.identity.sourceIp;
+  }
+
+  try {
+    await dynamo
+      .put({
+        TableName: USERS_TABLE,
+        Item: item,
+      })
+      .promise();
+  } catch (error) {
+    console.error('Failed to persist user record.', error);
+    return createResponse(500, { message: 'Failed to persist user record.' });
+  }
+
+  return createResponse(200, {
+    message: 'User profile synchronised.',
+    item,
+  });
+};

--- a/serverless/lib/http.js
+++ b/serverless/lib/http.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const DEFAULT_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Requested-With',
+  'Access-Control-Allow-Methods': 'OPTIONS,GET,POST',
+};
+
+function createResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: DEFAULT_HEADERS,
+    body: body ? JSON.stringify(body) : '',
+  };
+}
+
+function parseJsonBody(event) {
+  if (!event?.body) {
+    return null;
+  }
+  if (typeof event.body === 'object') {
+    return event.body;
+  }
+  try {
+    return JSON.parse(event.body);
+  } catch (error) {
+    const err = new Error('Invalid JSON payload');
+    err.code = 'INVALID_JSON';
+    throw err;
+  }
+}
+
+function handleOptions() {
+  return {
+    statusCode: 204,
+    headers: DEFAULT_HEADERS,
+    body: '',
+  };
+}
+
+module.exports = {
+  createResponse,
+  parseJsonBody,
+  handleOptions,
+  DEFAULT_HEADERS,
+};

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -1,0 +1,125 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >-
+  Serverless backend for Infinite Dimension providing Google-authenticated user sync and a DynamoDB-backed scoreboard.
+
+Globals:
+  Function:
+    Runtime: nodejs18.x
+    Timeout: 10
+    MemorySize: 256
+    Environment:
+      Variables:
+        USERS_TABLE: !Ref UsersTable
+        SCORES_TABLE: !Ref ScoresTable
+        SCORES_INDEX_NAME: ScoreIndex
+
+Resources:
+  ApiGateway:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      Cors:
+        AllowMethods: "'OPTIONS,GET,POST'"
+        AllowHeaders: "'Content-Type,Authorization,X-Requested-With'"
+        AllowOrigin: "'*'"
+
+  UsersTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: googleId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: googleId
+          KeyType: HASH
+      SSESpecification:
+        SSEEnabled: true
+
+  ScoresTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: googleId
+          AttributeType: S
+        - AttributeName: scoreBucket
+          AttributeType: S
+        - AttributeName: scoreSort
+          AttributeType: N
+      KeySchema:
+        - AttributeName: googleId
+          KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: ScoreIndex
+          KeySchema:
+            - AttributeName: scoreBucket
+              KeyType: HASH
+            - AttributeName: scoreSort
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+      SSESpecification:
+        SSEEnabled: true
+
+  UsersFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: handlers/users.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref UsersTable
+      Events:
+        PostUser:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /users
+            Method: post
+        OptionsUser:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /users
+            Method: options
+
+  ScoresFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: handlers/scores.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref ScoresTable
+      Events:
+        GetScores:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /scores
+            Method: get
+        PostScore:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /scores
+            Method: post
+        OptionsScores:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /scores
+            Method: options
+
+Outputs:
+  ApiEndpoint:
+    Description: Invoke URL for the Infinite Dimension API Gateway stage.
+    Value: !Sub 'https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com/Prod'
+  UsersTableName:
+    Description: DynamoDB table storing Google-linked explorer profiles.
+    Value: !Ref UsersTable
+  ScoresTableName:
+    Description: DynamoDB table storing multiverse scoreboard entries.
+    Value: !Ref ScoresTable

--- a/styles.css
+++ b/styles.css
@@ -1681,6 +1681,52 @@ input[type='search'] {
   color: var(--accent-strong);
 }
 
+.signin-callout {
+  margin: 1.75rem 0 2rem;
+  padding: 1.5rem 1.75rem 1.75rem;
+  border-radius: 20px;
+  border: 1px solid rgba(73, 242, 255, 0.24);
+  background: linear-gradient(160deg, rgba(6, 22, 44, 0.95), rgba(6, 22, 44, 0.75));
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+  text-align: center;
+}
+
+.signin-callout h3 {
+  font-family: 'Chakra Petch', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  font-size: clamp(1.1rem, 1.6vw, 1.35rem);
+}
+
+.signin-callout__summary {
+  color: var(--text-secondary);
+  margin: 0 auto;
+  max-width: 28rem;
+  line-height: 1.6;
+}
+
+.signin-callout__actions {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+  width: 100%;
+}
+
+.signin-callout__actions .primary {
+  min-width: clamp(200px, 60%, 260px);
+}
+
+.signin-callout__note {
+  color: rgba(242, 245, 250, 0.65);
+  font-size: 0.875rem;
+  margin: 0;
+  max-width: 26rem;
+}
+
 .guide-modal {
   align-items: flex-start;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- surface the Google sign-in call-to-action on the landing modal and wire the identity layer to drive multiple sign-in buttons
- polish the modal styling so the new callout is prominent while keeping the sidebar fallback entry point
- add an AWS SAM package with Lambda handlers, DynamoDB tables, and documentation for the `/users` and `/scores` endpoints

## Testing
- npm test
- npm run test:e2e *(fails: Playwright browsers not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a7fdf1f4832bbd0892c1ed023f9d