### PR TITLE
Sanitize uniforms before initial render

### DIFF
--- a/script.js
+++ b/script.js
@@ -3671,6 +3671,11 @@
       createPlayerLocator();
       syncCameraToPlayer({ idleBob: 0, walkBob: 0, movementStrength: 0 });
       updateLighting(0);
+      const uniformsReady = sanitizeSceneUniforms();
+      if (!uniformsReady) {
+        pendingUniformSanitizations = Math.max(pendingUniformSanitizations, 2);
+      }
+      rendererRecoveryFrames = Math.max(rendererRecoveryFrames, 1);
       console.log('Scene loaded');
       return true;
     }


### PR DESCRIPTION
## Summary
- trigger uniform sanitization as part of renderer setup so shader uniforms are valid before the first frame
- schedule follow-up sanitization passes and give the renderer a recovery frame when uniforms need rebuilding

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d54839e13c832bbccd231ba762a519