### PR TITLE
Fix renderer uniform cache sanitization for portal shaders

### DIFF
--- a/script.js
+++ b/script.js
@@ -6582,7 +6582,7 @@
             return false;
           }
 
-          const filtered = seq.filter((entry) => Boolean(entry && typeof entry === 'object'));
+          const filtered = seq.filter((entry) => !hasInvalidUniformEntry(entry));
           if (filtered.length === seq.length) {
             return false;
           }
@@ -6595,7 +6595,7 @@
           if (uniforms.map && typeof uniforms.map === 'object') {
             Object.keys(uniforms.map).forEach((key) => {
               const value = uniforms.map[key];
-              if (!value || typeof value !== 'object') {
+              if (hasInvalidUniformEntry(value)) {
                 delete uniforms.map[key];
               }
             });


### PR DESCRIPTION
## Summary
- tighten renderer uniform cache purging so undefined or malformed entries are removed
- drop invalid cached map entries to avoid undefined uniform reads that disable portal shaders

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c882cb98832ba7e2d7a8f1641308