### PR TITLE
Fix sanitization for renderer-managed uniform containers lacking map

### DIFF
--- a/script.js
+++ b/script.js
@@ -6220,12 +6220,7 @@
       }
 
       const isRendererManagedUniformContainer = (container) =>
-        Boolean(
-          container &&
-            typeof container === 'object' &&
-            Array.isArray(container.seq) &&
-            typeof container.map === 'object'
-        );
+        Boolean(container && typeof container === 'object' && Array.isArray(container.seq));
 
       function sanitizeSceneUniforms() {
         if (!scene || typeof scene.traverse !== 'function') {
@@ -6299,6 +6294,11 @@
           const visited = new Set();
 
           if (isRendererManagedUniformContainer(uniforms)) {
+            if (!uniforms.map || typeof uniforms.map !== 'object') {
+              uniforms.map = {};
+              updated = true;
+              requiresRendererReset = true;
+            }
             const repairRendererUniformEntry = (container, key, entry) => {
               let updatedEntry = entry;
               let entryUpdated = false;


### PR DESCRIPTION
## Summary
- treat renderer-managed uniform containers as valid even when their map is missing
- recreate missing renderer uniform maps during sanitization to keep seq entries valid

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d61c4d8190832b92ef5a89447dfdc6