### PR TITLE
Document portal shader recovery steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ sam deploy --guided
 - **Mechanics summary API** – `portal-mechanics.js` exposes pure functions for tests and docs to report the frame footprint,
   activation behaviour, transition flow, and score rewards.
 
+### Recovering portal shaders after uniform failures
+
+The renderer will fall back to emissive planes when it detects that a portal surface material has lost a required uniform (for
+example `uColor`, `uTime`, `uOpacity`, or `uActivation`). The console surfaces this by printing a warning similar to
+`Portal shaders disabled after renderer failure; continuing with emissive fallback materials.` alongside the missing uniforms.
+
+1. Rebuild or repair the affected material so that every required uniform once again exposes a `value` (the recovery helpers can
+   populate defaults if the container exists).
+2. Reload the scene or refresh the page. Once valid uniforms are present, the warning disappears and the renderer keeps using
+   the true portal shader instead of the emissive fallback, so you retain the intended ripple animation.
+
 ## Local Development
 
 No build tooling is required. Open `index.html` in any modern browser or use a lightweight static server:


### PR DESCRIPTION
## Summary
- document how to recover the full portal shader when uniforms go missing
- explain the fallback warning and how to resolve it by restoring uniforms and reloading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d49bc80c10832bbda8e0ce44bfb82c