### PR TITLE
Ensure portal uniform sanitization reports updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -6917,11 +6917,15 @@
               const forcePortalUniforms = Boolean(
                 isShaderMaterial || hasPortalUniforms || usesPortalShader
               );
-              ensurePortalShaderMaterialsHaveUniformValues(
+              const ensured = ensurePortalShaderMaterialsHaveUniformValues(
                 [mat],
                 portalMetadata,
                 { forceExpectPortal: forcePortalUniforms }
               );
+              if (ensured) {
+                updated = true;
+                sanitized = true;
+              }
             }
 
             const shouldSanitizeMaterialUniforms = Boolean(


### PR DESCRIPTION
## Summary
- flag portal uniform repairs performed during scene sanitization so renderer recovery logic can react immediately
- mark the sanitization cycle as updated when portal materials were refreshed to avoid repeated rendering failures

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d6c0f060c0832b9fb6647c4ad152ee