### PR TITLE
Ensure portal uniform containers exist before sanitization

### DIFF
--- a/script.js
+++ b/script.js
@@ -5867,9 +5867,14 @@
           if (!targetMaterial || typeof targetMaterial !== 'object') {
             return;
           }
-          const uniforms = targetMaterial.uniforms;
+          let uniforms = targetMaterial.uniforms;
           if (!uniforms || typeof uniforms !== 'object') {
-            return;
+            uniforms = {};
+            try {
+              targetMaterial.uniforms = uniforms;
+            } catch (assignError) {
+              return;
+            }
           }
 
           const resolveDefault = (value) => (typeof value === 'function' ? value() : value);


### PR DESCRIPTION
## Summary
- ensure portal material sanitization creates a uniform container when missing to prevent renderer crashes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d48f5f3cfc832b82bc83e5435cbf65