### PR TITLE
Handle renderer-managed uniform wrappers

### DIFF
--- a/script.js
+++ b/script.js
@@ -5560,6 +5560,26 @@
         return null;
       };
 
+      const hasUsableUniformValue = (uniform) => {
+        if (!uniform || typeof uniform !== 'object') {
+          return false;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(uniform, 'value')) {
+          return true;
+        }
+
+        if (typeof uniform.setValue === 'function') {
+          return true;
+        }
+
+        if (uniform.map && typeof uniform.map === 'object' && Array.isArray(uniform.seq)) {
+          return true;
+        }
+
+        return false;
+      };
+
       let recovered = false;
 
       const updateSharedMaterialReference = (oldMaterial, newMaterial) => {
@@ -5673,7 +5693,7 @@
             return;
           }
           const uniform = resolveUniformReference(uniformContainers, uniformKey);
-          if (!uniform || typeof uniform !== 'object' || !('value' in uniform)) {
+          if (!hasUsableUniformValue(uniform)) {
             missingUniforms.push(uniformKey);
           }
         });


### PR DESCRIPTION
## Summary
- treat renderer-managed uniforms that expose setter methods as valid containers
- avoid repeatedly rebuilding materials when WebGLUniform wrappers lack a `value` property

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3b21c66cc832b98c4e9e8af2f2fe5