### PR TITLE
Add identity persistence and geolocation capture to simple mode

### DIFF
--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -31,6 +31,7 @@ Use it as a quick reference when planning manual or automated regression passes.
 | Requirement ID | Validation Method | Success Criteria | Test Scenarios |
 | --- | --- | --- | --- |
 | MP-01 / MP-02 | AWS console queries combined with multi-device login tests; Puppeteer launches dual tabs for sync timing. | • State synchronises in under two seconds (observed 1.4s tab-to-tab).<br>• Leaderboard updates live using mock scores. | • Scenario: Log in on mobile, play a session, then switch to desktop—score persists. |
+| MP-03 | Browser geolocation prompt exercised via Playwright; verify localStorage snapshot. | • Location prompt appears on first launch.<br>• Leaderboard rows include anonymised lat/lon label on approval.<br>• Decline path stores “Location permission denied” without crashes. | • Scenario: Accept geolocation once, refresh, confirm stored coordinates hydrate UI before new request. |
 
 ## Audio experience
 


### PR DESCRIPTION
## Summary
- persist the simplified experience identity profile so display name, google id, and location survive reloads
- add an automatic geolocation capture helper with throttling and update the run loop to hydrate leaderboard/location labels
- document the new geolocation validation scenario in the QA matrix

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8a55b40f4832ba210cbf84c61da28