### PR TITLE
Stabilize renderer uniform sanitization

### DIFF
--- a/script.js
+++ b/script.js
@@ -7083,10 +7083,11 @@
           materialProperties && typeof materialProperties.uniforms === 'object'
             ? materialProperties.uniforms
             : null;
+        if (stabiliseRendererUniformCache(rendererUniforms)) {
+          modified = true;
+        }
         if (uniformContainerNeedsSanitization(rendererUniforms)) {
-          if (stabiliseRendererUniformCache(rendererUniforms)) {
-            modified = true;
-          }
+          modified = true;
           return;
         }
 
@@ -7096,10 +7097,11 @@
           typeof materialProperties.program.getUniforms === 'function'
             ? materialProperties.program.getUniforms()
             : null;
+        if (stabiliseRendererUniformCache(programUniforms)) {
+          modified = true;
+        }
         if (uniformContainerNeedsSanitization(programUniforms)) {
-          if (stabiliseRendererUniformCache(programUniforms)) {
-            modified = true;
-          }
+          modified = true;
         }
       };
 


### PR DESCRIPTION
## Summary
- always stabilise renderer-provided uniform caches before checking for corruption
- ensure program uniform caches are normalised to prevent undefined shader uniform values that block rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7829ffd84832b9a30b57be0c32c8f