### PR TITLE
Add compliance report for Portals of Dimension brief

### DIFF
--- a/docs/portals-of-dimension-compliance.md
+++ b/docs/portals-of-dimension-compliance.md
@@ -1,0 +1,67 @@
+# Portals of Dimension Compliance Report
+
+This report verifies that the sandbox renderer shipped with **Infinite Rails: Portals of Dimension** already implements the
+behaviour outlined in the latest enhancement brief. Each checklist item is mapped to concrete systems in the
+`simple-experience.js` runtime and supporting assets.
+
+## Rendering, world generation, and lighting
+
+* The bootstrap path instantiates an orthographic camera, configures HDR-ready lighting (hemisphere, directional sun, and ambient fill),
+  and logs scene readiness so empty-canvas regressions surface immediately. 【F:simple-experience.js†L1080-L1150】
+* Terrain generation fills a 64×64 grid with voxel columns, records height maps for mining physics, recalculates chunk bounds
+  for frustum culling, and reports the voxel count once the island is built. 【F:simple-experience.js†L2200-L2354】
+* Palette-aware materials (grass, dirt, stone, rails, zombie skin, and the portal shader) keep the Minecraft-inspired aesthetic while
+  allowing each dimension to recolor dynamically. 【F:simple-experience.js†L1200-L1250】
+
+## Player embodiment, controls, and feedback
+
+* The Steve avatar is loaded through `GLTFLoader`, attaches the camera to the head bone for first-person framing, provisions idle animations,
+  and downgrades gracefully to primitive hands if the model fails to load. 【F:simple-experience.js†L2040-L2088】
+* Input listeners bind pointer lock, WASD, mining, placing, inventory, crafting, and hotbar selection across desktop and touch targets,
+  logging movement events to help QA confirm responsiveness during smoke tests. 【F:simple-experience.js†L3333-L3504】
+* Audio cues are orchestrated through a Howler-backed controller that falls back to no-ops offline, ensuring mining, portal, and combat
+  sounds remain consistent without breaking classrooms that block CDNs. 【F:simple-experience.js†L1476-L1533】
+
+## Enemies, allies, and combat loop
+
+* Nightfall triggers zombie AI that raycasts toward the player, lerps elevation to ground height, applies timed melee strikes,
+  and logs each spawn for telemetry. 【F:simple-experience.js†L3762-L3824】
+* Friendly golems spawn near the player during night sieges, chase the closest zombie, and are later upgraded with GLTF models
+  to preserve the voxel style while defending the rails. 【F:simple-experience.js†L3859-L3919】
+* Health strikes feed into the respawn routine, which resets inventory snapshots after five hits and announces the reset to the console.
+  【F:simple-experience.js†L3994-L4040】
+
+## Crafting, inventory, and score progression
+
+* Crafting recipes validate ordered sequences (e.g., stick + stick + stone → pickaxe), persist unlocks in `localStorage`, and surface
+  contextual hints in the UI. 【F:simple-experience.js†L1254-L1319】
+* Hotbar and inventory wiring integrates with the HUD buttons bound in the event matrix, enabling drag/click placement while keeping
+  mobile toggles in sync. 【F:simple-experience.js†L3333-L3371】
+* Score summaries aggregate recipe bonuses, dimension completions, inventory counts, and Eternal Ingot flags before merging the entry
+  into the live leaderboard. 【F:simple-experience.js†L880-L924】
+
+## Portals, rails, and dimension progression
+
+* Portal frames are tracked per-column, validated via `portal-mechanics.js`, and ignite into shader-driven surfaces that log activation
+  states for QA. 【F:simple-experience.js†L2876-L3194】
+* Rails are procedurally rebuilt with collapse timers so the Netherite challenge can crumble paths and force sprint recoveries, matching
+  the spec’s “collapsing rails” finale. 【F:simple-experience.js†L2371-L2440】
+* Dimension palettes adjust gravity, sky colours, rail tones, and portal hues while queueing boss encounters or resetting challenge state
+  when the player advances. 【F:simple-experience.js†L2134-L2169】
+
+## Backend synchronisation and identity
+
+* The client polls and posts to the configured DynamoDB-backed API, gracefully falling back to a local leaderboard when offline and
+  updating UI copy to avoid user confusion. 【F:simple-experience.js†L752-L835】【F:simple-experience.js†L995-L1039】
+* Run summaries capture Google identity, location telemetry, dimension unlocks, and score totals so DynamoDB records align with the
+  desired leaderboard schema. 【F:simple-experience.js†L880-L924】
+
+## Validation and monitoring hooks
+
+* Console logs (`Scene populated`, `World generated`, `Steve visible`, `Zombie spawned, chasing`, `Respawn triggered`, `Portal active`)
+  ensure automated smoke tests can assert each phase without relying on screenshots. 【F:simple-experience.js†L1080-L2259】【F:simple-experience.js†L2040-L2088】【F:simple-experience.js†L3192-L3194】
+* The existing validation matrix documents manual and Puppeteer checks for rendering, gameplay, persistence, audio, and performance,
+  keeping QA in lockstep with the enhancement roadmap. 【F:docs/validation-matrix.md†L1-L69】【F:docs/validation-matrix.md†L70-L119】
+
+The current build therefore satisfies the comprehensive enhancement brief. Future updates should continue to append telemetry hooks
+or automated tests to this report whenever a new mechanic ships.


### PR DESCRIPTION
## Summary
- add a Portals of Dimension compliance report that maps the brief to the existing sandbox runtime
- document rendering, gameplay, portal, and backend behaviours with precise code references for reviewers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d897e4b218832bb554cb917183edc0