### PR TITLE
Fallback to emissive portal materials when shader rebuild fails

### DIFF
--- a/script.js
+++ b/script.js
@@ -5846,25 +5846,36 @@
           return;
         }
         let replacement = null;
-        if (expectPortalUniforms) {
-          try {
-            const rebuilt = createPortalSurfaceMaterial(
-              portalMetadata.accentColor,
-              portalMetadata.isActive
-            );
-            replacement = rebuilt.material;
-            tagPortalSurfaceMaterial(replacement, portalMetadata.accentColor, portalMetadata.isActive);
-          } catch (factoryError) {
-            console.warn('Failed to regenerate portal surface shader; falling back to cloning.', {
-              error: factoryError,
-              accentColor: portalMetadata.accentColor,
-              isActive: portalMetadata.isActive,
-            });
+          if (expectPortalUniforms) {
+            try {
+              const rebuilt = createPortalSurfaceMaterial(
+                portalMetadata.accentColor,
+                portalMetadata.isActive
+              );
+              replacement = rebuilt.material;
+              tagPortalSurfaceMaterial(replacement, portalMetadata.accentColor, portalMetadata.isActive);
+            } catch (factoryError) {
+              console.warn(
+                'Failed to regenerate portal surface shader; switching to emissive fallback material.',
+                {
+                  error: factoryError,
+                  accentColor: portalMetadata.accentColor,
+                  isActive: portalMetadata.isActive,
+                }
+              );
+              portalShaderSupport = false;
+              replacement = createPortalFallbackMaterial(
+                portalMetadata.accentColor,
+                portalMetadata.isActive
+              );
+              if (replacement) {
+                replacement.renderOrder = material.renderOrder ?? replacement.renderOrder ?? 2;
+              }
+            }
           }
-        }
-        if (!replacement) {
-          replacement = material.clone();
-        }
+          if (!replacement) {
+            replacement = material.clone();
+          }
 
         if (portalMetadata) {
           if (expectPortalUniforms && hasValidPortalUniformStructure(replacement.uniforms)) {


### PR DESCRIPTION
## Summary
- fall back to emissive portal materials when the shader cannot be regenerated during uniform recovery
- disable portal shader support after a rebuild failure and carry over render ordering to the fallback material

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d40679e64c832bb71c92648d08fd74