### PR TITLE
Handle renderer recovery after portal shader failure

### DIFF
--- a/script.js
+++ b/script.js
@@ -398,7 +398,8 @@
       throw new Error('Three.js failed to load. Ensure the CDN script is available.');
     }
 
-    let portalShaderSupport = typeof THREE?.ShaderMaterial === 'function';
+  let portalShaderSupport = typeof THREE?.ShaderMaterial === 'function';
+  let rendererRecoveryFrames = 0;
 
     const scoreboardUtils =
       (typeof window !== 'undefined' && window.ScoreboardUtils) ||
@@ -7589,6 +7590,10 @@
       updateWorldMeshes();
       updateEntities();
       if (renderer && scene && camera) {
+        if (rendererRecoveryFrames > 0) {
+          rendererRecoveryFrames -= 1;
+          return;
+        }
         try {
           renderer.render(scene, camera);
         } catch (error) {
@@ -7597,7 +7602,10 @@
           }
           if (!disablePortalSurfaceShaders(error)) {
             console.error('Renderer encountered an unrecoverable error.', error);
+            return;
           }
+          rendererRecoveryFrames = Math.max(rendererRecoveryFrames, 2);
+          return;
         }
       }
     }


### PR DESCRIPTION
## Summary
- track renderer recovery frames so we briefly pause rendering after a portal shader failure
- skip rendering while recovering and ensure we bail out once portal shaders are disabled to prevent repeated failures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d41d00f9fc832b9056f867d957cc22