### PR TITLE
Improve uniform sanitization for missing renderer values

### DIFF
--- a/script.js
+++ b/script.js
@@ -6486,24 +6486,23 @@
       return true;
     }
 
+    if (entry.map && typeof entry.map === 'object' && Array.isArray(entry.seq)) {
+      return false;
+    }
+
     if (Object.prototype.hasOwnProperty.call(entry, 'value')) {
       return typeof entry.value === 'undefined';
     }
 
-    if (
-      entry.uniform &&
-      typeof entry.uniform === 'object' &&
-      Object.prototype.hasOwnProperty.call(entry.uniform, 'value')
-    ) {
+    if (entry.uniform && typeof entry.uniform === 'object') {
+      if (!Object.prototype.hasOwnProperty.call(entry.uniform, 'value')) {
+        return true;
+      }
       return typeof entry.uniform.value === 'undefined';
     }
 
     if (typeof entry.setValue === 'function') {
-      return false;
-    }
-
-    if (entry.map && typeof entry.map === 'object' && Array.isArray(entry.seq)) {
-      return false;
+      return !entry.uniform || typeof entry.uniform !== 'object';
     }
 
     return true;


### PR DESCRIPTION
## Summary
- update uniform sanitization to treat renderer-managed entries lacking backing uniform objects as invalid
- ensure sanitization catches corrupted renderer caches before rendering to avoid repeated shader failures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c669a0f0832ba5da2e9e64566beb