### PR TITLE
Fix uniform failure streak logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -8895,12 +8895,6 @@
           if (uniformValueErrorMessage.includes("Cannot read properties of undefined (reading 'value')")) {
             const sanitizedNow = sanitizeSceneUniforms();
             uniformSanitizationFailureStreak += 1;
-            if (sanitizedNow) {
-              uniformSanitizationFailureStreak = Math.max(
-                1,
-                uniformSanitizationFailureStreak - 1
-              );
-            }
             if (uniformSanitizationFailureStreak >= 3) {
               const disabled = disablePortalSurfaceShaders(
                 new Error(


### PR DESCRIPTION
## Summary
- allow repeated uniform failures to trigger the portal shader fallback
- remove the logic that prevented the failure streak counter from ever reaching the disable threshold

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d617cc9e54832b9a9dfc2296fa24a7