### PR TITLE
Disable portal shaders for software-rendered contexts

### DIFF
--- a/script.js
+++ b/script.js
@@ -3616,14 +3616,31 @@
           const rendererLabel = debugInfo
             ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
             : gl.getParameter(gl.RENDERER);
-          if (
-            typeof rendererLabel === 'string' &&
-            rendererLabel.toLowerCase().includes('swiftshader')
-          ) {
-            portalShaderSupport = false;
+          if (typeof rendererLabel === 'string') {
+            const normalisedLabel = rendererLabel.toLowerCase();
+            const softwareRendererPatterns = [
+              'swiftshader',
+              'llvmpipe',
+              'software',
+              'basic render driver',
+              'mesa',
+            ];
+            if (softwareRendererPatterns.some((pattern) => normalisedLabel.includes(pattern))) {
+              portalShaderSupport = false;
+            }
           }
         } catch (contextError) {
           // Ignore renderer identification issues; fallback will be used if shaders fail.
+        }
+        if (portalShaderSupport) {
+          const capabilities = renderer.capabilities || {};
+          const isWebGL2 = Boolean(capabilities.isWebGL2);
+          const derivativesSupported = Boolean(
+            isWebGL2 || gl.getExtension('OES_standard_derivatives')
+          );
+          if (!derivativesSupported) {
+            portalShaderSupport = false;
+          }
         }
       } catch (error) {
         renderer = null;


### PR DESCRIPTION
## Summary
- treat common software renderer identifiers (SwiftShader, llvmpipe, etc.) as unsupported for portal shaders
- fall back to emissive materials when required WebGL capabilities like OES_standard_derivatives are missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d79b1edb88832bb9685ac5ff5ab51b