### PR TITLE
Reset renderer caches when sanitizing portal uniforms

### DIFF
--- a/script.js
+++ b/script.js
@@ -6209,6 +6209,7 @@
                 const result = sanitizeUniformContainer(mat.uniforms);
                 if (result.updated) {
                   updated = true;
+                  rendererReset = true;
                 }
                 if (result.requiresRendererReset) {
                   rendererReset = true;
@@ -6229,6 +6230,7 @@
                   );
                   if (rendererUniformSanitization.updated) {
                     sanitized = true;
+                    rendererReset = true;
                   }
                   if (rendererUniformSanitization.requiresRendererReset) {
                     rendererReset = true;


### PR DESCRIPTION
## Summary
- ensure we drop renderer uniform caches whenever sanitizing material or renderer uniform containers
- prevent undefined uniform entries from persisting after sanitization to stop recurring shader warnings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5f36961c8832ba700fb9ad55a07af