### PR TITLE
Switch sandbox camera to orthographic frustum

### DIFF
--- a/docs/feature-verification.md
+++ b/docs/feature-verification.md
@@ -3,14 +3,14 @@
 This document maps the requested experience requirements to concrete implementations in the current codebase.
 
 ## Rendering and World Generation
-- Three.js scene setup, lighting, and render loop are established inside the simplified experience, including sun and hemisphere lights plus a delta-clamped animation frame.【F:simple-experience.js†L900-L960】【F:simple-experience.js†L2656-L2675】
-- Procedural 64×64 voxel island generation populates the world with grass, dirt, and stone cubes, logging the total voxel count after chunk creation.【F:simple-experience.js†L1971-L2051】
+- Three.js scene setup, lighting, and render loop are established inside the simplified experience, including sun and hemisphere lights plus a delta-clamped animation frame.【F:simple-experience.js†L912-L986】【F:simple-experience.js†L2850-L2869】
+- Procedural 64×64 voxel island generation populates the world with grass, dirt, and stone cubes, logging the total voxel count after chunk creation.【F:simple-experience.js†L1984-L2059】
 
 ## Player Visibility and First-Person Perspective
-- The Steve model (with idle animation fallback) loads via `GLTFLoader`, scales appropriately, and anchors the camera for a first-person perspective with visible arms.【F:simple-experience.js†L1740-L1784】【F:simple-experience.js†L1786-L1876】
+- The Steve model (with idle animation fallback) loads via `GLTFLoader`, scales appropriately, and anchors the camera for a first-person perspective with visible arms.【F:simple-experience.js†L1740-L1923】
 
 ## Input, Movement, and Interaction
-- Keyboard and mouse inputs support WASD locomotion, jumping, pointer-lock mining/placing, and yaw-only look, while mobile pointer controls add a virtual joystick and touch-friendly action buttons.【F:simple-experience.js†L1326-L1519】【F:simple-experience.js†L2483-L2620】
+- Keyboard and mouse inputs support WASD locomotion, jumping, pointer-lock mining/placing, and yaw-only look, while mobile pointer controls add a virtual joystick and touch-friendly action buttons.【F:simple-experience.js†L1326-L1518】【F:simple-experience.js†L2676-L2885】
 
 ## Entities, Combat, and Survival Systems
 - Zombies spawn during night cycles, path toward the player, inflict damage on contact, and trigger heart depletion. Iron golems auto-spawn, intercept zombies, and provide allied defence.【F:simple-experience.js†L2904-L3093】
@@ -28,7 +28,7 @@ This document maps the requested experience requirements to concrete implementat
 - Score merges also power the in-world overlays: the victory state shows your live rank, while the portal progress HUD and hint system reference the latest sync results to keep explorers informed.【F:simple-experience.js†L4058-L4098】【F:simple-experience.js†L4040-L4089】
 
 ## Performance and Polish Considerations
-- Delta-based animation pacing, chunk-level frustum culling, and cached GLTF assets keep the experience close to the 60 FPS target.【F:simple-experience.js†L1923-L2051】【F:simple-experience.js†L2656-L2799】
+- Delta-based animation pacing, chunk-level frustum culling, and cached GLTF assets keep the experience close to the 60 FPS target.【F:simple-experience.js†L1984-L2059】【F:simple-experience.js†L2850-L3055】
 - Ambient hints, HUD tooltips, and accessibility-friendly overlays guide the user through onboarding and advanced mechanics.【F:index.html†L66-L204】【F:index.html†L205-L410】
 
 ## Audio, Mobile, and Immersion Polish

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -4,17 +4,17 @@ The sandbox renderer now delivers the end-to-end gameplay loop outlined in the "
 
 | Spec Area | Current Status | Evidence Summary |
 | --- | --- | --- |
