### PR TITLE
Ensure assets deployment and strengthen Three.js fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,15 @@ jobs:
             fi
           fi
 
-          aws s3 sync . "s3://${DEPLOY_BUCKET}" --delete --exclude ".git/*" --exclude ".github/*" --exclude "README.md" --exclude "LICENSE"
+          aws s3 sync . "s3://${DEPLOY_BUCKET}" \
+            --delete \
+            --exclude "*" \
+            --include "index.html" \
+            --include "styles.css" \
+            --include "script.js" \
+            --include "scoreboard-utils.js" \
+            --include "assets/*" \
+            --include "vendor/*"
 
       - name: Configure bucket access policy
         env:


### PR DESCRIPTION
## Summary
- limit the deployment sync to the static site files and explicitly include the assets and vendor directories so S3 always has the required game bundles
- extend the Three.js bootstrapping logic to try multiple CDN fallbacks when the local bundle is missing or blocked

## Testing
- npm test
- npm run test:e2e *(fails: Playwright browsers are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d13ec60b04832b9f29c041335ae442