### PR TITLE
Fix renderer uniform validation for portal scenes

### DIFF
--- a/script.js
+++ b/script.js
@@ -6574,15 +6574,21 @@
       return typeof entry.value === 'undefined';
     }
 
+    if (typeof entry.setValue === 'function') {
+      if (entry.uniform && typeof entry.uniform === 'object') {
+        if (!Object.prototype.hasOwnProperty.call(entry.uniform, 'value')) {
+          return true;
+        }
+        return typeof entry.uniform.value === 'undefined';
+      }
+      return false;
+    }
+
     if (entry.uniform && typeof entry.uniform === 'object') {
       if (!Object.prototype.hasOwnProperty.call(entry.uniform, 'value')) {
         return true;
       }
       return typeof entry.uniform.value === 'undefined';
-    }
-
-    if (typeof entry.setValue === 'function') {
-      return !entry.uniform || typeof entry.uniform !== 'object';
     }
 
     return true;


### PR DESCRIPTION
## Summary
- treat WebGL-managed uniform entries with setValue handlers as valid to avoid unnecessary sanitization
- prevent the renderer uniform cache from being rebuilt with placeholder entries that trigger undefined value errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d76314f914832ba1eea05f69036cdf