### PR TITLE
Fix portal uniform sanitization

### DIFF
--- a/script.js
+++ b/script.js
@@ -5262,8 +5262,17 @@
           const accentColor = portalSurface.accentColor ?? '#7b6bff';
           let uniformsUpdated = false;
           Object.entries(uniforms).forEach(([key, uniform]) => {
-            if (!uniform || typeof uniform !== 'object' || !('value' in uniform)) {
-              delete uniforms[key];
+            if (!uniform || typeof uniform !== 'object') {
+              uniforms[key] = { value: null };
+              uniformsUpdated = true;
+              return;
+            }
+            if (!('value' in uniform)) {
+              try {
+                uniform.value = uniform.value ?? null;
+              } catch (error) {
+                uniforms[key] = { value: null };
+              }
               uniformsUpdated = true;
             }
           });


### PR DESCRIPTION
## Summary
- ensure portal shader uniform sanitization preserves entries and assigns safe defaults so three.js uniforms always expose a value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d359424c00832bab6ac08bcc38a790