### PR TITLE
Avoid sanitizing fallback portal materials

### DIFF
--- a/script.js
+++ b/script.js
@@ -6947,8 +6947,9 @@
               }
             }
 
-            const shouldSanitizeRendererUniforms = Boolean(renderer?.properties?.get) &&
-              (isShaderMaterial || hasPortalUniforms || usesPortalShader || portalMetadata);
+            const shouldSanitizeRendererUniforms =
+              Boolean(renderer?.properties?.get) &&
+              (isShaderMaterial || hasPortalUniforms || usesPortalShader);
             if (shouldSanitizeRendererUniforms) {
               let materialProperties = null;
               try {


### PR DESCRIPTION
## Summary
- stop sanitizing renderer-managed uniform caches for non-shader portal fallback materials to avoid corrupting Three.js internals

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c4d9bcd8832b97b3b3fd208c8177