### PR TITLE
Fix renderer uniform sanitization to reset cache

### DIFF
--- a/script.js
+++ b/script.js
@@ -6312,6 +6312,7 @@
           if (!entry || typeof entry !== 'object') {
             container[key] = { value: null };
             result.updated = true;
+            result.requiresRendererReset = true;
             markReset();
             return result;
           }
@@ -6342,6 +6343,7 @@
 
             container[key] = { value: preservedValue ?? null };
             result.updated = true;
+            result.requiresRendererReset = true;
             markReset();
             return result;
           }


### PR DESCRIPTION
## Summary
- ensure uniform sanitization flags renderer cache resets when rebuilding invalid entries
- prevent repeated renderer TypeErrors from stale shader uniform references

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d641016cf4832b9787bb0debe20aaf