### PR TITLE
Ensure portal shaders fallback for all scene objects

### DIFF
--- a/script.js
+++ b/script.js
@@ -6017,6 +6017,38 @@
         }
       }
 
+      if (scene && typeof scene.traverse === 'function') {
+        scene.traverse((object) => {
+          if (!object) return;
+          const { material } = object;
+          if (!material) {
+            return;
+          }
+
+          const applyFallback = (mat) => {
+            if (!mat?.userData?.portalSurface) {
+              return false;
+            }
+            const metadata = mat.userData.portalSurface;
+            const accentColor = metadata?.accentColor ?? '#7b6bff';
+            const isActive = metadata?.isActive ?? false;
+            if (replaceChildMaterial(object, mat, accentColor, isActive)) {
+              disabled = true;
+              return true;
+            }
+            return false;
+          };
+
+          if (Array.isArray(material)) {
+            material.forEach((mat) => {
+              applyFallback(mat);
+            });
+          } else {
+            applyFallback(material);
+          }
+        });
+      }
+
       if (supportWasEnabled && (needsReset || !disabled)) {
         resetWorldMeshes();
         disabled = true;


### PR DESCRIPTION
## Summary
- traverse the full scene when disabling portal shaders so any remaining portal materials fall back to emissive meshes
- mark fallback operations as disabling the shader path to avoid repeated renderer failures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d40a34ce18832b9f556e4dd0fcdb0f