### PR TITLE
Improve render instrumentation for the advanced renderer

### DIFF
--- a/script.js
+++ b/script.js
@@ -2605,6 +2605,7 @@
     let virtualJoystickReady = false;
 
     let renderer;
+    const renderClock = new THREE.Clock();
     let scene;
     let camera;
     let worldGroup;
@@ -4700,6 +4701,10 @@
           );
           voxelIslandAssets.instancingFallbackNotified = true;
         }
+      }
+      voxelIslandAssets.tileCount = index;
+      if (typeof console !== 'undefined') {
+        console.log(`World generated: ${index} voxels`);
       }
     }
 
@@ -10835,6 +10840,10 @@
       entityGroup.add(playerMesh);
       attachPlayerKeyLight(playerMesh);
 
+      if (typeof console !== 'undefined') {
+        console.log('Steve visible in scene');
+      }
+
       const hairNode = playerMesh.getObjectByName('Hair') ?? null;
       const fringeNode = playerMesh.getObjectByName('Fringe') ?? null;
 
@@ -14485,6 +14494,9 @@
         const cycleRatio = THREE.MathUtils.clamp(DEFAULT_DAY_START_RATIO, 0, 0.99);
         state.elapsed = state.dayLength * cycleRatio;
       }
+      renderClock.stop();
+      renderClock.start();
+      renderClock.getDelta();
       teardownPreviewScene();
       resetRendererUniformCaches();
       pendingUniformSanitizations = Math.max(pendingUniformSanitizations, 2);
@@ -14674,10 +14686,8 @@
     const TARGET_FRAME_TIME = 1 / 60;
     let frameAccumulator = 0;
 
-    function loop(timestamp) {
-      if (!state.prevTimestamp) state.prevTimestamp = timestamp;
-      const delta = (timestamp - state.prevTimestamp) / 1000;
-      state.prevTimestamp = timestamp;
+    function loop() {
+      const delta = Math.min(renderClock.getDelta(), 0.12);
       frameAccumulator += delta;
       frameAccumulator = Math.min(frameAccumulator, TARGET_FRAME_TIME * 5);
       while (frameAccumulator >= TARGET_FRAME_TIME) {


### PR DESCRIPTION
## Summary
- add a dedicated THREE.Clock instance to drive the main render loop with clamped deltas
- emit explicit console logs when the voxel island and player model finish initialising
- reset the render clock whenever a new run starts to keep timing consistent between sessions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d83865befc832bb3e92abde6cc46b1