### PR TITLE
Handle portal shader failures gracefully

### DIFF
--- a/script.js
+++ b/script.js
@@ -5267,6 +5267,10 @@
           disabled = true;
         }
       }
+      if (!disabled) {
+        resetWorldMeshes();
+        disabled = true;
+      }
       if (disabled) {
         console.warn(
           'Portal shaders disabled after renderer failure; continuing with emissive fallback materials.',


### PR DESCRIPTION
## Summary
- reset and rebuild world meshes if portal shaders fail before any surfaces can be swapped
- ensure we still disable the custom shader and continue with emissive fallback materials

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2dcd39300832b8ded5957b180a1a6