### PR TITLE
Handle undefined uniform render errors

### DIFF
--- a/script.js
+++ b/script.js
@@ -8216,6 +8216,22 @@
             pendingUniformSanitizations = Math.max(pendingUniformSanitizations, 2);
             return;
           }
+          const uniformValueErrorMessage =
+            typeof error?.message === 'string'
+              ? error.message
+              : typeof error === 'string'
+              ? error
+              : '';
+          if (uniformValueErrorMessage.includes("Cannot read properties of undefined (reading 'value')")) {
+            const sanitizedNow = sanitizeSceneUniforms();
+            rendererRecoveryFrames = Math.max(rendererRecoveryFrames, sanitizedNow ? 1 : 2);
+            pendingUniformSanitizations = Math.max(pendingUniformSanitizations, sanitizedNow ? 1 : 2);
+            console.warn(
+              'Renderer detected undefined uniform values; scheduling additional uniform sanitization.',
+              error
+            );
+            return;
+          }
           if (!disablePortalSurfaceShaders(error)) {
             console.error('Renderer encountered an unrecoverable error.', error);
             pendingUniformSanitizations = Math.max(pendingUniformSanitizations, 2);


### PR DESCRIPTION
## Summary
- detect renderer failures caused by undefined uniform values and trigger additional sanitization instead of immediately disabling portal shaders
- schedule uniform cleanup and recovery frames when the specific TypeError is encountered

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5278aca6c832b8a65c5db141e92c3