### PR TITLE
Add spec compliance summary documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ To keep progress visible, the actionable checklist extracted from that brief now
 [`docs/enhancement-roadmap.md`](docs/enhancement-roadmap.md). Update that roadmap as features land so the team can quickly gauge
 momentum toward the full experience described in the brief.
 
+If you need a quick status snapshot, [`docs/spec-compliance.md`](docs/spec-compliance.md) summarises how each requirement in the
+brief maps to shipped code (with direct citations), while [`docs/feature-verification.md`](docs/feature-verification.md) dives
+deeper into the implementation details and validation steps.
+
 If you work with coding agents (for example GitHub Copilot or Code Interpreter) the verbatim prompts from the brief are archived in [`docs/coding-agent-prompts.md`](docs/coding-agent-prompts.md). Reusing those prompts keeps automated contributions aligned with the currently shipped sandbox systems.
 
 ## Simplified sandbox mode

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -1,0 +1,22 @@
+# Spec Compliance Summary: Infinite Rails — Portals of Dimension
+
+The table below maps each requirement from the "Comprehensive Analysis and Enhancement Specifications for Infinite Rails" brief to concrete implementations in the repository. Citations point to the shipped code or markup that satisfies the behaviour.
+
+| Spec Area | Implementation Evidence |
+| --- | --- |
+| **Initialization & Onboarding** | `SimpleExperience.start()` boots the renderer, hides the intro modal, presents a five-second controls briefing, and focuses the canvas for immediate play.【F:simple-experience.js†L504-L559】 The viewport ships with a dedicated tutorial overlay inside `index.html` that calls out WASD, mining, and portal creation controls.【F:index.html†L134-L197】 |
+| **Procedural World & Lighting** | `setupScene()` instantiates the Three.js scene, camera, lights, and renderer, while `buildTerrain()` generates a 64×64 voxel island and logs the 4,096-block grid to the console to confirm population.【F:simple-experience.js†L900-L961】【F:simple-experience.js†L1971-L2051】 Day/night sun orbits run every frame via `updateSunCycle()` to deliver the requested 10-minute daylight loop.【F:simple-experience.js†L2857-L2880】 |
+| **Player Visibility & First-Person Perspective** | `loadPlayerCharacter()` attaches the Steve GLTF to the camera rig, plays the idle animation, and ensures fallback cubes render if the asset fails—logging “Steve visible in scene” once loaded.【F:simple-experience.js†L1740-L1877】 |
+| **Movement, Input & Mining/Placement** | Keyboard, pointer lock, and mobile handlers cover WASD movement, jumping, mouse-look, raycast mining, block placement, and a virtual joystick for touch. Mining feeds inventory updates and HUD hints.【F:simple-experience.js†L1326-L1557】【F:simple-experience.js†L2483-L2620】 |
+| **Entities, Combat & Survival** | `spawnZombiesForNight()` and `updateZombies()` spawn Minecraft-style enemies after dusk, steering toward the player and deducting half-heart damage on contact; `spawnGolemsIfNeeded()` adds allied defenders with intercept logic.【F:simple-experience.js†L2904-L3093】 Hearts, oxygen bubbles, and damage overlays update inside `updateHud()` and `animateDamageOverlay()` to reflect survival state.【F:simple-experience.js†L3097-L3174】【F:simple-experience.js†L3897-L3970】 |
+| **Crafting, Inventory & Score Feedback** | Drag-and-drop crafting sequences validate recipes, award +2 points, unlock hotbar items, and update scoreboard tallies. Inventory slots stack to 99 items, mirroring the spec’s hotbar rules.【F:simple-experience.js†L3271-L3655】 |
+| **Portals, Dimensions & Progression** | Portal detection scans for 4×3 frames, activates shader-driven transitions, increments dimension indices, and adjusts gravity/lighting per realm. The Netherite dimension installs collapsing rails and Eternal Ingot victory flow before triggering the celebration modal.【F:simple-experience.js†L2100-L2462】【F:simple-experience.js†L3735-L3964】 |
+| **Backend Sync & SSO Hooks** | The sandbox polls `GET /scores`, posts leaderboard updates on unlock events, and merges responses into the UI. Google SSO wiring in `script.js` mirrors the spec by provisioning GIS buttons, persisting identity, and syncing to DynamoDB-ready endpoints.【F:simple-experience.js†L593-L710】【F:simple-experience.js†L760-L872】【F:script.js†L760-L1010】 |
+| **UI Feedback & Accessibility** | HUD tooltips, objective panels, and aria-aware modals in `index.html` surface the mission brief, leaderboard, crafting panels, and settings toggles described in the spec.【F:index.html†L40-L410】 |
+| **Performance & Asset Optimisation** | Delta-time pacing clamps animation frames, chunk-level frustum culling skips off-screen voxels, and cached GLTF assets prevent redundant fetches—all contributing to the 60 FPS target with lazy-loaded models.【F:simple-experience.js†L1923-L2051】【F:simple-experience.js†L2656-L2799】 |
+
+## Additional Notes
+
+- Audio cues route through Howler.js with graceful fallbacks when the library is unavailable, matching the spec’s request for ambient mining and combat sounds.【F:simple-experience.js†L1231-L1334】
+- Score synchronisation defers to offline local storage when `APP_CONFIG.apiBaseUrl` is unset, ensuring consistent UX regardless of backend availability.【F:simple-experience.js†L593-L710】
+- The compliance evidence is additive to the existing `docs/feature-verification.md` deep dive and will be updated as new portal rules or mechanics land.


### PR DESCRIPTION
## Summary
- add a spec compliance reference document that maps the enhancement brief to concrete implementations
- link the new summary alongside the existing roadmap and verification docs in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d81a7c79b4832ba9de19f913f8748b