### PR TITLE
Fix portal uniform proxy to heal undefined entries

### DIFF
--- a/script.js
+++ b/script.js
@@ -5211,7 +5211,24 @@
           }
 
           if (Object.prototype.hasOwnProperty.call(target, normalizedKey)) {
-            return target[normalizedKey];
+            const entry = target[normalizedKey];
+            if (!entry || typeof entry !== 'object') {
+              const placeholder = { value: null };
+              target[normalizedKey] = placeholder;
+              return placeholder;
+            }
+
+            if (!Object.prototype.hasOwnProperty.call(entry, 'value')) {
+              if (!assignPortalUniformValue(entry, null)) {
+                const placeholder = { value: null };
+                target[normalizedKey] = placeholder;
+                return placeholder;
+              }
+            } else if (typeof entry.value === 'undefined') {
+              assignPortalUniformValue(entry, null);
+            }
+
+            return entry;
           }
 
           const placeholder = { value: null };


### PR DESCRIPTION
## Summary
- reinforce the portal uniform guard so proxy lookups replace invalid entries with safe placeholders
- ensure undefined uniform values are normalized through assignPortalUniformValue before being returned to Three.js

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d696909130832bb6205e6d73a6ecc6