### PR TITLE
Fix uniform sanitization for shader materials only

### DIFF
--- a/script.js
+++ b/script.js
@@ -7647,10 +7647,8 @@
             const isShaderMaterial =
               mat?.isShaderMaterial === true || mat?.type === 'ShaderMaterial';
             const portalMetadata = mat?.userData?.portalSurface || null;
-            const expectPortalUniforms = Boolean(portalMetadata);
             const hasPortalUniforms = hasValidPortalUniformStructure(mat?.uniforms);
             const usesPortalShader = materialUsesPortalSurfaceShader(mat);
-            const hasUniformObject = Boolean(mat?.uniforms && typeof mat.uniforms === 'object');
 
             const distanceUniformResult = ensureDistanceMaterialUniformIntegrity(mat);
             if (distanceUniformResult.modified) {
@@ -7679,7 +7677,7 @@
             }
 
             const shouldSanitizeMaterialUniforms = Boolean(
-              isShaderMaterial || hasPortalUniforms || usesPortalShader || hasUniformObject
+              isShaderMaterial || hasPortalUniforms || usesPortalShader
             );
 
             if (shouldSanitizeMaterialUniforms && mat.uniforms && typeof mat.uniforms === 'object') {


### PR DESCRIPTION
## Summary
- restrict uniform sanitization to shader and portal materials during scene traversal
- prevent standard materials from receiving proxy uniform containers that caused undefined uniform errors at runtime

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d78748e1d4832b8a5646ba2dd3dd24