### PR TITLE
Guard portal shader uniform detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -7472,6 +7472,18 @@
             }
             visitedMaterials.add(mat);
 
+            const portalMetadata = mat?.userData?.portalSurface ?? null;
+            const isShaderMaterial =
+              mat?.isShaderMaterial === true || mat?.type === 'ShaderMaterial';
+            const usesPortalShader = materialUsesPortalSurfaceShader(mat);
+            const hasPortalUniforms = hasValidPortalUniformStructure(mat.uniforms);
+            const expectsPortalUniforms =
+              usesPortalShader || hasPortalUniforms || (portalMetadata && isShaderMaterial);
+            if (expectsPortalUniforms && !hasPortalUniforms) {
+              invalid = true;
+              return;
+            }
+
             if (uniformContainerNeedsSanitization(mat.uniforms)) {
               invalid = true;
               return;


### PR DESCRIPTION
## Summary
- detect missing portal shader uniform values while scanning the scene for uniform issues
- trigger uniform sanitisation when a portal shader is missing its required uniform entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d74c1f2718832b8675b17f5a670577