### PR TITLE
Fix portal shader uniform recovery by reflagging materials

### DIFF
--- a/script.js
+++ b/script.js
@@ -5305,7 +5305,13 @@
 
           if (uniformsUpdated && Array.isArray(portalSurface.materials)) {
             portalSurface.materials.forEach((material) => {
-              if (material && 'uniformsNeedUpdate' in material) {
+              if (!material || typeof material !== 'object') {
+                return;
+              }
+              if ('needsUpdate' in material) {
+                material.needsUpdate = true;
+              }
+              if ('uniformsNeedUpdate' in material) {
                 material.uniformsNeedUpdate = true;
               }
             });


### PR DESCRIPTION
## Summary
- ensure repaired portal surface uniform sets flag their materials for recompilation
- keep shader materials in sync by requesting both structural and value updates when patching uniforms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3804f5e9c832bb9dabf509284596e