### PR TITLE
Expand uniform sanitization coverage

### DIFF
--- a/script.js
+++ b/script.js
@@ -6530,49 +6530,48 @@
               isShaderMaterial || hasPortalUniforms || usesPortalShader
             );
 
-            if (shouldSanitizeMaterialUniforms) {
-              if (mat.uniforms && typeof mat.uniforms === 'object') {
-                const guardedUniforms = guardUniformContainer(mat.uniforms);
-                if (guardedUniforms && guardedUniforms !== mat.uniforms) {
-                  mat.uniforms = guardedUniforms;
-                }
-                const result = sanitizeUniformContainer(mat.uniforms);
-                if (result.updated) {
-                  updated = true;
-                  rendererReset = true;
-                }
-                if (result.requiresRendererReset) {
-                  rendererReset = true;
-                }
+            if (shouldSanitizeMaterialUniforms && mat.uniforms && typeof mat.uniforms === 'object') {
+              const guardedUniforms = guardUniformContainer(mat.uniforms);
+              if (guardedUniforms && guardedUniforms !== mat.uniforms) {
+                mat.uniforms = guardedUniforms;
+              }
+              const result = sanitizeUniformContainer(mat.uniforms);
+              if (result.updated) {
+                updated = true;
+                rendererReset = true;
+              }
+              if (result.requiresRendererReset) {
+                rendererReset = true;
+              }
+            }
+
+            const shouldSanitizeRendererUniforms = Boolean(renderer?.properties?.get);
+            if (shouldSanitizeRendererUniforms) {
+              let rendererUniforms = null;
+              try {
+                rendererUniforms = renderer.properties.get(mat)?.uniforms ?? null;
+              } catch (propertyError) {
+                rendererUniforms = null;
               }
 
-              if (mat && renderer?.properties?.get) {
-                let rendererUniforms = null;
-                try {
-                  rendererUniforms = renderer.properties.get(mat)?.uniforms ?? null;
-                } catch (propertyError) {
-                  rendererUniforms = null;
+              if (rendererUniforms && typeof rendererUniforms === 'object') {
+                const purgedRendererUniforms = purgeRendererUniformCache(rendererUniforms);
+                if (purgedRendererUniforms) {
+                  sanitized = true;
+                  rendererReset = true;
                 }
 
-                if (rendererUniforms && typeof rendererUniforms === 'object') {
-                  const purgedRendererUniforms = purgeRendererUniformCache(rendererUniforms);
-                  if (purgedRendererUniforms) {
-                    sanitized = true;
-                    rendererReset = true;
-                  }
+                const rendererUniformSanitization = sanitizeUniformContainer(rendererUniforms);
+                if (rendererUniformSanitization.updated) {
+                  sanitized = true;
+                  rendererReset = true;
+                }
+                if (rendererUniformSanitization.requiresRendererReset) {
+                  rendererReset = true;
+                  sanitized = true;
+                }
 
-                  const rendererUniformSanitization = sanitizeUniformContainer(
-                    rendererUniforms
-                  );
-                  if (rendererUniformSanitization.updated) {
-                    sanitized = true;
-                    rendererReset = true;
-                  }
-                  if (rendererUniformSanitization.requiresRendererReset) {
-                    rendererReset = true;
-                    sanitized = true;
-                  }
-
+                if (shouldSanitizeMaterialUniforms) {
                   if (!mat.uniforms || typeof mat.uniforms !== 'object') {
                     mat.uniforms = guardUniformContainer({});
                   } else {


### PR DESCRIPTION
## Summary
- sanitize shader materials only when their uniform containers exist and track renderer resets
- always scrub renderer-managed uniform caches, even for non-shader materials
- keep shader uniform mirrors in sync with renderer caches when portal shaders are in play

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d624f02c6c832b9cb0fe4452b9db4e