### PR TITLE
Tighten E2E smoke test coverage for core gameplay signals

### DIFF
--- a/tests/e2e-check.js
+++ b/tests/e2e-check.js
@@ -4,9 +4,14 @@ async function run() {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   const warnings = [];
+  const infoLogs = [];
   page.on('console', (msg) => {
+    const text = msg.text();
+    if (msg.type() === 'log') {
+      infoLogs.push(text);
+    }
     if (msg.type() === 'error' || msg.type() === 'warning') {
-      warnings.push(msg.text());
+      warnings.push(text);
     }
   });
   page.on('pageerror', (err) => {
@@ -23,6 +28,32 @@ async function run() {
     const eventCount = await page.evaluate(() => document.querySelectorAll('#eventLog li').length);
     if (eventCount === 0) {
       throw new Error('No events were logged after starting the game.');
+    }
+    const worldGenerated = infoLogs.find((line) => line.includes('World generated:'));
+    if (!worldGenerated) {
+      throw new Error('World generation log was not emitted.');
+    }
+    const steveVisible = infoLogs.find((line) => line.includes('Steve visible in scene'));
+    if (!steveVisible) {
+      throw new Error('Player visibility confirmation log missing.');
+    }
+    const dimensionLog = infoLogs.find((line) => line.includes('Dimension online:'));
+    if (!dimensionLog) {
+      throw new Error('Dimension activation log missing.');
+    }
+    const hudState = await page.evaluate(() => ({
+      gameActive: document.body.classList.contains('game-active'),
+      heartsMarkup: document.querySelector('#hearts')?.innerHTML ?? '',
+      timeText: document.querySelector('#timeOfDay')?.textContent?.trim() ?? '',
+    }));
+    if (!hudState.gameActive) {
+      throw new Error('HUD did not transition to the active gameplay state.');
+    }
+    if (!hudState.heartsMarkup || hudState.heartsMarkup.trim().length === 0) {
+      throw new Error('Heart display did not initialise.');
+    }
+    if (!hudState.timeText) {
+      throw new Error('Time-of-day indicator remained empty.');
     }
     const unexpected = warnings.filter((msg) =>
       !msg.includes('accounts.google.com') &&


### PR DESCRIPTION
## Summary
- expand the Playwright smoke test to capture console output from the sandbox
- assert that world generation, player visibility, and dimension activation logs appear
- verify the HUD enters an active state with hearts and a time indicator before continuing

## Testing
- npm run test:e2e *(fails: Playwright browsers not installed in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d83098183c832b8261d2b34c9ca971