-| **Initialization & Onboarding** | ✅ Implemented | Loading the page instantiates the sandbox renderer, fades the briefing overlay, and locks the camera to the player rig with pointer lock and tutorial prompts.【F:simple-experience.js†L520-L599】【F:index.html†L205-L324】 |
-| **Procedural World & Lighting** | ✅ Implemented | `buildTerrain()` generates the 64×64 voxel island, applies fog/sky palettes per dimension, and animates the hemisphere/sun lights on a 600-second cycle.【F:simple-experience.js†L1984-L2057】【F:simple-experience.js†L2656-L2799】 |
-| **Player Visibility & First-Person Perspective** | ✅ Implemented | Steve's GLTF rig loads with idle animation and anchors the camera to animated arms for a stable first-person view.【F:simple-experience.js†L1740-L1876】 |
-| **Movement, Input & Mining/Placement** | ✅ Implemented | WASD + pointer lock movement, virtual joystick controls, and raycast-driven mining/placement update the world and inventory every frame.【F:simple-experience.js†L2641-L2760】【F:simple-experience.js†L3300-L3392】 |
+| **Initialization & Onboarding** | ✅ Implemented | Loading the page instantiates the sandbox renderer, fades the briefing overlay, and locks the camera to the player rig with pointer lock and tutorial prompts.【F:simple-experience.js†L515-L603】【F:index.html†L205-L324】 |
+| **Procedural World & Lighting** | ✅ Implemented | `buildTerrain()` generates the 64×64 voxel island, applies fog/sky palettes per dimension, and animates the hemisphere/sun lights on a 600-second cycle.【F:simple-experience.js†L1984-L2060】【F:simple-experience.js†L3064-L3080】 |
+| **Player Visibility & First-Person Perspective** | ✅ Implemented | Steve's GLTF rig loads with idle animation and anchors the camera to animated arms for a stable first-person view.【F:simple-experience.js†L1740-L1923】 |
+| **Movement, Input & Mining/Placement** | ✅ Implemented | WASD + pointer lock movement, virtual joystick controls, and raycast-driven mining/placement update the world and inventory every frame.【F:simple-experience.js†L2676-L2885】【F:simple-experience.js†L3300-L3392】 |
 | **Entities, Combat & Survival** | ✅ Implemented | Nightly zombie spawns chase the player, iron golems intercept threats, and heart/air HUD elements react to damage and underwater exposure.【F:simple-experience.js†L2888-L3099】【F:simple-experience.js†L3897-L3970】 |
 | **Crafting, Inventory & Score Feedback** | ✅ Implemented | The drag-and-drop crafting grid validates ordered recipes, updates score tallies, and syncs the hotbar/inventory state with the HUD.【F:simple-experience.js†L3271-L3655】 |
 | **Portals, Dimensions & Progression** | ✅ Implemented | Portal frames activate with shader swirls, award progression points, swap dimension physics, and culminate in the Netherite victory flow.【F:simple-experience.js†L2108-L2462】【F:simple-experience.js†L3735-L3964】 |
-| **Backend Sync & SSO Hooks** | ✅ Implemented | Leaderboard fetch/post routines push scores to the configured API, while Google Sign-In integrates via GIS and gapi fallbacks with persistent identity storage.【F:simple-experience.js†L593-L710】【F:script.js†L720-L938】 |
+| **Backend Sync & SSO Hooks** | ✅ Implemented | Leaderboard fetch/post routines push scores to the configured API, while Google Sign-In integrates via GIS and gapi fallbacks with persistent identity storage.【F:simple-experience.js†L605-L710】【F:script.js†L720-L938】 |
 | **Victory & Leaderboard Presentation** | ✅ Implemented | The dimension briefing panel doubles as a victory summary, surfacing the player’s run score, leaderboard rank, and replay button when the Eternal Ingot is secured.【F:simple-experience.js†L4058-L4098】 |
 | **UI Feedback & Accessibility** | ✅ Implemented | HUD overlays, tooltips, modals, and responsive layouts update dynamically and honour reduced-motion/accessibility settings.【F:index.html†L66-L204】【F:simple-experience.js†L3972-L4140】 |
-| **Performance & Asset Optimisation** | ✅ Implemented | Delta-time pacing, chunk-level culling, cached GLTF assets, and pointer-lock throttling maintain the 60 FPS target even under load.【F:simple-experience.js†L1984-L2057】【F:simple-experience.js†L2656-L2799】 |
+| **Performance & Asset Optimisation** | ✅ Implemented | Delta-time pacing, chunk-level culling, cached GLTF assets, and pointer-lock throttling maintain the 60 FPS target even under load.【F:simple-experience.js†L1984-L2059】【F:simple-experience.js†L2850-L3055】 |
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- replace the sandbox renderer's perspective camera with an orthographic frustum sized to the viewport for the requested Minecraft-style stability
- keep the player spawn centred at the island crest, initialise yaw toward the rail direction, and refresh the projection whenever the canvas resizes
- refresh the spec compliance and feature verification docs so their evidence citations match the new line locations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d839d77fe8832b954acf52aba8b91c