### PR TITLE
Add local Three.js fallback for offline play

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,8 @@
 (function () {
   const THREE_CDN_URLS = [
+    // Local build bundled with the project so the experience works offline/file://
+    // without depending on a CDN (which may be blocked in classroom environments).
+    'vendor/three.min.js',
     'https://unpkg.com/three@0.161.0/build/three.min.js',
     'https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.min.js',
   ];


### PR DESCRIPTION
## Summary
- ensure the app loads Three.js from the bundled vendor copy before trying external CDNs so it renders offline

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7b2911370832ba722ec3cb79d8ac0