### PR TITLE
Prevent sanitization from clobbering WebGL uniform entries

### DIFF
--- a/script.js
+++ b/script.js
@@ -6861,15 +6861,25 @@
 
           if (!Object.prototype.hasOwnProperty.call(entry, 'value')) {
             if (typeof entry.setValue === 'function') {
-              try {
-                entry.setValue(entry.value ?? null);
-                if (Object.prototype.hasOwnProperty.call(entry, 'value')) {
-                  return result;
+              const repair = repairRendererUniformEntry(container, key, entry);
+              if (repair.removed) {
+                if (Array.isArray(container)) {
+                  const index = typeof key === 'number' ? key : Number.parseInt(`${key}`, 10);
+                  if (Number.isInteger(index)) {
+                    container.splice(index, 1);
+                  }
+                } else {
+                  delete container[key];
                 }
-              } catch (setError) {
+                result.updated = true;
+              } else if (repair.updated) {
+                result.updated = true;
+              }
+              if (repair.requiresRendererReset) {
                 result.requiresRendererReset = true;
                 markReset();
               }
+              return result;
             }
 
             let preservedValue = null;


### PR DESCRIPTION
## Summary
- update uniform sanitization so WebGL-managed entries use the existing repair helper instead of being replaced with plain objects
- ensure removed renderer-managed entries are deleted safely without corrupting the backing container

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d75d590bc4832b8e276897c8d8681d