### PR TITLE
Fix renderer uniform sanitization scope

### DIFF
--- a/script.js
+++ b/script.js
@@ -7000,6 +7000,14 @@
               }
             }
 
+            const props =
+              renderer?.properties && typeof renderer.properties.get === 'function'
+                ? renderer.properties.get(mat)
+                : null;
+            const rendererUniformsCandidate =
+              props && typeof props.uniforms === 'object' ? props.uniforms : null;
+            const programInfo = props?.program?.getUniforms?.() ?? null;
+
             const rendererUniformsNeedSanitization =
               uniformContainerNeedsSanitization(rendererUniformsCandidate) ||
               uniformContainerNeedsSanitization(programInfo);


### PR DESCRIPTION
## Summary
- derive renderer uniform containers from the current material before sanitizing them
- ensure program uniform info is available when evaluating renderer reset requirements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d749433a5c832ba37864b3e1655f32