### PR TITLE
Add voxel Manu emblem and tooltip-enhanced HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,67 @@
   </head>
   <body>
     <div class="background-sheen"></div>
-    <div class="manu-logo" aria-hidden="false">
-      <img src="assets/manu-logo.svg" alt="Created by Manu" class="manu-logo__image" />
+    <div class="manu-logo" id="logo" aria-hidden="false" data-hint="Created by Manu">
+      <svg
+        class="manu-logo__glyph"
+        viewBox="0 0 48 48"
+        role="img"
+        aria-labelledby="logoTitle logoDesc"
+      >
+        <title id="logoTitle">Manu voxel monogram</title>
+        <desc id="logoDesc">Stylised glowing M emblem rendered with a blue gradient.</desc>
+        <defs>
+          <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#00aaff"></stop>
+            <stop offset="100%" stop-color="#0044ff"></stop>
+          </linearGradient>
+          <filter id="voxelGlow" x="-40%" y="-40%" width="180%" height="180%">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="2.6" result="blur"></feGaussianBlur>
+            <feMerge>
+              <feMergeNode in="blur"></feMergeNode>
+              <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+          </filter>
+        </defs>
+        <rect x="4" y="4" width="40" height="40" rx="10" fill="url(#grad)" filter="url(#voxelGlow)"></rect>
+        <path
+          d="M12 32V16l6 8l6-8v16"
+          fill="none"
+          stroke="rgba(255, 255, 255, 0.88)"
+          stroke-width="4"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        ></path>
+        <path
+          d="M24 16l6 8l6-8v16"
+          fill="none"
+          stroke="rgba(180, 220, 255, 0.82)"
+          stroke-width="4"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        ></path>
+        <text
+          x="24"
+          y="32"
+          text-anchor="middle"
+          fill="white"
+          font-family="'Chakra Petch', 'Exo 2', sans-serif"
+          font-size="16"
+          font-weight="700"
+        >
+          M
+        </text>
+      </svg>
+      <span class="manu-logo__label" aria-hidden="true">Created by Manu</span>
+      <span class="sr-only">Created by Manu</span>
     </div>
     <main class="main-layout">
-      <aside class="objectives-panel" id="objectivesPanel" aria-label="Mission objectives">
+      <aside
+        class="objectives-panel"
+        id="objectivesPanel"
+        aria-label="Mission objectives"
+        data-hint="Review mission objectives and lore."
+      >
         <div class="logo-area objectives-panel__brand">
           <img src="assets/infinite-dimension-logo.svg" alt="Infinite Dimension logo" class="brand-logo" />
           <div class="brand-copy">
@@ -25,28 +81,41 @@
           <header class="objectives-panel__header">
             <h2>Current Objectives</h2>
           </header>
-          <div class="objectives-panel__card">
-            <div class="overlay-panel" id="dimensionInfo"></div>
+          <div class="objectives-panel__card" data-hint="Current dimension intel and environmental traits.">
+            <div class="overlay-panel" id="dimensionInfo" data-hint="Dimension briefing updates in real-time."></div>
           </div>
         </section>
         <section class="objectives-panel__section objectives-panel__section--hint" aria-live="polite">
           <header class="objectives-panel__header objectives-panel__header--hint">
             <h2>Guidance</h2>
           </header>
-          <div class="objectives-panel__card objectives-panel__card--hint">
-            <div class="player-hint" id="playerHint" role="status" aria-live="assertive" tabindex="0"></div>
+          <div class="objectives-panel__card objectives-panel__card--hint" data-hint="Helpful reminders for surviving each biome.">
+            <div
+              class="player-hint"
+              id="playerHint"
+              role="status"
+              aria-live="assertive"
+              tabindex="0"
+              data-hint="Priority hint feed; focus to repeat guidance."
+            ></div>
           </div>
         </section>
       </aside>
-      <section class="primary-panel">
-        <canvas id="gameCanvas" width="960" height="600" aria-label="Game world"></canvas>
+      <section class="primary-panel" data-hint="Central viewport where you explore each dimension.">
+        <canvas
+          id="gameCanvas"
+          width="960"
+          height="600"
+          aria-label="Game world"
+          data-hint="Navigate and interact with the voxel realm here."
+        ></canvas>
         <div class="hud-layer" id="gameHud">
           <div class="hud-layer__corner hud-layer__corner--top-left">
