### PR TITLE
Fix uniform resolution for nested keys

### DIFF
--- a/script.js
+++ b/script.js
@@ -5585,6 +5585,9 @@
           for (let i = segments.length; i >= 1; i -= 1) {
             pushCandidate(segments.slice(0, i).join('.'));
           }
+          for (let i = 0; i < segments.length; i += 1) {
+            pushCandidate(segments.slice(i).join('.'));
+          }
         } else {
           pushCandidate(`${uniformKey}`);
         }


### PR DESCRIPTION
## Summary
- expand uniform key normalization so nested program keys like `material.opacity` resolve to the renderer-managed entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3c913b5d4832ba6d000b4956d7fa8