### PR TITLE
feat: create animated landing screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,31 +193,55 @@
       </div>
     </footer>
 
-    <div class="modal" id="introModal" role="dialog" aria-modal="true" aria-labelledby="introTitle">
-      <div class="modal-content">
-        <h2 id="introTitle">Welcome to Infinite Dimension</h2>
-        <p>
-          Survive, craft, and weave portals across dimensions. Gather resources from each world, solve rail puzzles,
-          and bring home the Eternal Ingot.
-        </p>
-        <section class="signin-callout" id="landingSignInPanel" aria-label="Link your explorer profile">
-          <h3>Sync your journey before you depart</h3>
-          <p class="signin-callout__summary">
-            Sign in with Google to unlock the shared scoreboard, capture your location badge, and mirror your progress across
-            every device.
-          </p>
-          <div class="signin-callout__actions">
-            <div class="gsi-container" data-google-button-container hidden></div>
-            <button type="button" class="primary" data-google-fallback-signin>Sign in with Google</button>
-            <p class="signin-callout__note">Prefer to explore as a guest? You can connect later from the Player Hub.</p>
+    <div
+      class="modal landing-modal"
+      id="introModal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="introTitle"
+    >
+      <div class="landing-modal__background" aria-hidden="true">
+        <div class="landing-modal__stars landing-modal__stars--back"></div>
+        <div class="landing-modal__stars landing-modal__stars--front"></div>
+        <div class="landing-modal__glow"></div>
+      </div>
+      <div class="modal-content landing-modal__content" role="document">
+        <div class="landing-modal__layout">
+          <header class="landing-modal__header">
+            <p class="landing-modal__eyebrow">Infinite Rails</p>
+            <h1 id="introTitle" class="landing-modal__title">Portals of Dimension</h1>
+            <p class="landing-modal__tagline">
+              Stabilise shimmering tracks between realities before you brave the storm of fractured worlds.
+            </p>
+            <div class="landing-modal__actions">
+              <button id="startButton" class="primary landing-modal__start">Start Expedition</button>
+              <button type="button" class="ghost landing-modal__howto" id="landingGuideButton">How to Play</button>
+            </div>
+          </header>
+          <div class="landing-modal__body">
+            <section
+              class="signin-callout landing-modal__signin"
+              id="landingSignInPanel"
+              aria-label="Link your explorer profile"
+            >
+              <h3>Sync your journey before you depart</h3>
+              <p class="signin-callout__summary">
+                Sign in with Google to unlock the shared scoreboard, capture your location badge, and mirror your progress across
+                every device.
+              </p>
+              <div class="signin-callout__actions">
+                <div class="gsi-container" data-google-button-container hidden></div>
+                <button type="button" class="primary" data-google-fallback-signin>Sign in with Google</button>
+                <p class="signin-callout__note">Prefer to explore as a guest? You can connect later from the Player Hub.</p>
+              </div>
+            </section>
+            <ul class="landing-modal__highlights" aria-label="Highlights">
+              <li>Build 4×3 portals with unique materials to unlock new rules.</li>
+              <li>Craft using ordered sequences and uncover hidden recipes.</li>
+              <li>Survive nightly assaults while protecting villagers and rails.</li>
+            </ul>
           </div>
-        </section>
-        <ul class="modal-highlights">
-          <li>Build 4×3 portals with unique materials to unlock new rules.</li>
-          <li>Craft using ordered sequences and uncover hidden recipes.</li>
-          <li>Survive nightly assaults while protecting villagers and rails.</li>
-        </ul>
-        <button id="startButton" class="primary">Enter the Rails</button>
+        </div>
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -88,6 +88,7 @@
     const eventLogEl = document.getElementById('eventLog');
     const codexListEl = document.getElementById('dimensionCodex');
     const openGuideButton = document.getElementById('openGuide');
+    const landingGuideButton = document.getElementById('landingGuideButton');
     const openSettingsButton = document.getElementById('openSettings');
     const settingsModal = document.getElementById('settingsModal');
     const closeSettingsButton = document.getElementById('closeSettings');
@@ -5453,6 +5454,9 @@
         button.addEventListener('click', () => updateFromMobile(button.dataset.action));
       });
       openGuideButton?.addEventListener('click', openGuideModal);
+      landingGuideButton?.addEventListener('click', () => {
+        openGuideModal();
+      });
       openSettingsButton?.addEventListener('click', openSettingsModal);
       toggleSidebarButton?.addEventListener('click', toggleSidebar);
       sidePanelScrim?.addEventListener('click', () => closeSidebar(true));

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,248 @@ body.game-active {
   height: auto;
 }
 
