### PR TITLE
Fix portal shader recovery when renderer uniforms become invalid

### DIFF
--- a/script.js
+++ b/script.js
@@ -6800,7 +6800,36 @@
             if (!material || replacements.has(material)) {
               return;
             }
-            if (hasValidPortalUniformStructure(material.uniforms)) {
+
+            let rendererUniformsInvalid = false;
+            if (renderer?.properties?.get) {
+              let materialProperties = null;
+              try {
+                materialProperties = renderer.properties.get(material) ?? null;
+              } catch (propertiesError) {
+                materialProperties = null;
+              }
+
+              const rendererUniforms =
+                materialProperties && typeof materialProperties.uniforms === 'object'
+                  ? materialProperties.uniforms
+                  : null;
+              const programUniforms =
+                materialProperties &&
+                materialProperties.program &&
+                typeof materialProperties.program.getUniforms === 'function'
+                  ? materialProperties.program.getUniforms()
+                  : null;
+
+              rendererUniformsInvalid =
+                uniformContainerNeedsSanitization(rendererUniforms) ||
+                uniformContainerNeedsSanitization(programUniforms);
+            }
+
+            if (
+              hasValidPortalUniformStructure(material.uniforms) &&
+              !rendererUniformsInvalid
+            ) {
               return;
             }
 


### PR DESCRIPTION
## Summary
- detect portal shader materials whose renderer-managed uniforms have become invalid
- rebuild portal shader materials when renderer caches are corrupt instead of disabling shaders immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7977b4368832bbf6ffd9629a54f19