### PR TITLE
Add mobile controls and audio polish to simple experience

### DIFF
--- a/script.js
+++ b/script.js
@@ -539,6 +539,9 @@
           scoreboardListEl,
           scoreboardStatusEl,
           refreshScoresButton,
+          mobileControls,
+          virtualJoystick: virtualJoystickEl,
+          virtualJoystickThumb,
         },
       });
       const launchSimple = () => {


### PR DESCRIPTION
## Summary
- expose the mobile HUD elements to the simple experience bootstrap so the simplified renderer can manage touch input
- add a dedicated mobile control layer with virtual joystick, touch look, and button handlers plus integrate lightweight audio cues throughout the gameplay loop
- update movement, jumping, and state transitions to honour touch input and trigger feedback when mining, taking damage, changing dimensions, or securing victory

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7f2a9e238832b9b1439ee3db32440