### PR TITLE
Add settings modal controls and accessibility toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Infinite Dimension · Portals Reimagined</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=Exo+2:wght@400;600;700&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
   </head>
@@ -103,12 +97,20 @@
                 <button
                   type="button"
                   id="openSettings"
-                  class="ghost"
+                  class="ghost settings-toggle"
                   aria-haspopup="dialog"
                   aria-controls="settingsModal"
                   aria-expanded="false"
                 >
-                  Settings
+                  <span class="settings-toggle__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                      <path
+                        fill="currentColor"
+                        d="M12 8.25a3.75 3.75 0 1 0 0 7.5a3.75 3.75 0 0 0 0-7.5Zm9.35 3.19l-1.57-.91a7.53 7.53 0 0 0-.41-1.02l.57-1.77a1 1 0 0 0-.23-1.04l-1.48-1.5a1 1 0 0 0-1.04-.23l-1.78.57c-.33-.14-.68-.27-1.03-.38L13.6 2.7a1 1 0 0 0-.97-.7h-2.26a1 1 0 0 0-.97.7l-.51 1.57c-.36.11-.7.24-1.04.38l-1.78-.57a1 1 0 0 0-1.04.23L3.55 5.51a1 1 0 0 0-.23 1.04l.57 1.77c-.15.34-.28.68-.4 1.03l-1.56.9A1 1 0 0 0 1.58 11v2a1 1 0 0 0 .55.9l1.57.91c.11.35.25.7.4 1.03l-.57 1.77a1 1 0 0 0 .23 1.04l1.48 1.5a1 1 0 0 0 1.04.23l1.78-.57c.33.14.68.27 1.03.38l.51 1.58a1 1 0 0 0 .97.7h2.26a1 1 0 0 0 .97-.7l.51-1.58c.35-.11.7-.24 1.03-.38l1.78.57a1 1 0 0 0 1.04-.23l1.48-1.5a1 1 0 0 0 .23-1.04l-.57-1.77c.15-.34.29-.68.4-1.03l1.57-.91a1 1 0 0 0 .55-.9v-2a1 1 0 0 0-.55-.9ZM20 12.74l-1.42.82a1 1 0 0 0-.48.62a6.04 6.04 0 0 1-.77 1.85a1 1 0 0 0-.05.83l.5 1.54l-.7.71l-1.55-.5a1 1 0 0 0-.84.1a6.2 6.2 0 0 1-1.83.76a1 1 0 0 0-.7.66l-.45 1.39h-1l-.45-1.39a1 1 0 0 0-.7-.66a6.24 6.24 0 0 1-1.83-.76a1 1 0 0 0-.84-.1l-1.55.5l-.7-.7l.5-1.54a1 1 0 0 0-.05-.83a6.04 6.04 0 0 1-.77-1.85a1 1 0 0 0-.48-.62L4 12.74v-1.48l1.42-.82a1 1 0 0 0 .48-.62a6.04 6.04 0 0 1 .77-1.85a1 1 0 0 0 .05-.83l-.5-1.54l.7-.7l1.55.5a1 1 0 0 0 .84-.1a6.2 6.2 0 0 1 1.83-.76a1 1 0 0 0 .7-.66l.45-1.4h1l.45 1.4a1 1 0 0 0 .7.66a6.24 6.24 0 0 1 1.83.76a1 1 0 0 0 .84.1l1.55-.5l.7.7l-.5 1.54a1 1 0 0 0 .05.83a6.04 6.04 0 0 1 .77 1.85a1 1 0 0 0 .48.62L20 11.26v1.48Z"
+                      />
+                    </svg>
+                  </span>
+                  <span class="settings-toggle__label">Settings</span>
                 </button>
                 <button
                   type="button"
@@ -140,6 +142,7 @@
             </div>
           </div>
         </div>
+        <div class="subtitle-overlay" id="subtitleOverlay" role="status" aria-live="assertive" hidden></div>
         <div class="victory-banner" id="victoryBanner" role="status" aria-live="assertive"></div>
         <div
           class="victory-celebration"
@@ -340,7 +343,7 @@
         </header>
         <form class="settings-modal__form" data-settings-form>
           <fieldset class="settings-modal__fieldset">
-            <legend class="sr-only">Volume levels</legend>
+            <legend class="settings-modal__legend">Audio mix</legend>
             <div class="settings-modal__field">
               <div class="settings-modal__label-row">
                 <label for="masterVolume">Master Volume</label>
