### PR TITLE
Fix portal uniform recovery when uniforms lose value references

### DIFF
--- a/script.js
+++ b/script.js
@@ -5658,21 +5658,23 @@
               ) {
                 return;
               }
+
+              // Register the uniform key even when the stored entry is malformed so that
+              // recovery logic can detect the missing value instead of skipping it outright.
+              keySet.add(key);
+
               const entry = container[key];
               if (
-                !entry ||
-                typeof entry !== 'object' ||
-                (!Object.prototype.hasOwnProperty.call(entry, 'value') &&
-                  typeof entry.setValue !== 'function' &&
-                  !(
-                    entry.map &&
+                entry &&
+                typeof entry === 'object' &&
+                (Object.prototype.hasOwnProperty.call(entry, 'value') ||
+                  typeof entry.setValue === 'function' ||
+                  (entry.map &&
                     typeof entry.map === 'object' &&
-                    Array.isArray(entry.seq)
-                  ))
+                    Array.isArray(entry.seq)))
               ) {
                 return;
               }
-              keySet.add(key);
             });
           }
 


### PR DESCRIPTION
## Summary
- ensure portal shader uniform inspection keeps keys even when the stored entry becomes malformed
- allow the rebuild routine to detect and restore missing uniform values instead of skipping them

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3b96251c0832ba4552473b568b24d