### PR TITLE
Restrict renderer uniform sanitization to portal shaders

### DIFF
--- a/script.js
+++ b/script.js
@@ -6947,7 +6947,8 @@
               }
             }
 
-            const shouldSanitizeRendererUniforms = Boolean(renderer?.properties?.get);
+            const shouldSanitizeRendererUniforms = Boolean(renderer?.properties?.get) &&
+              (isShaderMaterial || hasPortalUniforms || usesPortalShader || portalMetadata);
             if (shouldSanitizeRendererUniforms) {
               let materialProperties = null;
               try {


### PR DESCRIPTION
## Summary
- limit WebGL uniform sanitization to shader-based or portal materials to avoid mutating standard material uniforms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c2742998832bb244f105b27f52cb