### PR TITLE
Ensure portal shader recovery rebuilds world meshes

### DIFF
--- a/script.js
+++ b/script.js
@@ -6120,6 +6120,7 @@
           };
         }
         handledMaterials.add(material);
+        needsReset = true;
         return true;
       };
 
@@ -6211,7 +6212,7 @@
         });
       }
 
-      if (supportWasEnabled && (needsReset || !disabled)) {
+      if (needsReset || (supportWasEnabled && !disabled)) {
         resetWorldMeshes();
         disabled = true;
         needsReset = false;


### PR DESCRIPTION
## Summary
- force portal shader fallback handling to rebuild world meshes whenever shader materials are replaced
- always reset tile render state after disabling portal shaders to avoid lingering invalid uniforms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d43a9219c0832b9d9de39201a8b806