-            <div class="hud-card hud-card--status">
-              <div class="hud-status" aria-label="Player vitals" role="group">
-                <div class="status-item hearts" id="hearts"></div>
-                <div class="status-item bubbles" id="bubbles"></div>
-                <div class="status-item time" id="timeOfDay"></div>
+            <div class="hud-card hud-card--status" data-hint="Monitor vitals and access crafting tools.">
+              <div class="hud-status" aria-label="Player vitals" role="group" data-hint="Health, oxygen, and time remainers.">
+                <div class="status-item hearts" id="hearts" data-hint="Current health hearts."></div>
+                <div class="status-item bubbles" id="bubbles" data-hint="Breath remaining while underwater."></div>
+                <div class="status-item time" id="timeOfDay" data-hint="Local dimension time."></div>
               </div>
               <button
                 type="button"
@@ -55,6 +124,7 @@
                 aria-label="Open crafting interface"
                 aria-haspopup="dialog"
                 aria-controls="craftingModal"
+                data-hint="Launch the portable crafting interface."
               >
                 <span aria-hidden="true" class="craft-launcher__icon"></span>
                 <span class="sr-only">Open crafting interface</span>
@@ -62,7 +132,13 @@
             </div>
           </div>
           <div class="hud-layer__corner hud-layer__corner--top-right">
-            <div class="score-overlay" id="scorePanel" role="status" aria-live="polite">
+            <div
+              class="score-overlay"
+              id="scorePanel"
+              role="status"
+              aria-live="polite"
+              data-hint="Real-time summary of your score and bonuses."
+            >
               <span class="score-overlay__label">Score</span>
               <span class="score-overlay__value" id="scoreTotal">0</span>
               <ul class="score-overlay__breakdown">
@@ -76,7 +152,7 @@
                 </li>
               </ul>
             </div>
-            <div class="hud-card hud-card--actions">
+            <div class="hud-card hud-card--actions" data-hint="Quick actions for leaderboards, guides, and settings.">
               <div class="hud-actions" role="group" aria-label="HUD controls">
                 <button
                   type="button"
@@ -85,6 +161,7 @@
                   aria-haspopup="dialog"
                   aria-controls="leaderboardModal"
                   aria-expanded="false"
+                  data-hint="View the multiverse leaderboard."
                 >
                   <span class="leaderboard-toggle__icon" aria-hidden="true">
                     <span></span>
@@ -93,7 +170,7 @@
                   </span>
                   <span class="leaderboard-toggle__label">Leaderboard</span>
                 </button>
-                <button type="button" id="openGuide" class="ghost">Game Guide</button>
+                <button type="button" id="openGuide" class="ghost" data-hint="Open the survival guide.">Game Guide</button>
                 <button
                   type="button"
                   id="openSettings"
@@ -101,6 +178,7 @@
                   aria-haspopup="dialog"
                   aria-controls="settingsModal"
                   aria-expanded="false"
+                  data-hint="Configure audio, visuals, and difficulty."
                 >
                   <span class="settings-toggle__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
@@ -118,13 +196,14 @@
                   class="ghost mobile-sidebar-toggle"
                   aria-expanded="false"
                   aria-controls="sidePanel"
+                  data-hint="Toggle the companion panels on smaller screens."
                 >
                   Player Panels
                 </button>
               </div>
-              <div class="user-identity" aria-live="polite">
-                <span class="user-name" id="headerUserName">Guest Explorer</span>
-                <span class="user-location" id="headerUserLocation">Location unavailable</span>
+              <div class="user-identity" aria-live="polite" data-hint="Profile data captured for this run.">
+                <span class="user-name" id="headerUserName" data-hint="Current explorer alias.">Guest Explorer</span>
+                <span class="user-location" id="headerUserLocation" data-hint="Last known co-ordinates.">Location unavailable</span>
               </div>
             </div>
           </div>
@@ -136,27 +215,48 @@
               aria-valuemin="0"
               aria-valuemax="100"
               aria-valuenow="0"
+              data-hint="Stabilise portals by filling this progress bar."
             >
               <span class="label"></span>
               <span class="bar"></span>
             </div>
           </div>
         </div>
-        <div class="crosshair" id="crosshair" aria-hidden="true">
+        <div class="crosshair" id="crosshair" aria-hidden="true" data-hint="Aiming reticle for interactions.">
           <span class="crosshair__horizontal"></span>
           <span class="crosshair__vertical"></span>
         </div>
-        <div class="hand-overlay" id="handOverlay" aria-hidden="true" data-item="fist">
-          <div class="hand-overlay__icon" id="handOverlayIcon" aria-hidden="true" data-item="fist"></div>
-          <span class="hand-overlay__label" id="handOverlayLabel">Fist</span>
+        <div class="hand-overlay" id="handOverlay" aria-hidden="true" data-item="fist" data-hint="Currently equipped item.">
+          <div
+            class="hand-overlay__icon"
+            id="handOverlayIcon"
+            aria-hidden="true"
+            data-item="fist"
+            data-hint="Visual icon for your held tool."
+          ></div>
+          <span class="hand-overlay__label" id="handOverlayLabel" data-hint="Name of the held item.">Fist</span>
         </div>
