### PR TITLE
Ensure uniform sanitization retains set values

### DIFF
--- a/script.js
+++ b/script.js
@@ -5918,7 +5918,9 @@
             if (typeof entry.setValue === 'function') {
               try {
                 entry.setValue(entry.value ?? null);
-                return result;
+                if (Object.prototype.hasOwnProperty.call(entry, 'value')) {
+                  return result;
+                }
               } catch (setError) {
                 result.requiresRendererReset = true;
               }


### PR DESCRIPTION
## Summary
- make the uniform sanitization routine verify that calling setValue actually defines a value
- fall back to rebuilding the uniform entry when setValue does not produce a value property

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d53ff93e58832b9475ebb094c79237