### PR TITLE
Refresh Minecraft styling and interaction responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
   --accent-strong: #ffb657;
   --accent-soft: rgba(77, 164, 255, 0.28);
   --primary: #52e0a3;
-  --bg-dark: #040913;
+  --bg-dark: #2f4d1b;
   --glow: 0 0 14px rgba(82, 224, 163, 0.65);
   --dimension-primary: var(--accent);
   --dimension-glow: rgba(77, 164, 255, 0.4);
@@ -16,30 +16,42 @@
   --logo-opacity: 0.85;
   --tooltip-bg: rgba(5, 12, 28, 0.92);
   --tooltip-text: #f5f7fb;
-  --text-primary: #f6f8fb;
-  --text-secondary: rgba(214, 226, 255, 0.76);
+  --text-primary: #f7fbe9;
+  --text-secondary: rgba(233, 245, 220, 0.82);
   --danger: #ff5b7a;
   --success: #34d399;
   --grid-line: rgba(77, 164, 255, 0.1);
-  --card-shadow: 0 30px 80px rgba(3, 8, 20, 0.6);
+  --card-shadow: 0 18px 0 rgba(12, 18, 9, 0.4), 0 28px 56px rgba(5, 10, 6, 0.55);
   --manu-logo-max-size: 220px;
-  --page-background: radial-gradient(circle at 12% 18%, rgba(79, 167, 255, 0.18), transparent 50%),
-    radial-gradient(circle at 88% 12%, rgba(255, 182, 87, 0.12), transparent 55%),
-    linear-gradient(160deg, #060b18 0%, #09142a 55%, #071026 100%);
+  --page-background: linear-gradient(
+      180deg,
+      #8fd6ff 0%,
+      #9fe0ff 40%,
+      #cbefff 62%,
+      #7cc769 78%,
+      #4f8a34 88%,
+      #2f4d1b 100%
+    );
+  --panel-border-outer: #2f4820;
+  --panel-border-highlight: rgba(116, 195, 101, 0.32);
+  --panel-surface: rgba(32, 52, 28, 0.94);
+  --panel-surface-alt: rgba(24, 39, 22, 0.94);
+  --viewport-border: #3d5a27;
+  --viewport-shadow: 0 22px 0 rgba(15, 24, 12, 0.55), 0 30px 64px rgba(10, 16, 9, 0.6);
   --time-phase: 0;
-  --hud-panel-border: rgba(77, 164, 255, 0.32);
-  --hud-panel-shadow: 0 22px 50px rgba(7, 16, 32, 0.6);
-  --hud-panel-bg: rgba(8, 18, 34, 0.92);
-  --hud-panel-bg-alt: rgba(12, 26, 48, 0.88);
-  --hud-heart-color: #ff6f91;
-  --hud-heart-glow: rgba(255, 111, 145, 0.5);
-  --hud-bubble-color: #4bbbf5;
-  --hud-bubble-color-rgb: 75, 187, 245;
-  --hud-bubble-highlight: rgba(255, 255, 255, 0.82);
-  --hud-score-gradient: linear-gradient(160deg, rgba(12, 22, 40, 0.95), rgba(18, 32, 58, 0.92));
-  --hud-score-text: #f4f7fb;
-  --hud-progress-track: rgba(77, 164, 255, 0.22);
-  --hud-progress-glow: rgba(82, 224, 163, 0.45);
+  --hud-panel-border: rgba(71, 111, 54, 0.75);
+  --hud-panel-shadow: 0 14px 0 rgba(18, 26, 14, 0.6), 0 26px 56px rgba(8, 14, 7, 0.6);
+  --hud-panel-bg: rgba(38, 60, 32, 0.94);
+  --hud-panel-bg-alt: rgba(28, 46, 26, 0.94);
+  --hud-heart-color: #ff6767;
+  --hud-heart-glow: rgba(255, 103, 103, 0.45);
+  --hud-bubble-color: #7ad4ff;
+  --hud-bubble-color-rgb: 122, 212, 255;
+  --hud-bubble-highlight: rgba(255, 255, 255, 0.88);
+  --hud-score-gradient: linear-gradient(180deg, rgba(40, 66, 32, 0.95), rgba(28, 44, 26, 0.95));
+  --hud-score-text: #f6fbe9;
+  --hud-progress-track: rgba(116, 195, 101, 0.28);
+  --hud-progress-glow: rgba(210, 255, 168, 0.55);
   font-size: 16px;
 }
 
