### PR TITLE
Sanitize WebGL program uniforms before rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -6985,6 +6985,28 @@
                   sanitized = true;
                 }
 
+                if (
+                  programInfo &&
+                  programInfo !== rendererUniforms &&
+                  typeof programInfo === 'object'
+                ) {
+                  const purgedProgramUniforms = purgeRendererUniformCache(programInfo);
+                  if (purgedProgramUniforms) {
+                    sanitized = true;
+                    rendererReset = true;
+                  }
+
+                  const programUniformSanitization = sanitizeUniformContainer(programInfo);
+                  if (programUniformSanitization.updated) {
+                    sanitized = true;
+                    rendererReset = true;
+                  }
+                  if (programUniformSanitization.requiresRendererReset) {
+                    rendererReset = true;
+                    sanitized = true;
+                  }
+                }
+
                 const ensureRendererManagedUniform = (uniformId) => {
                   if (uniformId === null || typeof uniformId === 'undefined') {
                     return;


### PR DESCRIPTION
## Summary
- sanitize WebGL program uniform caches alongside renderer uniform caches
- reuse the existing uniform container sanitizer to reset stale shader metadata when errors occur

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d73d4888c0832b8d05e155d1c4c24f