### PR TITLE
Ensure uniform sanitization covers non-portal shader materials

### DIFF
--- a/script.js
+++ b/script.js
@@ -6637,6 +6637,8 @@
             const expectPortalUniforms = Boolean(portalMetadata);
             const hasPortalUniforms = hasValidPortalUniformStructure(mat?.uniforms);
             const usesPortalShader = materialUsesPortalSurfaceShader(mat);
+            const hasUniformObject = Boolean(mat?.uniforms && typeof mat.uniforms === 'object');
+
             const shouldInspect = Boolean(
               isShaderMaterial || portalMetadata || hasPortalUniforms || usesPortalShader
             );
@@ -6652,7 +6654,7 @@
             }
 
             const shouldSanitizeMaterialUniforms = Boolean(
-              isShaderMaterial || hasPortalUniforms || usesPortalShader
+              isShaderMaterial || hasPortalUniforms || usesPortalShader || hasUniformObject
             );
 
             if (shouldSanitizeMaterialUniforms && mat.uniforms && typeof mat.uniforms === 'object') {


### PR DESCRIPTION
## Summary
- ensure the renderer-side uniform sanitizer also processes shader materials that only expose raw uniform maps

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6699ceee8832b81781eb396d6a107