### PR TITLE
Create modal leaderboard with sortable table

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,23 @@
           <span class="subtitle">Portals Reimagined</span>
         </div>
       </div>
+      <div class="top-bar__center">
+        <button
+          type="button"
+          id="openLeaderboard"
+          class="leaderboard-toggle"
+          aria-haspopup="dialog"
+          aria-controls="leaderboardModal"
+          aria-expanded="false"
+        >
+          <span class="leaderboard-toggle__icon" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+          </span>
+          <span class="leaderboard-toggle__label">Leaderboard</span>
+        </button>
+      </div>
       <div class="top-actions">
         <button type="button" id="openGuide" class="ghost">Game Guide</button>
         <button
@@ -128,14 +145,6 @@
               Sign in to capture your location badge, sync your device fingerprint, and compete on the Infinite Dimension scorecard.
             </p>
           </div>
-        </section>
-        <section class="scoreboard-panel" id="scoreboardSection" aria-label="Multiverse scoreboard" hidden>
-          <header>
-            <h2>Multiverse Scoreboard</h2>
-            <button type="button" id="refreshScores" class="ghost small">Refresh</button>
-          </header>
-          <p class="scoreboard-status" id="scoreboardStatus" aria-live="polite">Sign in to view the multiverse scorecard.</p>
-          <ol class="scoreboard-list" id="scoreboardList" aria-live="polite"></ol>
         </section>
         <section class="inventory-panel">
           <h2>Inventory</h2>
@@ -361,6 +370,58 @@
           </p>
         </section>
       </article>
+    </div>
+
+    <div
+      class="modal leaderboard-modal"
+      id="leaderboardModal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="leaderboardTitle"
+      hidden
+    >
+      <div class="modal-content leaderboard-modal__content">
+        <header class="leaderboard-modal__header">
+          <div>
+            <p class="leaderboard-modal__eyebrow">Global Rankings</p>
+            <h2 id="leaderboardTitle">Multiverse Scoreboard</h2>
+          </div>
+          <button type="button" class="ghost small" id="closeLeaderboard" aria-label="Close leaderboard">Close</button>
+        </header>
+        <p class="leaderboard-status" id="scoreboardStatus" aria-live="polite"></p>
+        <div class="leaderboard-controls">
+          <button type="button" id="refreshScores" class="ghost small leaderboard-refresh" data-loading="false">
+            <span class="leaderboard-refresh__spinner" aria-hidden="true"></span>
+            <span class="leaderboard-refresh__label">Refresh</span>
+          </button>
+        </div>
+        <div class="leaderboard-table__container" id="leaderboardTable" data-empty="true">
+          <table class="leaderboard-table">
+            <thead>
+              <tr>
+                <th scope="col" class="leaderboard-col-rank">#</th>
+                <th scope="col" class="leaderboard-sortable" data-sort-key="name" tabindex="0">Explorer</th>
+                <th
+                  scope="col"
+                  class="leaderboard-sortable"
+                  data-sort-key="score"
+                  data-sort-direction="desc"
+                  tabindex="0"
+                >
+                  Score
+                </th>
+                <th scope="col" class="leaderboard-sortable" data-sort-key="runTimeSeconds" tabindex="0">Run Time</th>
+                <th scope="col" class="leaderboard-sortable" data-sort-key="dimensionCount" tabindex="0">Realms</th>
+                <th scope="col" class="leaderboard-sortable" data-sort-key="inventoryCount" tabindex="0">Inventory</th>
+                <th scope="col" class="leaderboard-sortable" data-sort-key="locationLabel" tabindex="0">Location</th>
+                <th scope="col" class="leaderboard-sortable" data-sort-key="updatedAt" tabindex="0">Updated</th>
+              </tr>
+            </thead>
+            <tbody id="scoreboardList"></tbody>
+          </table>
+          <p class="leaderboard-empty" id="leaderboardEmptyMessage">Sign in to publish your victories and see the live rankings.</p>
+        </div>
+      </div>
     </div>
 
     <div class="mobile-controls" id="mobileControls">

