### PR TITLE
Prevent uniform sanitization from clobbering renderer caches

### DIFF
--- a/script.js
+++ b/script.js
@@ -6472,9 +6472,20 @@
           sanitizeArrayEntries(uniforms);
 
           Object.keys(uniforms).forEach((key) => {
-            if (key === 'seq') {
+            if (key === 'map' && uniforms.map && typeof uniforms.map === 'object') {
+              Object.keys(uniforms.map).forEach((mapKey) => {
+                const result = sanitizeUniformEntry(uniforms.map, mapKey, uniforms.map[mapKey], {
+                  markRendererReset: true,
+                });
+                processResult(result);
+              });
               return;
             }
+
+            if (RESERVED_UNIFORM_CONTAINER_KEYS.has(key)) {
+              return;
+            }
+
             processKey(key);
           });
 


### PR DESCRIPTION
## Summary
- avoid treating renderer-managed uniform metadata keys as corrupt values during sanitisation
- recursively clean uniform map entries without replacing the container so WebGLMaterials keeps its required uniforms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d621d5f0fc832bac4e5395d87bf2f7