### PR TITLE
Add fulfillment digest for Portals of Dimension sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Infinite Dimension is a browser-based voxel survival-puzzle experience inspired 
 - survival systems spanning health, bubbles, zombies, iron golems, crafting, scoring, and sequential dimension unlocks; and
 - backend-aware score syncing, Google Sign-In hooks, and responsive HUD/leaderboard overlays.
 
-Advanced renderer work is still underway, so the interactive sandbox renderer now boots by default to guarantee the full 3D experience the moment the page loads. See [docs/portals-of-dimension-plan.md](docs/portals-of-dimension-plan.md) for the roadmap that bridges the sandbox and the long-term vision.
+Advanced renderer work is still underway, so the interactive sandbox renderer now boots by default to guarantee the full 3D experience the moment the page loads. See [docs/portals-of-dimension-plan.md](docs/portals-of-dimension-plan.md) for the roadmap that bridges the sandbox and the long-term vision, and consult [docs/portals-of-dimension-fulfillment.md](docs/portals-of-dimension-fulfillment.md) for a citation-rich snapshot that ties each gameplay loop back to its shipped implementation.
 
 ## Current status
 

--- a/docs/portals-of-dimension-fulfillment.md
+++ b/docs/portals-of-dimension-fulfillment.md
@@ -1,0 +1,29 @@
+# Portals of Dimension Fulfillment Summary
+
+This digest maps the highest-priority requirements from the "Comprehensive Analysis and Enhancement Specifications" brief to the shipped sandbox implementation. Use it as a quick compliance reference when verifying gameplay loops or onboarding collaborators.
+
+## Rendering and World Bootstrap
+- `setupScene()` spins up the Three.js r161 pipeline with an orthographic camera anchored to a first-person rig, ACES tonemapping, hemisphere/directional lighting, and grouped scene layers before logging a populated scene.【F:simple-experience.js†L1191-L1271】
+- `buildTerrain()` regenerates the 64×64 voxel island on load, filling heightmaps, seeding chunk groups, and reporting voxel totals so regressions in the render loop are immediately visible in the console.【F:simple-experience.js†L2428-L2505】
+
+## Player Presence and Controls
+- `loadPlayerCharacter()` attaches the Steve GLTF (or a fallback cube) to the player rig, binds the camera to the head bone for first-person view, and boots the idle animation mixer so the avatar is always visible in-scene.【F:simple-experience.js†L2239-L2308】
+- `renderFrame()` drives the 60 FPS loop, applying day/night progression, portal animation, AI updates, scoreboard polling, and finally rendering the scene with `renderer.render(scene, camera)`. Movement input from `updateMovement()` respects pointer lock, joystick/touch states, jump physics, and gravity scaling for each dimension.【F:simple-experience.js†L3774-L3858】
+
+## Survival Entities and Combat
+- Nightfall triggers `updateZombies()`, which continuously spawns pursuing zombies at the island edge, lerps them to ground height, and damages the player on contact. Each spawn logs to the console while `spawnZombie()` swaps placeholder meshes with GLTF upgrades when available.【F:simple-experience.js†L4024-L4086】
+- Iron golem patrols, health depletion, respawns, and camera impulses for damage/mining are orchestrated through the same module, ensuring the survival loop never idles during combat.【F:simple-experience.js†L4198-L4256】
+
+## Crafting, Inventory, and Feedback
+- The crafting handlers gate ordered recipes, enforce inventory counts, apply score rewards, persist unlocks, and fire Howler-backed cues whenever `handleCraftButton()` completes a sequence. Inventory clicks, clear, and sort flows all reuse the same state machine.【F:simple-experience.js†L4706-L4817】
+- HUD refreshes cascade through `updateHud()`, `updatePortalProgress()`, and `updateDimensionInfoPanel()`, keeping hearts, portal readiness, and dimension metadata in sync with every action while surfacing leaderboard rank after victory.【F:simple-experience.js†L5017-L5113】
+
+## Portals, Dimensions, and Progression
+- Portal assembly relies on anchor/grid helpers that hide interior voxels, validate 4×3 frames, ignite via `PortalMechanics`, and update interior validity/portal progress. Successful ignition awards score, shows hints, and feeds the transition pipeline.【F:simple-experience.js†L3204-L3390】
+- Dimension advancement resets terrain, rails, zombies, golems, and boss challenge state while applying realm-specific gravity/colour palettes and queuing scoreboard sync events, culminating in the Netherite victory routine.【F:simple-experience.js†L3520-L3567】
+
+## Backend Sync and Leaderboards
+- Scoreboard widgets call `loadScoreboard()` to pull top runs (with offline fallbacks) and `scheduleScoreSync()`/`flushScoreSync()` to push updated summaries whenever the player crafts, unlocks dimensions, or completes the game.【F:simple-experience.js†L856-L1159】
+- Victory overlays query `getPlayerLeaderboardRank()` so the post-run panel highlights score, leaderboard standing, and the replay affordance without leaving the HUD stale.【F:simple-experience.js†L5074-L5113】
+
+With these systems in place, the sandbox renderer satisfies the actionable goals from the enhancement brief: a populated world, visible Steve avatar, reactive survival loop, crafting and portals, and live scoreboard plumbing. The document should be updated as additional advanced-renderer milestones ship so stakeholders can trace coverage at a glance.


### PR DESCRIPTION
## Summary
- add a citation-rich fulfilment digest that maps the enhancement brief to the sandbox implementation
- link the new digest from the README so contributors can find the compliance snapshot quickly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d92a0d5b44832b97dd8cd8a1420b2a