--- a/styles.css
+++ b/styles.css
@@ -220,8 +220,8 @@ body::after {
 }
 
 .top-bar {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   padding: 1.5rem 2.5rem;
   backdrop-filter: blur(14px);
@@ -230,6 +230,12 @@ body::after {
   position: sticky;
   top: 0;
   z-index: 10;
+}
+
+.top-bar__center {
+  display: flex;
+  justify-content: center;
+  padding: 0 1.5rem;
 }
 
 .logo-area {
@@ -381,6 +387,61 @@ body::after {
   display: flex;
   align-items: center;
   gap: clamp(1rem, 3vw, 1.75rem);
+}
+
+.leaderboard-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(73, 242, 255, 0.35);
+  background: rgba(6, 18, 36, 0.65);
+  color: var(--text-primary);
+  font-family: 'Chakra Petch', sans-serif;
+  font-size: 0.95rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  white-space: nowrap;
+}
+
+.leaderboard-toggle:hover,
+.leaderboard-toggle:focus-visible {
+  border-color: var(--accent);
+  background: rgba(10, 26, 48, 0.85);
+  transform: translateY(-1px);
+}
+
+.leaderboard-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.leaderboard-toggle[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.leaderboard-toggle__icon {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.28rem;
+  width: 1.25rem;
+}
+
+.leaderboard-toggle__icon span {
+  display: block;
+  height: 0.18rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent-strong), var(--accent));
+}
+
+.leaderboard-toggle__label {
+  font-weight: 600;
 }
 
 .mobile-sidebar-toggle {
@@ -1071,75 +1132,240 @@ body.sidebar-open .player-hint {
   line-height: 1.5;
 }
 
-.scoreboard-panel {
+.leaderboard-modal__content {
+  max-width: min(960px, 95vw);
+  width: 100%;
+  text-align: left;
   display: grid;
-  gap: 0.85rem;
+  gap: 1.5rem;
 }
 
-.scoreboard-panel header {
+.leaderboard-modal__header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  gap: 1.25rem;
 }
 
-.scoreboard-status {
+.leaderboard-modal__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  color: var(--text-secondary);
   font-size: 0.75rem;
+  margin: 0 0 0.35rem;
+}
+
+.leaderboard-status {
+  font-size: 0.8rem;
   color: var(--text-secondary);
   letter-spacing: 0.08em;
-}
-
-.scoreboard-list {
-  list-style: none;
-  display: grid;
-  gap: 0.65rem;
   margin: 0;
-  padding: 0;
+  min-height: 1.25rem;
 }
 
-.score-entry {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 0.85rem;
+.leaderboard-controls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.leaderboard-refresh {
+  display: inline-flex;
   align-items: center;
-  padding: 0.75rem 1rem;
-  border-radius: 18px;
-  background: linear-gradient(135deg, rgba(10, 18, 35, 0.9), rgba(10, 18, 35, 0.55));
+  gap: 0.6rem;
+  position: relative;
+  padding-inline: 1.25rem;
+}
+
+.leaderboard-refresh[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.leaderboard-refresh__spinner {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  border-top-color: var(--accent);
+  border-right-color: var(--accent);
+  opacity: 0;
+  animation: leaderboard-spin 0.9s linear infinite;
+  transform: translateZ(0);
+}
+
+.leaderboard-refresh[data-loading='true'] .leaderboard-refresh__spinner {
+  opacity: 1;
+}
+
+.leaderboard-refresh[data-loading='true'] .leaderboard-refresh__label {
+  opacity: 0.65;
+}
+
+.leaderboard-table__container {
+  border-radius: 24px;
   border: 1px solid rgba(73, 242, 255, 0.18);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  background: linear-gradient(145deg, rgba(8, 18, 35, 0.92), rgba(8, 18, 35, 0.72));
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.35);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  overflow: auto;
+  max-height: min(70vh, 620px);
+  position: relative;
 }
 
-.score-entry .rank {
-  font-family: 'Chakra Petch', sans-serif;
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: var(--accent-strong);
-  letter-spacing: 0.12em;
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
 }
 
-.score-entry__body {
-  display: grid;
-  gap: 0.25rem;
+.leaderboard-table thead th {
+  text-align: left;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--text-secondary);
+  padding-bottom: 0.75rem;
+  position: sticky;
+  top: 0;
+  background: rgba(8, 18, 35, 0.95);
+  z-index: 1;
 }
 
-.score-entry__body strong {
+.leaderboard-table thead th:first-child {
+  text-align: center;
+}
+
+.leaderboard-table thead th:nth-child(3),
+.leaderboard-table thead th:nth-child(4),
+.leaderboard-table thead th:nth-child(5),
+.leaderboard-table thead th:nth-child(6) {
+  text-align: right;
+}
+
+.leaderboard-table tbody tr {
+  border-bottom: 1px solid rgba(73, 242, 255, 0.14);
+  transition: background 0.2s ease;
+}
+
+.leaderboard-table tbody tr:hover {
+  background: rgba(73, 242, 255, 0.08);
+}
+
+.leaderboard-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.leaderboard-table th,
+.leaderboard-table td {
+  padding: 0.65rem 0.85rem;
+  vertical-align: middle;
+}
+
+.leaderboard-table td {
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+}
+
+.leaderboard-table td strong {
   font-size: 0.95rem;
   letter-spacing: 0.08em;
-  text-transform: uppercase;
+  color: var(--text-primary);
 }
 
-.score-entry__body span {
+.leaderboard-col-rank {
+  width: 3rem;
+  font-family: 'Chakra Petch', sans-serif;
+  color: var(--accent-strong);
+}
+
+.leaderboard-sortable {
+  cursor: pointer;
+  padding-right: 1.75rem;
+}
+
+.leaderboard-sortable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.leaderboard-sortable::after {
+  content: '';
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-right: 2px solid var(--accent);
+  border-bottom: 2px solid var(--accent);
+  transform: translateY(-50%) rotate(45deg);
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.leaderboard-sortable[data-sort-direction='asc']::after {
+  opacity: 1;
+  transform: translateY(-50%) rotate(-135deg);
+}
+
+.leaderboard-sortable[data-sort-direction='desc']::after {
+  opacity: 1;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.leaderboard-sortable[data-sort-direction='asc'],
+.leaderboard-sortable[data-sort-direction='desc'] {
+  color: var(--accent);
+}
+
+.leaderboard-table tbody td {
+  color: rgba(242, 245, 250, 0.78);
+}
+
+.leaderboard-table tbody td:nth-child(1) {
+  text-align: center;
+}
+
+.leaderboard-table tbody td:nth-child(3),
+.leaderboard-table tbody td:nth-child(4),
+.leaderboard-table tbody td:nth-child(5),
+.leaderboard-table tbody td:nth-child(6) {
+  text-align: right;
+}
+
+.leaderboard-table tbody td[data-cell='location'] {
   font-size: 0.75rem;
   color: var(--text-secondary);
-  letter-spacing: 0.06em;
 }
 
-.score-entry__meta {
-  display: grid;
-  justify-items: end;
-  font-size: 0.7rem;
+.leaderboard-table tbody td[data-cell='updated'] {
+  font-size: 0.72rem;
+  color: rgba(242, 245, 250, 0.6);
+}
+
+.leaderboard-table__container[data-empty='true'] .leaderboard-table {
+  display: none;
+}
+
+.leaderboard-empty {
+  display: none;
+  margin: 1.5rem 0 0;
+  text-align: center;
   color: var(--text-secondary);
+  font-size: 0.85rem;
   letter-spacing: 0.08em;
-  text-align: right;
+}
+
+.leaderboard-table__container[data-empty='true'] .leaderboard-empty {
+  display: block;
+}
+
+@keyframes leaderboard-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .hotbar {
@@ -2255,9 +2481,19 @@ input[type='search'] {
   }
 
   .top-bar {
-    flex-direction: column;
-    align-items: flex-start;
+    grid-template-columns: 1fr;
     gap: 0.75rem;
+    justify-items: stretch;
+  }
+
+  .top-bar__center {
+    justify-content: flex-start;
+    padding: 0;
+  }
+
+  .leaderboard-toggle {
+    width: 100%;
+    justify-content: center;
   }
 
   .top-actions {
@@ -2373,14 +2609,18 @@ input[type='search'] {
     padding: 1rem;
   }
 
-  .score-entry {
-    grid-template-columns: 1fr;
-    justify-items: flex-start;
+  .leaderboard-toggle {
+    padding: 0.6rem 1.1rem;
+    gap: 0.65rem;
+    font-size: 0.85rem;
   }
 
-  .score-entry__meta {
-    justify-items: flex-start;
-    text-align: left;
+  .leaderboard-table {
+    min-width: 560px;
+  }
+
+  .leaderboard-modal__content {
+    padding: 1.5rem;
   }
 
   .footer {


### PR DESCRIPTION
## Summary
- add a top bar leaderboard toggle that opens a dedicated modal scoreboard table
- restyle the leaderboard with sortable headers, loading affordances, and responsive layout tweaks
- update scoreboard logic to drive the modal lifecycle, sorting behaviour, and status messaging

## Testing
- npm test
- npm run test:e2e # fails: missing Playwright browsers


------
https://chatgpt.com/codex/tasks/task_e_68d0a9f9a020832b9579777190038bf5