### PR TITLE
Ensure uniform sanitization runs before gameplay rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -12522,6 +12522,9 @@
           : 'origin';
       teardownPreviewScene();
       resetRendererUniformCaches();
+      pendingUniformSanitizations = Math.max(pendingUniformSanitizations, 2);
+      rendererRecoveryFrames = Math.max(rendererRecoveryFrames, 1);
+      uniformSanitizationFailureStreak = 0;
       const context = ensureAudioContext();
       context?.resume?.().catch(() => {});
       if (window.Howler?.ctx?.state === 'suspended') {


### PR DESCRIPTION
## Summary
- prime the renderer uniform recovery counters when starting a run so sanitization happens before the first gameplay frame

## Testing
- npm test
- node tests/e2e-check.js

------
https://chatgpt.com/codex/tasks/task_e_68d76c9442a8832bb2972668b7df7643