### PR TITLE
Fix portal shader uniform sanitization

### DIFF
--- a/script.js
+++ b/script.js
@@ -5280,12 +5280,25 @@
               uniformsUpdated = true;
               return;
             }
-            if (!('value' in uniform)) {
-              try {
-                uniform.value = uniform.value ?? null;
-              } catch (error) {
-                uniforms[key] = { value: null };
+            if (!Object.prototype.hasOwnProperty.call(uniform, 'value')) {
+              let preserved = null;
+              if (typeof uniform.clone === 'function') {
+                try {
+                  preserved = uniform.clone();
+                } catch (cloneError) {
+                  preserved = null;
+                }
+              } else if (typeof uniform.value !== 'undefined') {
+                preserved = uniform.value;
+              } else {
+                preserved = uniform;
               }
+              uniforms[key] = { value: preserved ?? null };
+              uniformsUpdated = true;
+              return;
+            }
+            if (typeof uniform.value === 'undefined') {
+              uniforms[key] = { value: null };
               uniformsUpdated = true;
             }
           });


### PR DESCRIPTION
## Summary
- guard portal shader uniform repair to wrap raw uniform values in standard uniform objects
- preserve existing uniform data when rebuilding so WebGLRenderer always receives `.value`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d392bd3144832b88ee8f678fb90cf7