### PR TITLE
Add celebratory victory overlay with share flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,50 @@
           </div>
         </div>
         <div class="victory-banner" id="victoryBanner" role="status" aria-live="assertive"></div>
+        <div
+          class="victory-celebration"
+          id="victoryCelebration"
+          hidden
+          aria-hidden="true"
+        >
+          <div class="victory-celebration__backdrop" aria-hidden="true"></div>
+          <div class="victory-celebration__effects" aria-hidden="true">
+            <div class="victory-confetti" id="victoryConfetti" aria-hidden="true"></div>
+            <div class="victory-fireworks" id="victoryFireworks" aria-hidden="true"></div>
+          </div>
+          <div
+            class="victory-celebration__content"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="victoryTitle"
+            aria-describedby="victoryMessage victoryStats victoryShareStatus"
+          >
+            <span class="victory-celebration__eyebrow">Multiverse Secured</span>
+            <h2 id="victoryTitle">Victory Achieved</h2>
+            <p id="victoryMessage">
+              You returned with the Eternal Ingot. The bridge between worlds is safe once more.
+            </p>
+            <dl class="victory-celebration__stats" id="victoryStats">
+              <div>
+                <dt>Final Score</dt>
+                <dd>0</dd>
+              </div>
+              <div>
+                <dt>Dimensions Stabilised</dt>
+                <dd>0</dd>
+              </div>
+              <div>
+                <dt>Run Time</dt>
+                <dd>00:00</dd>
+              </div>
+            </dl>
+            <div class="victory-celebration__actions">
+              <button type="button" class="primary" id="victoryShareButton">Share your run</button>
+              <button type="button" class="ghost" id="victoryCloseButton">Continue exploring</button>
+            </div>
+            <p class="victory-celebration__share-status" id="victoryShareStatus" role="status" aria-live="polite"></p>
+          </div>
+        </div>
         <div class="drowning-vignette" id="drowningVignette" aria-hidden="true"></div>
         <div class="dimension-transition" id="dimensionTransition" aria-hidden="true"></div>
         <div

--- a/styles.css
+++ b/styles.css
@@ -1357,6 +1357,237 @@ body.hud-inactive #gameHud .craft-launcher {
   color: var(--text-secondary);
 }
 
