### PR TITLE
Fix portal shader uniform access failures

### DIFF
--- a/script.js
+++ b/script.js
@@ -5196,6 +5196,24 @@
       }
 
       const proxy = new Proxy(container, {
+        get(target, key, receiver) {
+          if (typeof key === 'symbol') {
+            return Reflect.get(target, key, receiver);
+          }
+
+          const normalizedKey = `${key}`;
+          if (!normalizedKey || RESERVED_UNIFORM_CONTAINER_KEYS.has(normalizedKey)) {
+            return Reflect.get(target, key, receiver);
+          }
+
+          if (Object.prototype.hasOwnProperty.call(target, normalizedKey)) {
+            return target[normalizedKey];
+          }
+
+          const placeholder = { value: null };
+          target[normalizedKey] = placeholder;
+          return placeholder;
+        },
         set(target, key, value) {
           if (typeof key === 'symbol') {
             target[key] = value;


### PR DESCRIPTION
## Summary
- ensure guarded uniform containers return a placeholder when the renderer requests a missing uniform key
- avoid undefined uniform.value lookups that caused repeated sanitization warnings during rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6114e2e9c832bbedcda4b1731e1d0