@@ -134,14 +146,14 @@ body.theme-grassland {
   --glow: 0 0 14px rgba(99, 212, 131, 0.5);
   --dimension-primary: #63d483;
   --dimension-glow: rgba(99, 212, 131, 0.4);
-  --hud-panel-border: rgba(99, 212, 131, 0.35);
-  --hud-panel-shadow: 0 24px 50px rgba(15, 40, 24, 0.4);
-  --hud-panel-bg: rgba(10, 26, 22, 0.9);
-  --hud-panel-bg-alt: rgba(14, 32, 26, 0.85);
-  --hud-bubble-color: #45c3ff;
-  --hud-bubble-color-rgb: 69, 195, 255;
-  --hud-progress-track: rgba(99, 212, 131, 0.25);
-  --hud-progress-glow: rgba(99, 212, 131, 0.5);
+  --hud-panel-border: rgba(82, 132, 60, 0.85);
+  --hud-panel-shadow: 0 14px 0 rgba(18, 28, 16, 0.55), 0 24px 48px rgba(10, 16, 9, 0.5);
+  --hud-panel-bg: rgba(40, 66, 34, 0.94);
+  --hud-panel-bg-alt: rgba(32, 54, 30, 0.94);
+  --hud-bubble-color: #7ad4ff;
+  --hud-bubble-color-rgb: 122, 212, 255;
+  --hud-progress-track: rgba(116, 195, 101, 0.3);
+  --hud-progress-glow: rgba(210, 255, 168, 0.55);
 }
 
 body.theme-netherite {
@@ -149,17 +161,17 @@ body.theme-netherite {
   --glow: 0 0 14px rgba(255, 112, 67, 0.55);
   --dimension-primary: #ff7043;
   --dimension-glow: rgba(255, 112, 67, 0.45);
-  --hud-panel-border: rgba(255, 139, 92, 0.4);
-  --hud-panel-shadow: 0 26px 56px rgba(72, 20, 12, 0.35);
-  --hud-panel-bg: rgba(38, 14, 12, 0.92);
-  --hud-panel-bg-alt: rgba(50, 16, 12, 0.9);
-  --hud-heart-glow: rgba(255, 135, 102, 0.7);
-  --hud-bubble-color: #ff9566;
-  --hud-bubble-color-rgb: 255, 149, 102;
-  --hud-bubble-highlight: rgba(255, 210, 189, 0.9);
-  --hud-score-gradient: linear-gradient(160deg, rgba(38, 12, 10, 0.95), rgba(72, 20, 12, 0.92));
-  --hud-progress-track: rgba(255, 149, 102, 0.26);
-  --hud-progress-glow: rgba(255, 149, 102, 0.5);
+  --hud-panel-border: rgba(134, 56, 32, 0.85);
+  --hud-panel-shadow: 0 14px 0 rgba(62, 24, 16, 0.55), 0 24px 48px rgba(40, 16, 10, 0.5);
+  --hud-panel-bg: rgba(68, 32, 22, 0.94);
+  --hud-panel-bg-alt: rgba(54, 26, 18, 0.94);
+  --hud-heart-glow: rgba(255, 135, 102, 0.55);
+  --hud-bubble-color: #ffb27d;
+  --hud-bubble-color-rgb: 255, 178, 125;
+  --hud-bubble-highlight: rgba(255, 239, 220, 0.9);
+  --hud-score-gradient: linear-gradient(180deg, rgba(68, 32, 22, 0.95), rgba(48, 22, 16, 0.95));
+  --hud-progress-track: rgba(255, 178, 125, 0.32);
+  --hud-progress-glow: rgba(255, 214, 168, 0.55);
 }
 
 body.game-active {
@@ -477,12 +489,12 @@ body:not(.game-active) .manu-logo {
   inset: 0;
   pointer-events: none;
   background:
-    radial-gradient(circle at 48% 32%, rgba(77, 164, 255, 0.22), transparent 62%),
-    radial-gradient(circle at 22% 68%, rgba(82, 224, 163, 0.14), transparent 70%),
-    linear-gradient(180deg, rgba(9, 20, 36, 0.65), rgba(4, 11, 23, 0.85));
-  mix-blend-mode: normal;
-  opacity: calc(0.2 + (1 - var(--time-phase)) * 0.25);
-  filter: saturate(0.85);
+    radial-gradient(circle at 40% 24%, rgba(255, 255, 255, 0.3), transparent 58%),
+    radial-gradient(circle at 72% 38%, rgba(255, 255, 255, 0.22), transparent 64%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(124, 199, 111, 0.12));
+  mix-blend-mode: screen;
+  opacity: calc(0.35 + (1 - var(--time-phase)) * 0.25);
+  filter: saturate(1.05) contrast(1.05);
   animation: pulse 14s ease-in-out infinite;
   transition: background 0.8s ease, opacity 0.8s ease, filter 0.8s ease;
   z-index: -1;
@@ -493,10 +505,11 @@ body::after {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 30% 8%, rgba(255, 255, 255, 0.08), transparent 58%),
-    radial-gradient(circle at 78% 16%, rgba(255, 214, 170, 0.08), transparent 60%),
-    linear-gradient(200deg, rgba(6, 12, 24, 0.6), rgba(6, 12, 24, 0));
-  opacity: calc(0.18 + var(--time-phase) * 0.45);
+  background:
+    radial-gradient(circle at 28% 12%, rgba(255, 255, 255, 0.22), transparent 60%),
+    radial-gradient(circle at 76% 20%, rgba(255, 255, 255, 0.16), transparent 58%),
+    linear-gradient(200deg, rgba(124, 199, 111, 0.2), rgba(58, 87, 36, 0.22));
+  opacity: calc(0.25 + var(--time-phase) * 0.35);
   transition: opacity 0.8s ease;
   z-index: -2;
 }
@@ -629,17 +642,17 @@ body::after {
   align-content: start;
   align-self: start;
   padding: clamp(1.35rem, 2.4vw, 1.9rem);
-  border-radius: 26px;
-  background: linear-gradient(165deg, rgba(8, 16, 32, 0.92), rgba(6, 14, 28, 0.78));
-  border: 1px solid rgba(77, 164, 255, 0.2);
-  box-shadow: var(--card-shadow);
-  backdrop-filter: blur(16px);
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--panel-surface), var(--panel-surface-alt));
+  border: 3px solid var(--panel-border-outer);
+  box-shadow: var(--viewport-shadow), inset 0 0 0 2px var(--panel-border-highlight);
+  backdrop-filter: none;
   position: sticky;
   top: clamp(1rem, 3vh, 2.25rem);
   max-height: calc(100vh - clamp(2rem, 6vh, 3.5rem));
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: rgba(73, 242, 255, 0.35) transparent;
+  scrollbar-color: rgba(122, 183, 86, 0.55) transparent;
 }
 
 .objectives-panel::-webkit-scrollbar {
@@ -647,7 +660,7 @@ body::after {
 }
 
 .objectives-panel::-webkit-scrollbar-thumb {
-  background: rgba(73, 242, 255, 0.35);
+  background: rgba(122, 183, 86, 0.55);
   border-radius: 999px;
 }
 
@@ -665,32 +678,34 @@ body::after {
 }
 
 .objectives-panel__header h2 {
-  font-family: 'Chakra Petch', sans-serif;
+  font-family: 'Press Start 2P', 'Chakra Petch', sans-serif;
   font-size: 0.85rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: var(--accent);
+  color: #f1f6e9;
+  text-shadow: 0 0 6px rgba(9, 16, 9, 0.6);
 }
 
 .objectives-panel__header--hint h2 {
-  color: var(--accent-strong);
+  color: #ffe28f;
 }
 
 .objectives-panel__card {
-  background: linear-gradient(155deg, rgba(10, 22, 40, 0.82), rgba(8, 18, 32, 0.62));
-  border-radius: 20px;
-  border: 1px solid rgba(77, 164, 255, 0.2);
+  background: linear-gradient(180deg, rgba(42, 68, 36, 0.96), rgba(30, 50, 28, 0.96));
+  border-radius: 10px;
+  border: 2px solid rgba(71, 111, 54, 0.85);
   padding: 1.1rem 1.25rem;
-  box-shadow: 0 20px 48px rgba(4, 10, 24, 0.45);
-  backdrop-filter: blur(12px);
+  box-shadow: 0 10px 0 rgba(15, 25, 12, 0.55);
+  backdrop-filter: none;
   display: grid;
   gap: 0.75rem;
+  color: #f6fbe9;
 }
 
 .objectives-panel__card--primer {
   padding: 1.25rem 1.4rem;
-  background: linear-gradient(160deg, rgba(12, 24, 44, 0.92), rgba(10, 20, 34, 0.78));
-  border: 1px solid rgba(77, 164, 255, 0.28);
+  background: linear-gradient(180deg, rgba(58, 97, 42, 0.96), rgba(40, 67, 32, 0.96));
+  border: 2px solid rgba(112, 168, 79, 0.75);
   gap: 1.1rem;
 }
 
@@ -714,10 +729,10 @@ body::after {
   place-items: center;
   width: 2.6rem;
   height: 2.6rem;
-  border-radius: 14px;
-  background: rgba(77, 164, 255, 0.12);
-  box-shadow: inset 0 0 0 1px rgba(77, 164, 255, 0.25), 0 10px 24px rgba(3, 10, 24, 0.35);
-  color: var(--accent);
+  border-radius: 10px;
+  background: rgba(122, 183, 86, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(122, 183, 86, 0.5), 0 8px 18px rgba(18, 28, 14, 0.4);
+  color: #ffe28f;
   font-size: 1.35rem;
 }
 
@@ -726,18 +741,18 @@ body::after {
   font-size: 1rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--text-primary);
+  color: #f8fceb;
 }
 
 .primer-list__content p {
   margin: 0;
   font-size: 0.9rem;
   line-height: 1.6;
-  color: var(--text-secondary);
+  color: rgba(245, 255, 231, 0.78);
 }
 
 .primer-list__content strong {
-  color: var(--accent-strong);
+  color: #ffe28f;
 }
 
 .objectives-panel__card--hint {
@@ -1249,11 +1264,11 @@ body.game-active #gameCanvas {
 
 .primary-panel {
   position: relative;
-  border-radius: 26px;
+  border-radius: 12px;
   overflow: hidden;
-  box-shadow: var(--card-shadow);
-  background: linear-gradient(160deg, rgba(7, 14, 26, 0.88), rgba(10, 20, 36, 0.78));
-  border: 1px solid rgba(77, 164, 255, 0.22);
+  box-shadow: var(--viewport-shadow), inset 0 0 0 3px var(--panel-border-highlight);
+  background: linear-gradient(180deg, rgba(58, 97, 42, 0.94), rgba(28, 47, 26, 0.96));
+  border: 4px solid var(--viewport-border);
   display: grid;
   grid-template-areas: 'viewport';
   grid-template-rows: minmax(0, 1fr);
@@ -1267,7 +1282,7 @@ body.game-active #gameCanvas {
   width: 100%;
   height: 100%;
   display: block;
-  background: radial-gradient(circle at 50% 18%, rgba(22, 42, 72, 0.78), rgba(6, 12, 22, 0.96));
+  background: linear-gradient(180deg, rgba(143, 214, 255, 0.95) 0%, rgba(128, 206, 255, 0.88) 36%, rgba(118, 190, 104, 0.95) 76%, rgba(88, 132, 62, 0.98) 100%);
 }
 
 #gameCanvas:focus {
@@ -1919,11 +1934,11 @@ body.game-active #gameCanvas {
   display: grid;
   gap: 0.75rem;
   padding: 0.9rem 1.1rem;
-  border-radius: 8px;
-  background: linear-gradient(160deg, var(--hud-panel-bg), var(--hud-panel-bg-alt));
-  border: 1px solid var(--hud-panel-border);
-  box-shadow: var(--hud-panel-shadow);
-  backdrop-filter: blur(10px);
+  border-radius: 10px;
+  background: linear-gradient(180deg, var(--hud-panel-bg), var(--hud-panel-bg-alt));
+  border: 2px solid var(--hud-panel-border);
+  box-shadow: var(--hud-panel-shadow), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  backdrop-filter: none;
   pointer-events: auto;
   min-width: clamp(220px, 24vw, 320px);
   position: relative;
@@ -5508,19 +5523,20 @@ body.colorblind-assist .subtitle-overlay {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 38px;
-  height: 38px;
+  width: 28px;
+  height: 28px;
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.18s ease;
   z-index: 35;
+  filter: drop-shadow(0 0 3px rgba(8, 12, 6, 0.7));
 }
 
 .crosshair__horizontal,
 .crosshair__vertical {
   position: absolute;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 0 6px rgba(255, 255, 255, 0.45);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 0 0 1px rgba(18, 26, 16, 0.65);
 }
 
 .crosshair__horizontal {


### PR DESCRIPTION
## Summary
- brighten the base atmosphere, renderer, and ambient lighting so the world and Steve read like Minecraft, including a dedicated key light on the avatar
- trigger block interactions on pointer up to remove the sluggish click delay on canvas input
- restyle the background, HUD, panels, and crosshair with earthy gradients and pixel-inspired accents to match a Minecraft aesthetic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7c9515750832bb19ed280f0e49e1a