### PR TITLE
Reset renderer caches after repairing portal uniforms

### DIFF
--- a/script.js
+++ b/script.js
@@ -5090,11 +5090,14 @@
           });
 
           if (updated) {
-            if ('uniformsNeedUpdate' in material) {
-              material.uniformsNeedUpdate = true;
-            }
-            if ('needsUpdate' in material) {
-              material.needsUpdate = true;
+            const cacheReset = resetMaterialUniformCache(material);
+            if (!cacheReset) {
+              if ('uniformsNeedUpdate' in material) {
+                material.uniformsNeedUpdate = true;
+              }
+              if ('needsUpdate' in material) {
+                material.needsUpdate = true;
+              }
             }
           }
 
@@ -7042,11 +7045,14 @@
         });
 
         if (updated && material && typeof material === 'object') {
-          if ('uniformsNeedUpdate' in material) {
-            material.uniformsNeedUpdate = true;
-          }
-          if ('needsUpdate' in material) {
-            material.needsUpdate = true;
+          const cacheReset = resetMaterialUniformCache(material);
+          if (!cacheReset) {
+            if ('uniformsNeedUpdate' in material) {
+              material.uniformsNeedUpdate = true;
+            }
+            if ('needsUpdate' in material) {
+              material.needsUpdate = true;
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- reset the WebGL renderer's material cache whenever portal uniforms are regenerated so its uniform list no longer references invalid entries
- extend the general uniform normalisation path to flush renderer caches after sanitising containers so repaired uniforms are respected immediately

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d789533678832b81f078a714a2cde7