### PR TITLE
Add defeat overlay with respawn countdown and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,11 +148,22 @@
           aria-hidden="true"
           tabindex="-1"
         >
-          <div class="defeat-overlay__content" role="dialog" aria-modal="true" aria-labelledby="defeatTitle">
-            <h3 id="defeatTitle">Respawn Imminent</h3>
+          <div
+            class="defeat-overlay__content"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="defeatTitle"
+            aria-describedby="defeatMessage defeatCountdown"
+          >
+            <h3 id="defeatTitle">You Perished</h3>
             <p class="defeat-overlay__message" id="defeatMessage"></p>
             <div class="defeat-overlay__inventory" id="defeatInventory" aria-live="polite"></div>
-            <p class="defeat-overlay__countdown" id="defeatCountdown"></p>
+            <p class="defeat-overlay__countdown" id="defeatCountdown" role="status" aria-live="assertive"></p>
+            <div class="defeat-overlay__actions">
+              <button type="button" class="defeat-overlay__respawn-button" id="defeatRespawn">
+                Respawn Now
+              </button>
+            </div>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -340,10 +340,17 @@
     const defeatMessageEl = document.getElementById('defeatMessage');
     const defeatInventoryEl = document.getElementById('defeatInventory');
     const defeatCountdownEl = document.getElementById('defeatCountdown');
+    const defeatRespawnButton = document.getElementById('defeatRespawn');
     const mainLayoutEl = document.querySelector('.main-layout');
     const primaryPanelEl = document.querySelector('.primary-panel');
     const topBarEl = document.querySelector('.top-bar');
     const footerEl = document.querySelector('.footer');
+
+    if (defeatRespawnButton) {
+      defeatRespawnButton.addEventListener('click', () => {
+        completeRespawn();
+      });
+    }
     const toggleSidebarButton = document.getElementById('toggleSidebar');
     const sidePanelEl = document.getElementById('sidePanel');
     const sidePanelScrim = document.getElementById('sidePanelScrim');
@@ -4544,6 +4551,10 @@
       if (defeatCountdownEl) {
         defeatCountdownEl.textContent = '';
       }
+      if (defeatRespawnButton) {
+        defeatRespawnButton.disabled = false;
+        defeatRespawnButton.textContent = 'Respawn Now';
+      }
       window.clearTimeout(state.ui.respawnCountdownTimeout);
       window.requestAnimationFrame(() => {
         defeatOverlayEl?.focus({ preventScroll: true });
@@ -4603,6 +4614,10 @@
 
     function completeRespawn() {
       if (!state.ui.respawnActive) return;
+      if (defeatRespawnButton) {
+        defeatRespawnButton.disabled = true;
+        defeatRespawnButton.textContent = 'Respawning...';
+      }
       if (state.ui.respawnCountdownTimeout) {
         window.clearTimeout(state.ui.respawnCountdownTimeout);
         state.ui.respawnCountdownTimeout = null;
@@ -4636,6 +4651,10 @@
       if (defeatInventoryEl) {
         defeatInventoryEl.innerHTML = '';
         delete defeatInventoryEl.dataset.empty;
+      }
+      if (defeatRespawnButton) {
+        defeatRespawnButton.disabled = true;
+        defeatRespawnButton.textContent = 'Respawn Now';
       }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -3535,6 +3535,49 @@ input[type='search'] {
   color: var(--accent-strong);
 }
 
+.defeat-overlay__actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.35rem;
+}
+
+.defeat-overlay__respawn-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.75rem 1.8rem;
+  border-radius: 999px;
+  border: none;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--bg-primary);
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  cursor: pointer;
+  box-shadow: 0 14px 32px rgba(73, 242, 255, 0.28);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, opacity 0.2s ease;
+}
+
+.defeat-overlay__respawn-button:hover,
+.defeat-overlay__respawn-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(73, 242, 255, 0.34);
+}
+
+.defeat-overlay__respawn-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 3px;
+}
+
+.defeat-overlay__respawn-button:disabled {
+  cursor: default;
+  opacity: 0.65;
+  box-shadow: none;
+}
+
 @media (max-width: 1180px) {
   .main-layout {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- replace the generic defeat modal markup with an explicit "You Perished" overlay that includes countdown messaging and a respawn control
- wire the defeat overlay into the game loop so respawn actions update the UI and can be triggered manually by the player
- style the new overlay actions for consistency with the existing HUD aesthetic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0bba96b3c832bb51814921877dd92