### PR TITLE
Handle renderer uniform entries without identifiers

### DIFF
--- a/script.js
+++ b/script.js
@@ -6533,12 +6533,29 @@
                     }
                   }
 
-                  const ensureMaterialUniform = (uniformId) => {
-                    if (!uniformId) {
-                      return;
+                  const ensureMaterialUniform = (uniformId, uniformEntry = null) => {
+                    let key = null;
+                    if (typeof uniformId === 'string' || typeof uniformId === 'number') {
+                      key = `${uniformId}`;
+                    } else if (uniformEntry && typeof uniformEntry === 'object') {
+                      if (typeof uniformEntry.id === 'string' || typeof uniformEntry.id === 'number') {
+                        key = `${uniformEntry.id}`;
+                      } else if (
+                        typeof uniformEntry.name === 'string' ||
+                        typeof uniformEntry.name === 'number'
+                      ) {
+                        key = `${uniformEntry.name}`;
+                      } else if (
+                        uniformEntry.uniform &&
+                        typeof uniformEntry.uniform === 'object' &&
+                        (typeof uniformEntry.uniform.id === 'string' ||
+                          typeof uniformEntry.uniform.id === 'number')
+                      ) {
+                        key = `${uniformEntry.uniform.id}`;
+                      }
                     }
-                    const key = typeof uniformId === 'string' ? uniformId : `${uniformId}`;
-                    if (!key) {
+
+                    if (key === null || typeof key === 'undefined') {
                       return;
                     }
                     const entry = mat.uniforms[key];
@@ -6559,7 +6576,7 @@
                       if (!uniform || typeof uniform !== 'object') {
                         return;
                       }
-                      ensureMaterialUniform(uniform.id ?? uniform.name ?? null);
+                      ensureMaterialUniform(uniform.id ?? uniform.name ?? null, uniform);
                     });
                   }
 


### PR DESCRIPTION
## Summary
- ensure sanitized portal materials always provide a uniform entry even when the renderer reports an empty id
- derive fallback keys from renderer uniform metadata before bailing out, preventing undefined uniform access

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d61eb20b64832bb63b2c490e4f1929