### PR TITLE
Add interactive carousel to player guide modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,6 +437,20 @@
           </div>
           <button type="button" class="ghost" data-close-guide>Close</button>
         </header>
+        <section class="guide-section guide-carousel" data-guide-carousel aria-label="Interactive player guide">
+          <div class="guide-carousel__viewport">
+            <article class="guide-card" id="guideCarouselCard" data-guide-card role="group" aria-live="polite"></article>
+          </div>
+          <div class="guide-carousel__controls">
+            <button type="button" class="guide-carousel__arrow" data-guide-prev aria-label="Previous guide card">
+              <span aria-hidden="true">&#x2039;</span>
+            </button>
+            <div class="guide-carousel__dots" data-guide-dots></div>
+            <button type="button" class="guide-carousel__arrow" data-guide-next aria-label="Next guide card">
+              <span aria-hidden="true">&#x203A;</span>
+            </button>
+          </div>
+        </section>
         <section class="guide-section">
           <h3>Game Overview</h3>
           <p>

--- a/styles.css
+++ b/styles.css
@@ -2803,6 +2803,282 @@ input[type='search'] {
   color: var(--text-secondary);
 }
 
+.guide-carousel {
+  background: radial-gradient(circle at top left, rgba(73, 242, 255, 0.16), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(247, 183, 51, 0.12), transparent 50%);
+  border: 1px solid rgba(73, 242, 255, 0.22);
+  border-radius: 28px;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  gap: clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.guide-carousel__viewport {
+  position: relative;
+}
+
+.guide-card {
+  background: rgba(8, 18, 36, 0.92);
+  border-radius: 24px;
+  border: 1px solid rgba(73, 242, 255, 0.18);
+  padding: clamp(1.25rem, 2.5vw, 2.25rem);
+  display: grid;
+  gap: clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.guide-card__header {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.guide-card__icon {
+  width: clamp(3.25rem, 4vw, 3.75rem);
+  height: clamp(3.25rem, 4vw, 3.75rem);
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(73, 242, 255, 0.25), rgba(47, 125, 255, 0.45));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(73, 242, 255, 0.3);
+  box-shadow: 0 18px 30px rgba(6, 16, 31, 0.45);
+}
+
+.guide-card__icon span {
+  font-size: clamp(1.85rem, 4vw, 2.2rem);
+  line-height: 1;
+}
+
+.guide-card__label {
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.7rem;
+  color: rgba(247, 183, 51, 0.8);
+}
+
+.guide-card__title {
+  font-family: 'Chakra Petch', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  font-size: clamp(1.1rem, 2.3vw, 1.6rem);
+  margin: 0;
+}
+
+.guide-card__description {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.guide-card__demo {
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(0.75rem, 2vw, 1.25rem);
+  border-radius: 18px;
+  background: rgba(12, 26, 49, 0.92);
+  border: 1px solid rgba(73, 242, 255, 0.16);
+}
+
+.guide-card__steps {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.guide-card__step {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.9rem;
+  background: rgba(10, 22, 42, 0.85);
+  border: 1px solid rgba(73, 242, 255, 0.12);
+  border-radius: 14px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 160ms ease, background-color 160ms ease, transform 160ms ease;
+}
+
+.guide-card__step:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.guide-card__step:hover {
+  border-color: rgba(73, 242, 255, 0.35);
+}
+
+.guide-card__step.is-active {
+  background: rgba(73, 242, 255, 0.18);
+  border-color: rgba(73, 242, 255, 0.45);
+}
+
+.guide-card__step.is-animating {
+  animation: guide-step-pulse 620ms ease;
+}
+
+.guide-card__step-label {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.65rem;
+  color: rgba(247, 183, 51, 0.9);
+}
+
+.guide-card__step-keys {
+  display: inline-flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.guide-card__step-keys kbd {
+  font-size: 0.75rem;
+}
+
+.guide-card__play {
+  justify-self: flex-start;
+  border: 1px solid rgba(247, 183, 51, 0.6);
+  background: rgba(247, 183, 51, 0.16);
+  color: rgba(247, 183, 51, 0.95);
+  border-radius: 999px;
+  padding: 0.45rem 1.05rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
+}
+
+.guide-card__play:hover {
+  background: rgba(247, 183, 51, 0.22);
+  transform: translateY(-1px);
+}
+
+.guide-card__play:focus-visible {
+  outline: 2px solid rgba(247, 183, 51, 0.8);
+  outline-offset: 2px;
+}
+
+.guide-card__caption {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: rgba(215, 226, 245, 0.85);
+}
+
+.guide-card__columns {
+  display: grid;
+  gap: 1.15rem;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.guide-card__list h4 {
+  margin-bottom: 0.6rem;
+}
+
+.guide-card__list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.guide-card__control {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.guide-card__control-keys {
+  display: inline-flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.guide-card__control-keys kbd {
+  font-size: 0.75rem;
+}
+
+.guide-card__tip {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: rgba(109, 212, 255, 0.85);
+}
+
+.guide-carousel__controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.guide-carousel__arrow {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid rgba(73, 242, 255, 0.3);
+  background: rgba(11, 26, 48, 0.9);
+  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+}
+
+.guide-carousel__arrow:hover {
+  border-color: rgba(73, 242, 255, 0.55);
+  background: rgba(16, 36, 67, 0.95);
+  transform: translateY(-1px);
+}
+
+.guide-carousel__arrow:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.guide-carousel__dots {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.guide-carousel__dots button {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  border: 1px solid rgba(73, 242, 255, 0.35);
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  transition: transform 160ms ease, background-color 160ms ease, border-color 160ms ease;
+}
+
+.guide-carousel__dots button[data-active='true'] {
+  background: var(--accent);
+  border-color: var(--accent);
+  transform: scale(1.1);
+}
+
+.guide-carousel__dots button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@keyframes guide-step-pulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(73, 242, 255, 0.45);
+  }
+  50% {
+    transform: scale(1.02);
+    box-shadow: 0 0 20px 0 rgba(73, 242, 255, 0.35);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(73, 242, 255, 0.2);
+  }
+}
+
 .guide-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add a carousel section to the player guide modal with navigation arrows and card layout
- populate the carousel from script data with interactive control demos and sequencing animations
- style the new guide cards, icons, demo steps, and navigation controls to match the HUD aesthetic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0b9c94bf8832bafe8cdfe588305d1