### PR TITLE
Fix uniform inspection for renderer-managed containers

### DIFF
--- a/script.js
+++ b/script.js
@@ -5643,14 +5643,42 @@
           if (!container || typeof container !== 'object') {
             return;
           }
-          Object.keys(container).forEach((key) => {
-            if (typeof key === 'string' && key && key !== 'map' && key !== 'seq') {
+
+          const isRendererUniformContainer =
+            Array.isArray(container.seq) && typeof container.map === 'object';
+
+          if (!isRendererUniformContainer) {
+            Object.keys(container).forEach((key) => {
+              if (
+                typeof key !== 'string' ||
+                !key ||
+                key === 'map' ||
+                key === 'seq' ||
+                key === 'value'
+              ) {
+                return;
+              }
+              const entry = container[key];
+              if (
+                !entry ||
+                typeof entry !== 'object' ||
+                (!Object.prototype.hasOwnProperty.call(entry, 'value') &&
+                  typeof entry.setValue !== 'function' &&
+                  !(
+                    entry.map &&
+                    typeof entry.map === 'object' &&
+                    Array.isArray(entry.seq)
+                  ))
+              ) {
+                return;
+              }
               keySet.add(key);
-            }
-          });
+            });
+          }
+
           if (container.map && typeof container.map === 'object') {
             Object.keys(container.map).forEach((key) => {
-              if (typeof key === 'string' && key) {
+              if (typeof key === 'string' && key && key !== 'value') {
                 keySet.add(key);
               }
             });


### PR DESCRIPTION
## Summary
- avoid treating renderer-managed uniform containers as missing shader uniforms
- filter out non-uniform keys so rebuild logic no longer flags materials such as the voxel island mesh

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3b5000834832bae65cc4385cbe64d