### PR TITLE
Fix renderer uniform sanitization loop

### DIFF
--- a/script.js
+++ b/script.js
@@ -7725,11 +7725,11 @@
           typeof materialProperties.program.getUniforms === 'function'
             ? materialProperties.program.getUniforms()
             : null;
-        if (stabiliseRendererUniformCache(programUniforms)) {
-          modified = true;
-        }
-        if (uniformContainerNeedsSanitization(programUniforms)) {
-          modified = true;
+        if (programUniforms) {
+          stabiliseRendererUniformCache(programUniforms);
+          if (uniformContainerNeedsSanitization(programUniforms)) {
+            modified = true;
+          }
         }
       };
 


### PR DESCRIPTION
## Summary
- stop treating transient program uniform sanitisation as a renderer mutation so the frame loop no longer stalls before rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e0be1044832bb76ec56ed83829cb