### PR TITLE
Pre-sanitise shader uniforms before starting runs

### DIFF
--- a/script.js
+++ b/script.js
@@ -12849,6 +12849,14 @@
       }
       updateStatusBars();
       updateDimensionOverlay();
+      // Prime the world meshes and shader uniforms before the first frame render.
+      try {
+        updateWorldMeshes();
+        sanitizeSceneUniforms();
+        ensureSceneUniformValuePresence();
+      } catch (initializationError) {
+        console.warn('Unable to pre-sanitise world uniforms before starting the run.', initializationError);
+      }
       requestAnimationFrame(loop);
       if (!progressSnapshot) {
         logEvent('You awaken on a floating island.');


### PR DESCRIPTION
## Summary
- pre-render the world immediately after starting a run so portal shaders have valid uniforms
- trigger uniform sanitisation proactively to prevent undefined uniform errors when the renderer boots
- log a console warning if the pre-sanitisation step ever fails

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d784b5417c832b8bacd2f3dc83a6c3