@@ -386,8 +389,62 @@
                 class="settings-modal__range"
               />
             </div>
+            <p class="settings-modal__hint">Balance ambient loops and crafting cues independently.</p>
           </fieldset>
-          <p class="settings-modal__hint">Changes apply instantly and are saved for your next expedition.</p>
+          <fieldset class="settings-modal__fieldset settings-modal__fieldset--toggles">
+            <legend class="settings-modal__legend">Accessibility</legend>
+            <label class="settings-modal__toggle">
+              <span class="settings-modal__toggle-copy">
+                <span id="colorBlindModeLabel" class="settings-modal__toggle-title">Colour-blind assist</span>
+                <span id="colorBlindModeDescription" class="settings-modal__toggle-description">
+                  Boost HUD contrast and highlight critical effects with dual-spectrum colours.
+                </span>
+              </span>
+              <span class="settings-modal__toggle-control">
+                <input
+                  type="checkbox"
+                  id="colorBlindMode"
+                  name="colorBlindMode"
+                  class="toggle-switch__input"
+                  aria-describedby="colorBlindModeDescription"
+                  aria-labelledby="colorBlindModeLabel"
+                />
+                <span class="toggle-switch" aria-hidden="true"></span>
+              </span>
+            </label>
+            <label class="settings-modal__toggle">
+              <span class="settings-modal__toggle-copy">
+                <span id="subtitleToggleLabel" class="settings-modal__toggle-title">Subtitles</span>
+                <span id="subtitleToggleDescription" class="settings-modal__toggle-description">
+                  Surface narrated log entries as large captions near the action.
+                </span>
+              </span>
+              <span class="settings-modal__toggle-control">
+                <input
+                  type="checkbox"
+                  id="subtitleToggle"
+                  name="subtitleToggle"
+                  class="toggle-switch__input"
+                  aria-describedby="subtitleToggleDescription"
+                  aria-labelledby="subtitleToggleLabel"
+                />
+                <span class="toggle-switch" aria-hidden="true"></span>
+              </span>
+            </label>
+          </fieldset>
+          <fieldset class="settings-modal__fieldset settings-modal__fieldset--account">
+            <legend class="settings-modal__legend">Account</legend>
+            <p class="settings-modal__note">Disconnect your synced explorer when you are ready to depart.</p>
+            <button
+              type="button"
+              class="ghost settings-modal__logout"
+              id="settingsLogout"
+              data-google-sign-out
+              hidden
+            >
+              Sign out of Google
+            </button>
+          </fieldset>
           <div class="settings-modal__actions">
             <button type="button" class="ghost" id="closeSettings">Close</button>
           </div>
@@ -669,13 +726,6 @@
     </div>
 
     <script src="https://accounts.google.com/gsi/client" async defer></script>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.4/howler.min.js"
-      integrity="sha512-xi/RZRIF/S0hJ+yJJYuZ5yk6/8pCiRlEXZzoguSMl+vk2i3m6UjUO/WcZ11blRL/O+rnj94JRGwt/CHbc9+6EA=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-      defer
-    ></script>
     <script src="vendor/three.min.js" defer></script>
     <script src="scoreboard-utils.js" defer></script>
     <script src="script.js" defer></script>

--- a/styles.css
+++ b/styles.css
@@ -1278,6 +1278,29 @@ body.game-active #gameCanvas {
   padding: 0.55rem 1.1rem;
 }
 
+.settings-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  letter-spacing: 0.08em;
+}
+
+.settings-toggle__icon {
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  color: var(--accent);
+}
+
+.settings-toggle__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.settings-toggle__label {
+  display: inline-block;
+}
+
 #gameHud .leaderboard-toggle {
   padding: 0.55rem 1.35rem;
 }
@@ -2915,12 +2938,30 @@ input[type='search'] {
   gap: 1.5rem;
 }
 