-        <div class="subtitle-overlay" id="subtitleOverlay" role="status" aria-live="assertive" hidden></div>
-        <div class="victory-banner" id="victoryBanner" role="status" aria-live="assertive"></div>
+        <div
+          class="subtitle-overlay"
+          id="subtitleOverlay"
+          role="status"
+          aria-live="assertive"
+          hidden
+          data-hint="Dialogue and lore subtitles appear here."
+        ></div>
+        <div
+          class="victory-banner"
+          id="victoryBanner"
+          role="status"
+          aria-live="assertive"
+          data-hint="Triumphant banner announcing your success."
+        ></div>
         <div
           class="victory-celebration"
           id="victoryCelebration"
           hidden
           aria-hidden="true"
+          data-hint="Animated celebration with stats and share tools."
         >
           <div class="victory-celebration__backdrop" aria-hidden="true"></div>
           <div class="victory-celebration__effects" aria-hidden="true">

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,16 @@
   --accent: #49f2ff;
   --accent-strong: #f7b733;
   --accent-soft: rgba(73, 242, 255, 0.3);
+  --primary: #00ff88;
+  --bg-dark: #000011;
+  --glow: 0 0 10px var(--primary);
+  --dimension-primary: var(--accent);
+  --dimension-glow: rgba(73, 242, 255, 0.45);
+  --logo-size-min: 36px;
+  --logo-size-max: 72px;
+  --logo-opacity: 0.85;
+  --tooltip-bg: rgba(5, 10, 24, 0.92);
+  --tooltip-text: #f8fbff;
   --text-primary: #f2f5fa;
   --text-secondary: rgba(242, 245, 250, 0.72);
   --danger: #ff4976;
@@ -17,7 +27,6 @@
     radial-gradient(circle at 80% 10%, rgba(247, 183, 51, 0.2), transparent 55%),
     linear-gradient(160deg, #050912, #0b1230 60%, #05131f 100%);
   --time-phase: 0;
-  --dimension-glow: rgba(73, 242, 255, 0.45);
   --hud-panel-border: rgba(73, 242, 255, 0.28);
   --hud-panel-shadow: 0 18px 36px rgba(0, 0, 0, 0.5);
   --hud-panel-bg: rgba(6, 14, 28, 0.82);
@@ -56,9 +65,62 @@
   border: 0;
 }
 
