### PR TITLE
Fix simple experience initialization crash

### DIFF
--- a/script.js
+++ b/script.js
@@ -500,6 +500,7 @@
     const landingSignInPanel = document.getElementById('landingSignInPanel');
     const scoreboardListEl = document.getElementById('scoreboardList');
     const scoreboardStatusEl = document.getElementById('scoreboardStatus');
+    const refreshScoresButton = document.getElementById('refreshScores');
 
     function shouldStartSimpleMode() {
       if (typeof window === 'undefined') return false;
@@ -555,7 +556,6 @@
     let gapiScriptPromise = null;
     let googleAuthPromise = null;
     let googleAuthInstance = null;
-    const refreshScoresButton = document.getElementById('refreshScores');
     const leaderboardModal = document.getElementById('leaderboardModal');
     const openLeaderboardButton = document.getElementById('openLeaderboard');
     const closeLeaderboardButton = document.getElementById('closeLeaderboard');


### PR DESCRIPTION
## Summary
- ensure the refresh scores button element is resolved before wiring up the simple mode bootstrapper so the experience can start without throwing a ReferenceError

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7f10ae6d0832b94bffc1bade60862