+.settings-modal__legend {
+  font-family: 'Chakra Petch', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.78rem;
+  color: var(--accent);
+  margin-bottom: 0.35rem;
+}
+
 .settings-modal__fieldset {
   border: 0;
   margin: 0;
   padding: 0;
   display: grid;
   gap: 1.25rem;
+}
+
+.settings-modal__fieldset--toggles {
+  gap: 1rem;
+}
+
+.settings-modal__fieldset--account {
+  justify-items: flex-start;
+  gap: 0.85rem;
 }
 
 .settings-modal__field {
@@ -2989,6 +3030,150 @@ input[type='search'] {
 .settings-modal__actions {
   display: flex;
   justify-content: flex-end;
+}
+
+.settings-modal__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(73, 242, 255, 0.18);
+  background: rgba(6, 18, 34, 0.72);
+  cursor: pointer;
+}
+
+.settings-modal__toggle:focus-within {
+  outline: 2px solid rgba(73, 242, 255, 0.45);
+  outline-offset: 3px;
+}
+
+.settings-modal__toggle-copy {
+  display: grid;
+  gap: 0.35rem;
+  text-align: left;
+}
+
+.settings-modal__toggle-title {
+  font-weight: 600;
+}
+
+.settings-modal__toggle-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.settings-modal__toggle-control {
+  position: relative;
+  width: 56px;
+  height: 32px;
+  flex-shrink: 0;
+}
+
+.toggle-switch__input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.toggle-switch {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: rgba(73, 242, 255, 0.2);
+  transition: background 0.25s ease, box-shadow 0.25s ease;
+}
+
+.toggle-switch::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: rgba(242, 245, 250, 0.8);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.25);
+  transition: transform 0.25s ease, background 0.25s ease;
+}
+
+.toggle-switch__input:checked + .toggle-switch {
+  background: linear-gradient(135deg, var(--accent), rgba(247, 183, 51, 0.65));
+  box-shadow: 0 12px 28px rgba(73, 242, 255, 0.25);
+}
+
+.toggle-switch__input:checked + .toggle-switch::after {
+  transform: translateX(24px);
+  background: #04111d;
+}
+
+.toggle-switch__input:focus-visible + .toggle-switch {
+  box-shadow: 0 0 0 3px rgba(73, 242, 255, 0.35);
+}
+
+.settings-modal__note {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.settings-modal__logout {
+  min-width: 0;
+}
+
+body.colorblind-assist {
+  --accent: #ffd166;
+  --accent-strong: #073b4c;
+  --accent-soft: rgba(255, 209, 102, 0.35);
+  --text-secondary: rgba(255, 255, 255, 0.85);
+}
+
+body.colorblind-assist .score-overlay__label,
+body.colorblind-assist .score-overlay__value,
+body.colorblind-assist .score-overlay__metric-value {
+  color: #ffd166;
+}
+
+body.colorblind-assist .portal-progress .bar {
+  background: linear-gradient(90deg, #ffd166, #118ab2);
+}
+
+.subtitle-overlay {
+  position: absolute;
+  bottom: clamp(48px, 12vh, 120px);
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: min(640px, 80vw);
+  padding: 0.9rem 1.4rem;
+  border-radius: 18px;
+  border: 1px solid rgba(73, 242, 255, 0.25);
+  background: rgba(6, 14, 28, 0.82);
+  box-shadow: 0 22px 40px rgba(0, 0, 0, 0.45);
+  font-size: clamp(1rem, 2.35vw, 1.4rem);
+  line-height: 1.45;
+  text-align: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.subtitle-overlay[data-visible='true'] {
+  opacity: 1;
+}
+
+body:not(.subtitles-enabled) .subtitle-overlay {
+  display: none !important;
+}
+
+body.colorblind-assist .subtitle-overlay {
+  border-color: rgba(255, 209, 102, 0.35);
+  box-shadow: 0 22px 40px rgba(17, 138, 178, 0.25);
 }
 
 .signin-callout__summary {
@@ -3846,6 +4031,14 @@ input[type='search'] {
     grid-template-columns: 1fr;
     padding: clamp(0.75rem, 5vw, 1.5rem);
     gap: clamp(0.85rem, 4vw, 1.35rem);
+  }
+
+  .settings-toggle {
+    padding-inline: 0.75rem;
+  }
+
+  .settings-toggle__label {
+    display: none;
   }
 
   .objectives-panel {


### PR DESCRIPTION
## Summary
- replace the HUD settings control with a gear icon button and add a subtitle overlay plus expanded modal sections for audio, accessibility, and account actions
- persist colour-blind and subtitle preferences, update the DOM classes accordingly, and surface subtitles from the event log while filtering noisy console output
- style the new toggle controls, colour-blind theme, and subtitle overlay while removing external font/howler dependencies that triggered network errors

## Testing
- npm test
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d0c7cfcf5c832ba12329d87c608bbe