### PR TITLE
Handle portal shader fallback when uniforms missing

### DIFF
--- a/script.js
+++ b/script.js
@@ -7851,7 +7851,8 @@
 
         if (!fallback) {
           const inferredState = inferPortalMaterialState(material, defaultAccent, defaultState);
-          if (!inferredState && !material?.userData?.portalSurface) {
+          const hasPortalSignature = materialUsesPortalSurfaceShader(material);
+          if (!inferredState && !material?.userData?.portalSurface && !hasPortalSignature) {
             return false;
           }
 


### PR DESCRIPTION
## Summary
- ensure portal shader fallbacks are applied when uniforms disappear by checking for the shader signature during fallback replacement

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a7177b78832b906863ac725d0fb9