+.victory-celebration {
+  position: fixed;
+  inset: 0;
+  display: none;
+  place-items: center;
+  z-index: 60;
+  pointer-events: none;
+}
+
+.victory-celebration.active {
+  display: grid;
+  pointer-events: auto;
+}
+
+.victory-celebration__backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(16, 32, 64, 0.85), rgba(5, 12, 28, 0.94));
+  backdrop-filter: blur(18px) saturate(130%);
+  opacity: 0;
+  transition: opacity 0.45s ease;
+}
+
+.victory-celebration.active .victory-celebration__backdrop {
+  opacity: 1;
+}
+
+.victory-celebration__effects {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.victory-confetti,
+.victory-fireworks {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.victory-confetti__piece {
+  position: absolute;
+  top: -12vh;
+  left: var(--x, 50%);
+  width: 0.65rem;
+  height: 1.35rem;
+  border-radius: 8px;
+  opacity: 0;
+  transform: translate3d(0, 0, 0) rotate(0deg);
+  background: var(--color, #ffffff);
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.2);
+  animation: victoryConfettiFall var(--duration, 2.8s) linear var(--delay, 0s) forwards;
+}
+
+@keyframes victoryConfettiFall {
+  0% {
+    transform: translate3d(0, -6vh, 0) rotate(0deg);
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(var(--offset-x, 0), 110vh, 0) rotate(var(--rotation, 360deg));
+    opacity: 0;
+  }
+}
+
+.victory-firework {
+  position: absolute;
+  bottom: -10vh;
+  left: var(--left, 50%);
+  width: 0.55rem;
+  height: 3rem;
+  border-radius: 999px;
+  background: linear-gradient(to top, hsla(var(--hue, 210), 90%, 72%, 0.6), rgba(255, 255, 255, 0));
+  box-shadow: 0 -8px 16px rgba(255, 255, 255, 0.35);
+  opacity: 0;
+  transform: translate(-50%, 0) scaleY(0.6);
+  animation: victoryFireworkLaunch var(--duration, 1.8s) ease-out var(--delay, 0s) forwards;
+}
+
+.victory-firework__burst {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: clamp(8rem, 26vw, 12rem);
+  aspect-ratio: 1 / 1;
+  transform: translate(-50%, -50%) scale(0.25);
+  opacity: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+      from 0deg,
+      hsla(var(--hue, 210), 100%, 72%, 0.95) 0deg,
+      hsla(var(--hue, 210), 100%, 70%, 0) 55deg,
+      hsla(var(--hue, 210), 100%, 70%, 0.8) 90deg,
+      hsla(var(--hue, 210), 100%, 70%, 0) 140deg,
+      hsla(var(--hue, 210), 100%, 72%, 0.9) 180deg,
+      hsla(var(--hue, 210), 100%, 70%, 0) 230deg,
+      hsla(var(--hue, 210), 100%, 70%, 0.8) 280deg,
+      hsla(var(--hue, 210), 100%, 70%, 0) 330deg,
+      hsla(var(--hue, 210), 100%, 72%, 0.95) 360deg
+    );
+  filter: drop-shadow(0 0 18px hsla(var(--hue, 210), 100%, 72%, 0.7));
+  mask-image: radial-gradient(circle, rgba(0, 0, 0, 1) 45%, rgba(0, 0, 0, 0) 70%);
+  transition: transform 0.55s ease-out, opacity 0.55s ease-out;
+}
+
+.victory-firework.burst .victory-firework__burst {
+  opacity: 0.95;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+@keyframes victoryFireworkLaunch {
+  0% {
+    transform: translate(-50%, 10vh) scaleY(0.5);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, var(--travel, -45vh)) scaleY(1.05);
+    opacity: 0;
+  }
+}
+
+.victory-celebration__content {
+  position: relative;
+  z-index: 1;
+  width: min(520px, 88vw);
+  padding: clamp(2.25rem, 4vw, 2.85rem);
+  border-radius: 32px;
+  background: linear-gradient(160deg, rgba(12, 26, 48, 0.92), rgba(11, 20, 38, 0.82));
+  border: 1px solid rgba(73, 242, 255, 0.35);
+  box-shadow: 0 45px 120px rgba(0, 0, 0, 0.55);
+  display: grid;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.victory-celebration__eyebrow {
+  font-family: 'Chakra Petch', sans-serif;
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: rgba(73, 242, 255, 0.7);
+}
+
+.victory-celebration__content h2 {
+  font-size: clamp(2.35rem, 6vw, 3rem);
+  color: var(--accent-strong);
+  margin: 0;
+}
+
+.victory-celebration__content p {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 1.05rem;
+}
+
+.victory-celebration__stats {
+  display: grid;
+  gap: 0.85rem;
+  margin: 0;
+}
+
+.victory-celebration__stats div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.victory-celebration__stats dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.26em;
+  color: rgba(231, 240, 255, 0.55);
+}
+
+.victory-celebration__stats dd {
+  margin: 0;
+  font-size: clamp(1.35rem, 3.4vw, 1.75rem);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.victory-celebration__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.victory-celebration__share-status {
+  min-height: 1.25rem;
+  font-size: 0.9rem;
+  color: rgba(231, 240, 255, 0.7);
+}
+
+body.victory-celebration-active {
+  overflow: hidden;
+}
+
+@media (max-width: 720px) {
+  .victory-celebration__content {
+    padding: clamp(1.75rem, 6vw, 2.25rem);
+    gap: 1.25rem;
+  }
+
+  .victory-celebration__content p {
+    font-size: 0.95rem;
+  }
+
+  .victory-celebration__stats dd {
+    font-size: clamp(1.2rem, 5vw, 1.55rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .victory-confetti__piece,
+  .victory-firework {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+
+  .victory-firework__burst {
+    transition-duration: 1ms;
+  }
+}
+
 .side-panel {
   position: fixed;
   top: 50%;


### PR DESCRIPTION
## Summary
- add a full-screen victory celebration overlay with confetti, fireworks, stats, and sharing controls
- wire the overlay into the victory flow, including focus management, reduced-motion support, and share/copy fallbacks
- refresh the victory banner messaging and reset the celebration state on new runs

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Playwright page.click timeout waiting for #startButton)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bd25c1e8832bb88ee21b7af0662d