### PR TITLE
Improve renderer uniform sanitization fallback

### DIFF
--- a/script.js
+++ b/script.js
@@ -7190,9 +7190,9 @@
           }
 
           if (!Object.prototype.hasOwnProperty.call(entry, 'value')) {
-              if (typeof entry.setValue === 'function') {
-                const repair = repairRendererUniformEntry(container, key, entry);
-                if (repair.removed) {
+            if (typeof entry.setValue === 'function') {
+              const repair = repairRendererUniformEntry(container, key, entry);
+              if (repair.removed) {
                 const { entry: stabilised } = stabiliseRendererUniformEntry(entry, key);
                 if (Array.isArray(container)) {
                   const index = typeof key === 'number' ? key : Number.parseInt(`${key}`, 10);
@@ -7206,7 +7206,25 @@
                 result.requiresRendererReset = true;
                 markReset();
                 return result;
-              } else if (repair.updated) {
+              }
+
+              if (hasInvalidUniformEntry(entry)) {
+                const { entry: stabilised } = stabiliseRendererUniformEntry(entry, key);
+                if (Array.isArray(container)) {
+                  const index = typeof key === 'number' ? key : Number.parseInt(`${key}`, 10);
+                  if (Number.isInteger(index)) {
+                    container[index] = stabilised;
+                  }
+                } else {
+                  container[key] = stabilised;
+                }
+                result.updated = true;
+                result.requiresRendererReset = true;
+                markReset();
+                return result;
+              }
+
+              if (repair.updated) {
                 result.updated = true;
               }
               if (repair.requiresRendererReset) {


### PR DESCRIPTION
## Summary
- stabilize portal shader uniform sanitization when renderer-managed entries stay invalid
- fall back to rebuilt uniform placeholders so portal materials keep defined values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d77e2417cc832b8e7ee932c73121db