+body:not(.game-active) .top-bar,
+body:not(.game-active) .main-layout,
+body:not(.game-active) .footer,
+body:not(.game-active) .side-panel__scrim,
+body:not(.game-active) .manu-logo {
+  display: none;
+}
+
+.landing-modal {
+  padding: clamp(2rem, 6vw, 4rem);
+  background: radial-gradient(circle at 50% 20%, rgba(73, 242, 255, 0.2), rgba(5, 9, 18, 0.9));
+  overflow: hidden;
+}
+
+.landing-modal__background {
+  position: absolute;
+  inset: -15% -15%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.landing-modal__stars {
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(2px 2px at 18% 22%, rgba(255, 255, 255, 0.8), transparent 55%),
+    radial-gradient(1.5px 1.5px at 74% 38%, rgba(73, 242, 255, 0.85), transparent 60%),
+    radial-gradient(1px 1px at 32% 68%, rgba(247, 183, 51, 0.65), transparent 60%),
+    radial-gradient(1.2px 1.2px at 86% 72%, rgba(255, 255, 255, 0.75), transparent 60%),
+    radial-gradient(1.1px 1.1px at 44% 44%, rgba(73, 242, 255, 0.65), transparent 60%),
+    radial-gradient(0.8px 0.8px at 12% 74%, rgba(255, 255, 255, 0.6), transparent 50%);
+  background-size: 220px 220px;
+  animation: landing-star-drift 52s linear infinite;
+  opacity: 0.6;
+  transform-origin: center;
+}
+
+.landing-modal__stars--front {
+  animation-duration: 28s;
+  opacity: 0.9;
+  transform: scale(1.05);
+}
+
+.landing-modal__stars--back {
+  animation-duration: 68s;
+  filter: blur(0.5px);
+  opacity: 0.45;
+  transform: scale(1.15);
+}
+
+.landing-modal__glow {
+  position: absolute;
+  inset: -20% -10% -15% -10%;
+  background: radial-gradient(circle at 20% 25%, rgba(73, 242, 255, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 15%, rgba(247, 183, 51, 0.28), transparent 60%),
+    radial-gradient(circle at 50% 70%, rgba(73, 242, 255, 0.18), transparent 65%);
+  mix-blend-mode: screen;
+  opacity: 0.65;
+  animation: landing-glow-pulse 18s ease-in-out infinite;
+}
+
+.landing-modal__content {
+  position: relative;
+  z-index: 1;
+  max-width: clamp(720px, 86vw, 980px);
+  padding: clamp(2.5rem, 5vw, 3.5rem);
+  border-radius: 28px;
+  background: rgba(5, 13, 26, 0.82);
+  border: 1px solid rgba(73, 242, 255, 0.3);
+  box-shadow: 0 40px 100px rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(20px);
+  overflow: hidden;
+}
+
+.landing-modal__content::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.landing-modal__layout {
+  position: relative;
+  display: grid;
+  gap: clamp(2rem, 4vw, 2.75rem);
+  text-align: center;
+}
+
+.landing-modal__header {
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+}
+
+.landing-modal__eyebrow {
+  font-family: 'Chakra Petch', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: clamp(0.75rem, 1.6vw, 0.85rem);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.landing-modal__title {
+  font-family: 'Chakra Petch', sans-serif;
+  font-size: clamp(2.2rem, 6vw, 3.6rem);
+  line-height: 1.1;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  background: linear-gradient(120deg, #ffffff 10%, #49f2ff 40%, #f7b733 60%, #ffffff 90%);
+  background-size: 220% 220%;
+  -webkit-background-clip: text;
+  color: transparent;
+  animation: landing-title-shimmer 7s ease-in-out infinite;
+}
+
+.landing-modal__tagline {
+  max-width: 38ch;
+  color: rgba(242, 245, 250, 0.78);
+  font-size: clamp(1rem, 1.9vw, 1.15rem);
+  line-height: 1.6;
+}
+
+.landing-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.9rem;
+  margin-top: 0.75rem;
+}
+
+.landing-modal__start {
+  font-size: 1rem;
+  padding: 0.85rem 1.75rem;
+  box-shadow: 0 18px 40px rgba(73, 242, 255, 0.35);
+}
+
+.landing-modal__howto {
+  border-color: rgba(73, 242, 255, 0.45);
+  color: var(--text-primary);
+  padding: 0.85rem 1.75rem;
+  background: rgba(6, 18, 34, 0.6);
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+.landing-modal__howto:hover,
+.landing-modal__howto:focus-visible {
+  background: rgba(73, 242, 255, 0.12);
+  border-color: rgba(247, 183, 51, 0.7);
+}
+
+.landing-modal__body {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 1.85rem);
+}
+
+.landing-modal__signin {
+  margin: 0;
+  width: 100%;
+}
+
+.landing-modal__highlights {
+  list-style: none;
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.6rem 1.75rem;
+  border-radius: 20px;
+  border: 1px solid rgba(73, 242, 255, 0.18);
+  background: linear-gradient(150deg, rgba(6, 18, 34, 0.85), rgba(6, 18, 34, 0.65));
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.38);
+  text-align: left;
+}
+
+.landing-modal__highlights li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  color: rgba(242, 245, 250, 0.78);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.landing-modal__highlights li::before {
+  content: '✦';
+  color: var(--accent-strong);
+  font-size: 0.9rem;
+  margin-top: 0.1rem;
+}
+
+@media (min-width: 900px) {
+  .landing-modal__layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    align-items: center;
+    text-align: left;
+  }
+
+  .landing-modal__header {
+    justify-items: flex-start;
+    gap: 1.1rem;
+  }
+
+  .landing-modal__actions {
+    justify-content: flex-start;
+  }
+}
+
+@keyframes landing-star-drift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(3%, -4%, 0) scale(1.02);
+  }
+  100% {
+    transform: translate3d(-2%, 5%, 0) scale(1);
+  }
+}
+
+@keyframes landing-title-shimmer {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+@keyframes landing-glow-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.85;
+    transform: scale(1.04);
+  }
+}
+
 .background-sheen {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- replace the static intro modal with a full-screen "Infinite Rails" splash that adds animated stars, shimmering title text, and start/how-to actions
- surface the Google sign-in prompt and gameplay highlights inside the new landing experience while hiding the HUD until the run begins
- wire the landing how-to button into the existing guide modal logic

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d0b0cf5ba4832b8310495e554e621a