### PR TITLE
Fix renderer uniform sanitization with renderer cache data

### DIFF
--- a/script.js
+++ b/script.js
@@ -6042,15 +6042,60 @@
             visitedMaterials.add(mat);
             let updated = false;
             let rendererReset = false;
-            if (mat.uniforms && typeof mat.uniforms === 'object') {
-              const result = sanitizeUniformContainer(mat.uniforms);
-              if (result.updated) {
-                updated = true;
+          if (mat.uniforms && typeof mat.uniforms === 'object') {
+            const result = sanitizeUniformContainer(mat.uniforms);
+            if (result.updated) {
+              updated = true;
+            }
+            if (result.requiresRendererReset) {
+              rendererReset = true;
+            }
+          }
+
+          if (mat && renderer?.properties?.get) {
+            let rendererUniforms = null;
+            try {
+              rendererUniforms = renderer.properties.get(mat)?.uniforms ?? null;
+            } catch (propertyError) {
+              rendererUniforms = null;
+            }
+
+            if (rendererUniforms && typeof rendererUniforms === 'object') {
+              if (!mat.uniforms || typeof mat.uniforms !== 'object') {
+                mat.uniforms = {};
               }
-              if (result.requiresRendererReset) {
-                rendererReset = true;
+
+              const ensureMaterialUniform = (uniformId) => {
+                if (!uniformId) {
+                  return;
+                }
+                const key = typeof uniformId === 'string' ? uniformId : `${uniformId}`;
+                if (!key) {
+                  return;
+                }
+                const entry = mat.uniforms[key];
+                if (!entry || typeof entry !== 'object' || !Object.prototype.hasOwnProperty.call(entry, 'value')) {
+                  mat.uniforms[key] = { value: entry && typeof entry === 'object' ? entry.value ?? null : null };
+                  updated = true;
+                }
+              };
+
+              if (Array.isArray(rendererUniforms.seq)) {
+                rendererUniforms.seq.forEach((uniform) => {
+                  if (!uniform || typeof uniform !== 'object') {
+                    return;
+                  }
+                  ensureMaterialUniform(uniform.id ?? uniform.name ?? null);
+                });
+              }
+
+              if (rendererUniforms.map && typeof rendererUniforms.map === 'object') {
+                Object.keys(rendererUniforms.map).forEach((key) => {
+                  ensureMaterialUniform(key);
+                });
               }
             }
+          }
             if (rendererReset && renderer?.properties?.remove) {
               try {
                 renderer.properties.remove(mat);


### PR DESCRIPTION
## Summary
- ensure uniform sanitization also considers renderer-managed uniform caches when rebuilding materials
- keep material uniform dictionaries populated for every uniform id tracked by the renderer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d5306cc690832bb576f7f5e477caf9