### PR TITLE
Fix uniform recovery when renderer caches are empty

### DIFF
--- a/script.js
+++ b/script.js
@@ -5701,9 +5701,6 @@
               material?.type === 'ShaderMaterial' ||
               hasValidPortalUniformStructure(material?.uniforms))
         );
-        if (!uniformContainers.length) {
-          return;
-        }
         const programInfo = props.program?.getUniforms?.() ?? null;
         const keySet = new Set();
         uniformContainers.forEach((container) => {


### PR DESCRIPTION
## Summary
- allow the renderer uniform recovery to continue even when cached uniform containers are missing
- ensure portal surface materials can be rebuilt from program info instead of falling through to fatal errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3ca547c60832ba25ae42f616a96cb