### PR TITLE
Fix portal uniform recovery when metadata missing

### DIFF
--- a/script.js
+++ b/script.js
@@ -5812,10 +5812,21 @@
           });
         }
         const programUniformKeys = Array.from(keySet);
+        const missingUniforms = [];
+
         if (!programUniformKeys.length) {
-          return;
+          if (expectPortalUniforms && !hasValidPortalUniformStructure(material?.uniforms)) {
+            PORTAL_UNIFORM_KEYS.forEach((key) => {
+              if (typeof key === 'string' && key && !missingUniforms.includes(key)) {
+                missingUniforms.push(key);
+              }
+            });
+          } else {
+            return;
+          }
         }
-          const missingUniforms = [];
+
+        if (!missingUniforms.length) {
           programUniformKeys.forEach((key) => {
             const uniformKey = typeof key === 'string' ? key : `${key}`;
             if (isRendererManagedUniform(uniformKey)) {
@@ -5843,6 +5854,7 @@
               missingUniforms.push(uniformKey);
             }
           });
+        }
         if (!missingUniforms.length) {
           return;
         }


### PR DESCRIPTION
## Summary
- ensure portal uniform recovery reconstructs portal shader uniforms even when the renderer reports no program uniforms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d438abcc0c832bbe578d09fc09f785