+[data-hint] {
+  position: relative;
+}
+
+[data-hint]::after {
+  content: attr(data-hint);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 12px);
+  transform: translateX(-50%);
+  padding: 0.35rem 0.55rem;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-text);
+  border-radius: 6px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 150;
+}
+
+[data-hint]:hover::after,
+[data-hint]:focus-visible::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(-4px);
+}
+
+[data-hint]::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 6px);
+  transform: translateX(-50%);
+  width: 10px;
+  height: 10px;
+  background: var(--tooltip-bg);
+  opacity: 0;
+  clip-path: polygon(50% 100%, 0 0, 100% 0);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 149;
+}
+
+[data-hint]:hover::before,
+[data-hint]:focus-visible::before {
+  opacity: 1;
+  transform: translateX(-50%) translateY(-2px);
+}
+
 body {
   font-family: 'Exo 2', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background: var(--page-background);
+  background-color: var(--bg-dark);
   color: var(--text-primary);
   min-height: 100vh;
   display: grid;
@@ -68,6 +130,10 @@ body {
 }
 
 body.theme-grassland {
+  --primary: #228b22;
+  --glow: 0 0 10px rgba(34, 139, 34, 0.65);
+  --dimension-primary: #228b22;
+  --dimension-glow: rgba(34, 139, 34, 0.55);
   --hud-panel-border: rgba(74, 222, 128, 0.45);
   --hud-panel-shadow: 0 22px 46px rgba(74, 222, 128, 0.18);
   --hud-panel-bg: rgba(8, 28, 16, 0.85);
@@ -79,6 +145,10 @@ body.theme-grassland {
 }
 
 body.theme-netherite {
+  --primary: #ff4500;
+  --glow: 0 0 10px rgba(255, 69, 0, 0.65);
+  --dimension-primary: #ff4500;
+  --dimension-glow: rgba(255, 69, 0, 0.55);
   --hud-panel-border: rgba(255, 118, 70, 0.48);
   --hud-panel-shadow: 0 24px 54px rgba(255, 118, 70, 0.22);
   --hud-panel-bg: rgba(28, 10, 10, 0.9);
@@ -97,34 +167,66 @@ body.game-active {
   min-height: 100vh;
 }
 
-.manu-logo {
+.manu-logo,
+#logo {
   position: fixed;
-  inset: auto 10px 10px auto;
-  display: inline-flex;
+  inset: auto clamp(12px, 3vw, 28px) clamp(12px, 3vw, 28px) auto;
+  display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.6rem 0.75rem;
-  border-radius: 18px;
-  background: linear-gradient(145deg, rgba(6, 14, 28, 0.88), rgba(6, 14, 28, 0.6));
-  border: 1px solid rgba(73, 242, 255, 0.35);
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.4), 0 0 18px rgba(73, 242, 255, 0.35);
-  backdrop-filter: blur(10px);
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  color: var(--dimension-primary);
+  font-family: 'Chakra Petch', 'Exo 2', sans-serif;
+  font-size: clamp(0.65rem, 1.2vw, 0.85rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-shadow: 0 0 10px rgba(0, 0, 0, 0.65), 0 0 18px var(--dimension-glow);
   z-index: 120;
-  opacity: 0.8;
+  opacity: var(--logo-opacity);
   transition: transform 0.35s ease, opacity 0.3s ease;
+  cursor: default;
 }
 
 .manu-logo:hover,
-.manu-logo:focus-visible {
-  transform: scale(1.1);
+.manu-logo:focus-visible,
+#logo:hover,
+#logo:focus-visible {
+  transform: scale(1.05);
   opacity: 1;
   outline: none;
 }
 
-.manu-logo__image {
+.manu-logo__glyph {
   display: block;
-  width: clamp(160px, 22vw, var(--manu-logo-max-size));
+  width: clamp(var(--logo-size-min), 9vw, var(--logo-size-max));
   height: auto;
+  filter: drop-shadow(0 0 10px rgba(7, 135, 240, 0.4));
+  transition: transform 0.35s ease, filter 0.35s ease;
+}
+
+.manu-logo:hover .manu-logo__glyph,
+.manu-logo:focus-visible .manu-logo__glyph,
+#logo:hover .manu-logo__glyph,
+#logo:focus-visible .manu-logo__glyph {
+  filter: drop-shadow(0 0 20px var(--dimension-glow));
+}
+
+.manu-logo__label {
+  color: var(--text-secondary);
+  letter-spacing: 0.32em;
+  text-shadow: 0 0 12px rgba(0, 0, 0, 0.55);
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .manu-logo {
+    gap: 0.35rem;
+  }
+
+  .manu-logo__glyph {
+    width: clamp(32px, 10vw, 56px);
+  }
 }
 
 body:not(.game-active) .main-layout,
@@ -4929,13 +5031,17 @@ body.colorblind-assist .subtitle-overlay {
   }
 
   .manu-logo {
-    inset: auto 10px 10px auto;
-    border-radius: 16px;
-    padding: 0.5rem 0.6rem;
+    inset: auto clamp(10px, 4vw, 18px) clamp(10px, 4vw, 18px) auto;
+    gap: 0.4rem;
+    padding: 0.25rem 0.4rem;
   }
 
-  .manu-logo__image {
-    width: clamp(140px, 40vw, 190px);
+  .manu-logo__glyph {
+    width: clamp(36px, 12vw, 54px);
+  }
+
+  .manu-logo__label {
+    display: none;
   }
 
   .main-layout {
@@ -5079,14 +5185,13 @@ body.colorblind-assist .subtitle-overlay {
   }
 
   .manu-logo {
-    inset: auto 10px calc(10px + env(safe-area-inset-bottom, 0px)) auto;
-    padding: 0.45rem 0.5rem;
-    border-radius: 14px;
+    inset: auto clamp(12px, 5vw, 20px) calc(12px + env(safe-area-inset-bottom, 0px)) auto;
+    padding: 0.2rem 0.35rem;
+    border-radius: 12px;
   }
 
-  .manu-logo__image {
-    width: calc(var(--manu-logo-max-size) * 0.8);
-    max-width: 100%;
+  .manu-logo__glyph {
+    width: clamp(32px, 14vw, 48px);
   }
 
   .main-layout {


### PR DESCRIPTION
## Summary
- embed an inline voxel Manu monogram with responsive gradient glow and accessible labelling
- expand styling tokens, theme hooks, and tooltip helpers to deliver contextual hints across HUD panels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f2edf1ec832ba983ab7ace236860