### PR TITLE
Integrate portal mechanics into simple experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -1050,6 +1050,7 @@
     <script src="vendor/three.min.js" defer></script>
     <script src="assets/offline-assets.js" defer></script>
     <script src="scoreboard-utils.js" defer></script>
+    <script src="portal-mechanics.js" defer></script>
     <script src="simple-experience.js" defer></script>
     <script src="script.js" defer></script>
   </body>

--- a/portal-mechanics.js
+++ b/portal-mechanics.js
@@ -135,7 +135,7 @@ function getPortalMechanicsSummary() {
   };
 }
 
-module.exports = {
+const api = {
   FRAME_WIDTH,
   FRAME_HEIGHT,
   buildPortalFrame,
@@ -144,3 +144,17 @@ module.exports = {
   enterPortal,
   getPortalMechanicsSummary,
 };
+
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = api;
+}
+
+const globalScope =
+  (typeof window !== 'undefined' && window) ||
+  (typeof globalThis !== 'undefined' && globalThis) ||
+  (typeof global !== 'undefined' && global) ||
+  null;
+
+if (globalScope && !globalScope.PortalMechanics) {
+  globalScope.PortalMechanics = api;
+}


### PR DESCRIPTION
## Summary
- expose the shared portal mechanics helpers in the browser and load them before the gameplay scripts
- update the simple experience to track portal readiness, ignite frames via the mechanics API, and apply transition metadata when travelling
- refresh HUD messaging and mobile controls so the new ignition flow is visible on both desktop and touch

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d81fc8a7c0832b8913bfc7637da19d