### PR TITLE
Expose simple experience debug snapshot and expand smoke test

### DIFF
--- a/script.js
+++ b/script.js
@@ -501,6 +501,16 @@
     const scoreboardListEl = document.getElementById('scoreboardList');
     const scoreboardStatusEl = document.getElementById('scoreboardStatus');
     const refreshScoresButton = document.getElementById('refreshScores');
+    const scorePanelEl = document.getElementById('scorePanel');
+    const scoreTotalEl = document.getElementById('scoreTotal');
+    const scoreRecipesEl = document.getElementById('scoreRecipes');
+    const scoreDimensionsEl = document.getElementById('scoreDimensions');
+    const playerHintEl = document.getElementById('playerHint');
+    const inventoryModal = document.getElementById('inventoryModal');
+    const closeInventoryButton = document.getElementById('closeInventory');
+    const inventoryGridEl = document.getElementById('inventoryGrid');
+    const inventorySortButton = document.getElementById('inventorySortButton');
+    const inventoryOverflowEl = document.getElementById('inventoryOverflow');
 
     function shouldStartSimpleMode() {
       if (typeof window === 'undefined') return false;
@@ -1066,10 +1076,6 @@
     const leaderboardTableContainer = document.getElementById('leaderboardTable');
     const leaderboardEmptyMessage = document.getElementById('leaderboardEmptyMessage');
     const leaderboardSortHeaders = Array.from(document.querySelectorAll('.leaderboard-sortable'));
-    const scorePanelEl = document.getElementById('scorePanel');
-    const scoreTotalEl = document.getElementById('scoreTotal');
-    const scoreRecipesEl = document.getElementById('scoreRecipes');
-    const scoreDimensionsEl = document.getElementById('scoreDimensions');
     const scoreState = {
       score: 0,
       recipes: new Set(),
@@ -1090,12 +1096,6 @@
     let dimensionOverlayState = { info: null, tasks: [] };
     let scoreFlipTimeout = null;
     let scoreOverlayInitialized = false;
-    const inventoryModal = document.getElementById('inventoryModal');
-    const closeInventoryButton = document.getElementById('closeInventory');
-    const inventoryGridEl = document.getElementById('inventoryGrid');
-    const inventorySortButton = document.getElementById('inventorySortButton');
-    const inventoryOverflowEl = document.getElementById('inventoryOverflow');
-
     const reduceMotionQuery =
       typeof window !== 'undefined' && window.matchMedia
         ? window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -1480,7 +1480,6 @@
         markObjectiveComplete('gather-wood', { celebrate });
       }
     }
-    const playerHintEl = document.getElementById('playerHint');
     const drowningVignetteEl = document.getElementById('drowningVignette');
     const tarOverlayEl = document.getElementById('tarOverlay');
     const dimensionTransitionEl = document.getElementById('dimensionTransition');

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -531,6 +531,7 @@
       this.showBriefingOverlay();
       this.updateLocalScoreEntry('start');
       this.loadScoreboard();
+      this.exposeDebugInterface();
       this.renderFrame(performance.now());
     }
 
@@ -4136,6 +4137,48 @@
           this.currentDimensionIndex + 1
         }/${DIMENSION_THEME.length}</p>
       `;
+    }
+
+    exposeDebugInterface() {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      const scope = window;
+      scope.__INFINITE_RAILS_ACTIVE_EXPERIENCE__ = this;
+      scope.__INFINITE_RAILS_DEBUG__ = {
+        experience: this,
+        getSnapshot: () => this.getDebugSnapshot(),
+      };
+      try {
+        scope.dispatchEvent(
+          new CustomEvent('infinite-rails:start', {
+            detail: {
+              mode: 'simple',
+              timestamp: Date.now(),
+            },
+          }),
+        );
+      } catch (error) {
+        console.debug('Debug event dispatch failed', error);
+      }
+    }
+
+    getDebugSnapshot() {
+      return {
+        started: this.started,
+        dimension: this.dimensionSettings?.name ?? null,
+        dimensionIndex: this.currentDimensionIndex,
+        voxelColumns: this.columns?.size ?? 0,
+        portalReady: Boolean(this.portalReady),
+        portalActivated: Boolean(this.portalActivated),
+        zombieCount: Array.isArray(this.zombies) ? this.zombies.length : 0,
+        golemCount: Array.isArray(this.golems) ? this.golems.length : 0,
+        score: Math.round(this.score ?? 0),
+        hotbarSlots: Array.isArray(this.hotbar) ? this.hotbar.length : 0,
+        sceneChildren: this.scene?.children?.length ?? 0,
+        hudActive:
+          typeof document !== 'undefined' ? document.body.classList.contains('game-active') : false,
+      };
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure DOM handles consumed by the simple sandbox are queried before it is instantiated so the experience can start without reference errors
- expose a debug snapshot interface from the simple experience so tooling and tests can observe game state when the sandbox boots
- expand the Playwright smoke test to exercise the sandbox path, validate HUD and scoreboard state, and ignore expected offline asset fallbacks

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d832384828832bafa2dda76de1cd28