### PR TITLE
Show unlocked dimensions on leaderboard entries

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2735,6 +2735,23 @@ body.sidebar-open .player-hint {
   color: var(--text-secondary);
 }
 
+.leaderboard-table tbody td[data-cell='dimensions'] {
+  white-space: normal;
+}
+
+.leaderboard-dimension-count {
+  display: block;
+  font-weight: 600;
+}
+
+.leaderboard-dimension-list {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  color: rgba(245, 247, 251, 0.7);
+}
+
 .leaderboard-table tbody td[data-cell='updated'] {
   font-size: 0.72rem;
   color: rgba(242, 245, 250, 0.6);

--- a/tests/scoreboard-utils.test.js
+++ b/tests/scoreboard-utils.test.js
@@ -14,7 +14,13 @@ describe('scoreboard utils', () => {
     const input = [
       { id: 'b', name: 'Beta', score: 100 },
       { googleId: 'c-google', displayName: 'Gamma', points: '250' },
-      { playerId: 'a-player', dimensions: '3', inventoryCount: 5, runtimeSeconds: 42 },
+      {
+        playerId: 'a-player',
+        dimensions: '3',
+        inventoryCount: 5,
+        runtimeSeconds: 42,
+        dimensionNames: ['Origin', 'Rock'],
+      },
     ];
     const result = normalizeScoreEntries(input);
     expect(result).toHaveLength(3);
@@ -24,6 +30,7 @@ describe('scoreboard utils', () => {
     expect(result[2].dimensionCount).toBe(3);
     expect(result[2].runTimeSeconds).toBe(42);
     expect(typeof result[2].id).toBe('string');
+    expect(result[2].dimensionLabels).toEqual(['Origin', 'Rock']);
   });
 
   it('formats numbers and runtimes for the scoreboard', () => {
@@ -44,14 +51,26 @@ describe('scoreboard utils', () => {
 
   it('inserts or updates scoreboard entries while keeping order', () => {
     const entries = [
-      { id: 'alpha', name: 'Alpha', score: 100 },
+      { id: 'alpha', name: 'Alpha', score: 100, dimensionLabels: ['Origin'] },
       { id: 'beta', name: 'Beta', score: 80 },
     ];
-    const updated = upsertScoreEntry(entries, { id: 'beta', name: 'Beta', score: 120 });
+    const updated = upsertScoreEntry(entries, {
+      id: 'beta',
+      name: 'Beta',
+      score: 120,
+      dimensionLabels: ['Origin', 'Rock'],
+    });
     expect(updated[0].id).toBe('beta');
     expect(updated[0].score).toBe(120);
-    const added = upsertScoreEntry(updated, { id: 'gamma', name: 'Gamma', score: 90 });
+    expect(updated[0].dimensionLabels).toEqual(['Origin', 'Rock']);
+    const added = upsertScoreEntry(updated, {
+      id: 'gamma',
+      name: 'Gamma',
+      score: 90,
+      dimensionLabels: ['Origin – Grassland Threshold'],
+    });
     expect(added.map((e) => e.id)).toEqual(['beta', 'alpha', 'gamma']);
     expect(entries[1].score).toBe(80);
+    expect(added[2].dimensionLabels).toEqual(['Origin – Grassland Threshold']);
   });
 });


### PR DESCRIPTION
## Summary
- normalise dimension label metadata in the shared scoreboard utilities so entries retain their unlocked realms
- surface the dimension list inside the leaderboard table UI and include it in snapshot/score sync payloads
- seed sample data and unit tests with dimension labels to validate the new behaviour

## Testing
- npm test
- npm run test:e2e *(fails: Playwright browser bundle missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d927d2af60832b8ca6cf0628fb3dbd