### PR TITLE
Enhance player avatar visuals and on-boarding guidance

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4870,6 +4870,15 @@ body.colorblind-assist .subtitle-overlay {
   color: var(--text-secondary);
 }
 
+.player-hint__note {
+  margin: 0;
+  margin-top: 0.35rem;
+  font-size: 0.78rem;
+  color: var(--accent-strong);
+  opacity: 0.85;
+  line-height: 1.45;
+}
+
 .player-hint__columns {
   display: grid;
   gap: 0.65rem;


### PR DESCRIPTION
## Summary
- add an SRGB-aware helper and build a multi-part fallback Steve avatar with accurate Minecraft-inspired palette
- retune the GLTF Steve materials, zombie/golem fallbacks, and NPC clones to boost emissive visibility across characters
- highlight the locator ring with movement-reactive colours and guide players to move and harvest via updated hints and controls copy

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d7ba8b5fb4832b91b9b18d613b46b4