### PR TITLE
Fix portal uniform recovery when renderer reports managed uniforms

### DIFF
--- a/script.js
+++ b/script.js
@@ -5680,6 +5680,14 @@
         );
       };
 
+      const isRendererManagedUniformContainer = (container) =>
+        Boolean(
+          container &&
+            typeof container === 'object' &&
+            Array.isArray(container.seq) &&
+            typeof container.map === 'object'
+        );
+
         const enumerateUniformKeyCandidates = (uniformKey) => {
           const normalizedKeys = [];
           const pushCandidate = (key) => {
@@ -5822,8 +5830,7 @@
             return;
           }
 
-          const isRendererUniformContainer =
-            Array.isArray(container.seq) && typeof container.map === 'object';
+          const isRendererUniformContainer = isRendererManagedUniformContainer(container);
 
           if (!isRendererUniformContainer) {
             Object.keys(container).forEach((key) => {
@@ -5917,10 +5924,18 @@
             let invalidDefinitions = 0;
 
             uniformContainers.forEach((container) => {
+              const isRendererContainer = isRendererManagedUniformContainer(container);
               const { hasDefinition, uniform } = findUniformInContainer(container, uniformKey);
               if (!hasDefinition) {
                 return;
               }
+              if (isRendererContainer) {
+                if (!hasUsableUniformValue(uniform)) {
+                  invalidDefinitions += 1;
+                }
+                return;
+              }
+
               definitions += 1;
               if (hasUsableUniformValue(uniform)) {
                 validDefinitions += 1;


### PR DESCRIPTION
## Summary
- add a helper to identify renderer-managed uniform containers
- ignore renderer-managed containers when deciding if shader uniforms are missing
- ensure broken portal materials are resanitized so render recovery no longer throws

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d49c938780832ba501dbdaf8ce6153