### PR TITLE
Document prompt coverage for sandbox renderer

### DIFF
--- a/docs/spec-prompts-fulfillment-digest.md
+++ b/docs/spec-prompts-fulfillment-digest.md
@@ -1,0 +1,33 @@
+# Coding Prompt Fulfilment Digest
+
+This digest crosswalks the "Detailed Prompts for Coding Agents" from the enhancement brief with the shipped sandbox implementation. Each entry calls out the concrete systems that satisfy the requested behaviour.
+
+## Rendering and world generation
+- `setupScene()` provisions the orthographic camera, lighting rig, and renderer specified in the rendering prompt, then anchors the player rig before any gameplay begins.【F:simple-experience.js†L1191-L1233】
+- `buildTerrain()` regenerates the 64×64 island, seeds chunk metadata, and logs both voxel and block totals ("World generated: 4096 voxels") so blank-scene regressions are immediately visible.【F:simple-experience.js†L2428-L2502】
+
+## Player visibility and first-person view
+- `loadPlayerCharacter()` attaches the GLTF-driven Steve mesh to the rig, moves the camera into the head pivot for first-person play, and falls back to a voxel avatar if the model fails, ensuring the "Steve visible" requirement is always met.【F:simple-experience.js†L2240-L2330】
+- The dedicated arm loader keeps the first-person hands synced to the camera so mining animations remain present even if the main model is unavailable.【F:simple-experience.js†L2192-L2237】
+
+## Input controls and responsiveness
+- Event binding inside `bindEvents()` wires pointer lock, WASD, mouse mining/placing, hotbar taps, and the virtual joystick, covering every interaction described in the control prompt.【F:simple-experience.js†L3600-L3658】
+- Movement handlers constrain camera pitch, track pressed keys, print the "Moving forward" debug cue, and keep delta-based acceleration aligned with Minecraft-style movement.【F:simple-experience.js†L3680-L3864】
+
+## Entities, zombies, and golem defence
+- Zombie AI spawns on night cycles, chases the player, and applies contact damage with the required debug log, fulfilling the combat prompt.【F:simple-experience.js†L4024-L4086】
+- Iron golems spawn near the player, pursue the nearest zombie, and reward defensive kills with score and hint feedback, mirroring the protective behaviour described in the specification.【F:simple-experience.js†L4151-L4214】
+
+## Crafting, inventory, and HUD dynamics
+- Inventory helpers stack items, update the hotbar, and surface accessibility labels so the crafting drag-and-drop workflow always reflects current resources.【F:simple-experience.js†L4454-L4590】
+- Crafting and inventory panels aggregate totals, expose draggable entries, and keep the satchel overflow banner accurate, ensuring the UI reacts immediately to recipe success or resource changes.【F:simple-experience.js†L4593-L4650】
+
+## Portals, dimensions, and progression
+- Portal ignition validates 4×3 frames, swaps in the shader plane, emits the "Portal active" log, and notifies the HUD, matching the portal activation prompt.【F:simple-experience.js†L3312-L3441】
+- Dimension advancement reapplies biome physics, awards points, and updates gravity or palette modifiers before continuing progression toward the Netherite finale.【F:simple-experience.js†L3488-L3520】
+
+## Backend sync, identity, and polish
+- Scoreboard polling and POST syncs push run summaries to `${apiBaseUrl}/scores`, hydrate local entries, and surface user-facing status text that mirrors the backend prompt expectations.【F:simple-experience.js†L867-L1170】
+- Identity helpers in the host shell persist Google SSO profiles, update HUD labels, and stream location changes back into the sandbox so sign-in flows stay connected to gameplay.【F:script.js†L826-L930】
+
+These references confirm that each automation-ready prompt from the specification maps to live systems inside the sandbox renderer.


### PR DESCRIPTION
## Summary
- add a spec digest that maps each coding-agent prompt to the shipped sandbox systems with direct file references

## Testing
- npm test
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d92c513fbc832bad8866489060fe48