### PR TITLE
Fix uniform sanitization for renderer map and seq entries

### DIFF
--- a/script.js
+++ b/script.js
@@ -5981,16 +5981,21 @@
             processResult(sanitizeUniformEntry(uniforms, normalizedKey, uniforms[normalizedKey]));
           };
 
-          if (Array.isArray(uniforms)) {
-            for (let i = 0; i < uniforms.length; i += 1) {
-              if (!Object.prototype.hasOwnProperty.call(uniforms, i)) {
-                uniforms[i] = { value: null };
+          const sanitizeArrayEntries = (container) => {
+            if (!Array.isArray(container)) {
+              return;
+            }
+            for (let i = 0; i < container.length; i += 1) {
+              if (!Object.prototype.hasOwnProperty.call(container, i)) {
+                container[i] = { value: null };
                 updated = true;
                 continue;
               }
-              processResult(sanitizeUniformEntry(uniforms, i, uniforms[i]));
+              processResult(sanitizeUniformEntry(container, i, container[i]));
             }
-          }
+          };
+
+          sanitizeArrayEntries(uniforms);
 
           Object.keys(uniforms).forEach((key) => {
             if (key === 'map' || key === 'seq') {
@@ -6000,6 +6005,7 @@
           });
 
           if (Array.isArray(uniforms.seq)) {
+            sanitizeArrayEntries(uniforms.seq);
             for (let i = 0; i < uniforms.seq.length; i += 1) {
               const entry = uniforms.seq[i];
               if (!entry || typeof entry !== 'object') {
@@ -6011,16 +6017,13 @@
                 typeof entry.setValue !== 'function'
               ) {
                 requiresRendererReset = true;
-                continue;
-              }
-              if (typeof entry.value === 'undefined' && typeof entry.setValue !== 'function') {
-                requiresRendererReset = true;
               }
             }
           }
 
           if (uniforms.map && typeof uniforms.map === 'object') {
             Object.keys(uniforms.map).forEach((key) => {
+              processResult(sanitizeUniformEntry(uniforms.map, key, uniforms.map[key]));
               processKey(key);
             });
           }


### PR DESCRIPTION
## Summary
- extend uniform sanitization to traverse nested uniform containers used by renderer-managed maps and sequences
- ensure shader uniform arrays receive default values during sanitization to avoid undefined value access
- sanitize renderer-managed uniform maps before scheduling additional renderer resets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d533af214c832bacf4e404a40ef35f