### PR TITLE
Fix portal shader recovery overriding standard uniforms

### DIFF
--- a/script.js
+++ b/script.js
@@ -6259,16 +6259,23 @@
           replacement = material.clone();
         }
 
-          const uniformKeysToRepair = missingUniforms.filter(
-            (key) => key !== RENDERER_UNIFORM_CORRUPTION_SENTINEL
-          );
-          if (uniformKeysToRepair.length) {
-            ensurePortalUniformIntegrity(replacement, {
-              missingKeys: uniformKeysToRepair,
-              expectPortal: expectPortalUniforms,
-              metadata: portalMetadata,
-            });
-          }
+        const uniformKeysToRepair = missingUniforms.filter(
+          (key) => key !== RENDERER_UNIFORM_CORRUPTION_SENTINEL
+        );
+        const shouldRepairPortalUniforms =
+          uniformKeysToRepair.length > 0 &&
+          replacement &&
+          typeof replacement === 'object' &&
+          (replacement.isShaderMaterial === true ||
+            replacement.type === 'ShaderMaterial' ||
+            hasValidPortalUniformStructure(replacement.uniforms));
+        if (shouldRepairPortalUniforms) {
+          ensurePortalUniformIntegrity(replacement, {
+            missingKeys: uniformKeysToRepair,
+            expectPortal: expectPortalUniforms,
+            metadata: portalMetadata,
+          });
+        }
 
         if (portalMetadata) {
           if (expectPortalUniforms && hasValidPortalUniformStructure(replacement.uniforms)) {


### PR DESCRIPTION
## Summary
- avoid forcing portal uniform repairs onto non-shader fallback materials when recovering from renderer errors
- ensure only shader-based replacements receive portal uniform integrity fixes to prevent MeshStandardMaterial uniform corruption

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d4aaf91008832b815b75fb2569d6d0