### PR TITLE
Prevent rendering during uniform sanitization

### DIFF
--- a/script.js
+++ b/script.js
@@ -8423,6 +8423,7 @@
           pendingUniformSanitizations -= 1;
           if (sanitized) {
             rendererRecoveryFrames = Math.max(rendererRecoveryFrames, 1);
+            return;
           }
         }
         try {


### PR DESCRIPTION
## Summary
- skip the current render frame whenever scene uniforms are sanitized so the renderer can rebuild clean state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5695d4254832b93a386960124b26c