### PR TITLE
Prevent proxying renderer-managed uniform containers

### DIFF
--- a/script.js
+++ b/script.js
@@ -5294,6 +5294,14 @@
         return container;
       }
 
+      if (container.isUniformsGroup === true) {
+        return container;
+      }
+
+      if (Array.isArray(container.seq) && typeof container.map === 'object') {
+        return container;
+      }
+
       if (PORTAL_UNIFORM_PROXY_TARGETS.has(container)) {
         return container;
       }


### PR DESCRIPTION
## Summary
- avoid wrapping renderer-managed uniform containers and uniform groups in the portal uniform guard
- leave WebGL-managed uniform caches untouched to stop undefined uniform entries from being created

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d75a6dac80832b96daf11892b37f72