### PR TITLE
Improve portal shader fallback handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -5265,13 +5265,12 @@
     }
 
     function disablePortalSurfaceShaders(error) {
-      if (!portalShaderSupport) {
-        return false;
-      }
+      const supportWasEnabled = portalShaderSupport;
       portalShaderSupport = false;
       let disabled = false;
-      for (let y = 0; y < tileRenderState.length; y += 1) {
-        const row = tileRenderState[y];
+      const layers = Array.isArray(tileRenderState) ? tileRenderState : [];
+      for (let y = 0; y < layers.length; y += 1) {
+        const row = layers[y];
         if (!row) continue;
         for (let x = 0; x < row.length; x += 1) {
           const renderInfo = row[x];
@@ -5293,7 +5292,7 @@
           disabled = true;
         }
       }
-      if (!disabled) {
+      if (!disabled && supportWasEnabled) {
         resetWorldMeshes();
         disabled = true;
       }


### PR DESCRIPTION
## Summary
- allow the portal shader fallback routine to run even after shader support has been disabled
- guard the render state iteration to avoid undefined access while replacing materials
- trigger a mesh reset only when the shader support flag was previously enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d33d4b2f2c832b86588dc5661660f5