### PR TITLE
Add first-person hands and API-aware leaderboard to simple experience

### DIFF
--- a/script.js
+++ b/script.js
@@ -515,6 +515,9 @@
     if (simpleModeEnabled && window.SimpleExperience?.create) {
       const simpleExperience = window.SimpleExperience.create({
         canvas,
+        apiBaseUrl: window.APP_CONFIG?.apiBaseUrl ?? null,
+        playerName:
+          (headerUserNameEl?.textContent || window.APP_CONFIG?.playerName || '').trim() || 'Explorer',
         ui: {
           introModal,
           startButton,
@@ -527,6 +530,9 @@
           scoreDimensionsEl,
           portalProgressLabel,
           portalProgressBar,
+          scoreboardListEl,
+          scoreboardStatusEl,
+          refreshScoresButton,
         },
       });
       const launchSimple = () => {


### PR DESCRIPTION
## Summary
- forward simple mode bootstrap information so the simplified experience can reach the configured API and display the active explorer name
- augment the simple experience with a first-person hand rig that reacts to movement and dimension palette changes for improved immersion
- implement local and remote leaderboard synchronisation with status messaging, refresh handling, and regular score updates in simple mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7eb97df04832bb71d7fa7c7f1933b