### PR TITLE
Ensure portal shaders always swap to fallback materials

### DIFF
--- a/script.js
+++ b/script.js
@@ -6078,11 +6078,12 @@
         }
 
         const inferredState = inferPortalMaterialState(material, defaultAccent, defaultState);
-        if (!inferredState) {
+        if (!inferredState && !material?.userData?.portalSurface) {
           return false;
         }
 
-        const { accentColor, isActive } = inferredState;
+        const accentColor = inferredState?.accentColor ?? defaultAccent ?? '#7b6bff';
+        const isActive = inferredState?.isActive ?? Boolean(defaultState);
         const fallback = createPortalFallbackMaterial(accentColor, isActive);
         fallback.renderOrder = child.renderOrder ?? 2;
 


### PR DESCRIPTION
## Summary
- default portal shader fallback replacement to use inferred data when available and fall back to provided defaults when inference fails
- keep portal shader metadata replacements working even if uniforms are missing so renderer swaps to emissive materials

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d4329f497c832b96de664751af5267