### PR TITLE
Avoid sanitizing fallback portal materials

### DIFF
--- a/script.js
+++ b/script.js
@@ -6420,7 +6420,11 @@
               );
             }
 
-            if (isShaderMaterial || expectPortalUniforms) {
+            const shouldSanitizeMaterialUniforms = Boolean(
+              isShaderMaterial || hasPortalUniforms || usesPortalShader
+            );
+
+            if (shouldSanitizeMaterialUniforms) {
               if (mat.uniforms && typeof mat.uniforms === 'object') {
                 const guardedUniforms = guardUniformContainer(mat.uniforms);
                 if (guardedUniforms && guardedUniforms !== mat.uniforms) {


### PR DESCRIPTION
## Summary
- avoid running the uniform sanitiser on non-shader portal fallback materials so that renderer-managed uniforms are left intact
- keep the existing portal uniform maintenance logic for shader-based materials

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d612954e2c832b822c8547cfa9adba