### PR TITLE
Add live Made by Manu footer and sync to HUD

### DIFF
--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -16,6 +16,7 @@ Use it as a quick reference when planning manual or automated regression passes.
 | --- | --- | --- | --- |
 | UI-01 | Browser load; click tests. | Landing loads in <2s; buttons navigate correctly; animations smooth. | Scenario: Open URL—see title, logo, start game to gameplay. |
 | UI-02 / UI-05 | Interaction simulation; guide review. | HUD non-obstructive; guide covers 100% controls; dynamics trigger as specified. | Scenario: First load—hints appear; open guide, interact demo. |
+| UI-06 | Visual inspection with console logging of HUD events. | Footer remains fixed, updates summary within 1s of dimension or score changes, and respects accessibility labels. | Scenario: Mine blocks to change score, ignite a portal, and observe footer swap from "explore" to "ready" to "transition" states. |
 
 ## Gameplay systems
 

--- a/index.html
+++ b/index.html
@@ -1038,6 +1038,28 @@
       <p>Made by Manu</p>
     </footer>
 
+    <footer
+      class="made-by-manu"
+      id="siteFooter"
+      role="contentinfo"
+      aria-live="polite"
+      data-hint="Made by Manu footer with live run summary."
+    >
+      <span class="made-by-manu__label" aria-hidden="true">Made by Manu</span>
+      <span class="sr-only">Experience crafted by Manu</span>
+      <span class="made-by-manu__summary">
+        Score
+        <span id="footerScore" class="made-by-manu__metric" aria-label="Current score">0</span>
+        · Dimension
+        <span id="footerDimension" class="made-by-manu__metric" aria-label="Current dimension"
+          >Origin Grassland</span
+        >
+        <span id="footerStatus" class="made-by-manu__status" aria-label="Status message"
+          >Stabilising the Origin rail.</span
+        >
+      </span>
+    </footer>
+
     <script src="vendor/howler-stub.js" defer></script>
     <script>
       window.APP_CONFIG = Object.assign(

--- a/script.js
+++ b/script.js
@@ -1294,6 +1294,10 @@
             closeInventoryButton,
             openInventoryButtons: [toggleExtendedBtn].filter(Boolean),
             pointerHintEl,
+            footerEl: document.getElementById('siteFooter'),
+            footerScoreEl: document.getElementById('footerScore'),
+            footerDimensionEl: document.getElementById('footerDimension'),
+            footerStatusEl: document.getElementById('footerStatus'),
           },
         });
       } catch (error) {

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -489,9 +489,14 @@
       this.hotbarEl = this.ui.hotbarEl || null;
       this.playerHintEl = this.ui.playerHintEl || null;
       this.pointerHintEl = this.ui.pointerHintEl || null;
+      this.footerEl = this.ui.footerEl || null;
+      this.footerScoreEl = this.ui.footerScoreEl || null;
+      this.footerDimensionEl = this.ui.footerDimensionEl || null;
+      this.footerStatusEl = this.ui.footerStatusEl || null;
       this.pointerHintActive = false;
       this.pointerHintHideTimer = null;
       this.pointerHintLastMessage = '';
+      this.lastHintMessage = '';
       this.craftingModal = this.ui.craftingModal || null;
       this.craftSequenceEl = this.ui.craftSequenceEl || null;
       this.craftingInventoryEl = this.ui.craftingInventoryEl || null;
@@ -4880,6 +4885,8 @@
     showHint(message) {
       if (!this.playerHintEl || !message) return;
       this.playerHintEl.textContent = message;
+      this.lastHintMessage = message;
+      this.updateFooterSummary();
     }
 
     handleHotbarClick(event) {
@@ -5238,6 +5245,7 @@
       this.updateInventoryUi();
       this.updateDimensionInfoPanel();
       this.updatePortalProgress();
+      this.updateFooterSummary();
     }
 
     updatePortalProgress() {
@@ -5276,6 +5284,50 @@
         }
         portalProgressBar.style.setProperty('--progress', displayProgress.toFixed(2));
       }
+    }
+
+    updateFooterSummary() {
+      if (!this.footerEl) return;
+      const scoreValue = Math.round(this.score ?? 0);
+      if (this.footerScoreEl) {
+        this.footerScoreEl.textContent = scoreValue.toLocaleString();
+      }
+      const currentTheme = this.dimensionSettings ?? DIMENSION_THEME[this.currentDimensionIndex] ?? null;
+      const dimensionName = currentTheme?.name ?? 'Unknown Realm';
+      if (this.footerDimensionEl) {
+        this.footerDimensionEl.textContent = dimensionName;
+      }
+      let statusMessage = '';
+      if (this.victoryAchieved) {
+        statusMessage = 'Eternal Ingot secured — portals stabilised.';
+      } else if (this.portalActivated) {
+        const nextName = this.getNextDimensionName();
+        statusMessage = nextName ? `Crossing to ${nextName}.` : 'Crossing to the next realm.';
+      } else if (this.portalReady) {
+        statusMessage = 'Portal ready — ignite with F to travel.';
+      } else if (this.lastHintMessage) {
+        statusMessage = this.lastHintMessage;
+      } else if (currentTheme?.description) {
+        statusMessage = currentTheme.description;
+      } else {
+        statusMessage = 'Stabilising the portal network.';
+      }
+      if (this.footerStatusEl) {
+        this.footerStatusEl.textContent = statusMessage;
+      }
+      const state = this.victoryAchieved
+        ? 'victory'
+        : this.portalActivated
+          ? 'transition'
+          : this.portalReady
+            ? 'ready'
+            : 'explore';
+      this.footerEl.dataset.state = state;
+    }
+
+    getNextDimensionName() {
+      const nextTheme = DIMENSION_THEME[this.currentDimensionIndex + 1];
+      return nextTheme?.name ?? null;
     }
 
     updateDimensionInfoPanel() {

--- a/styles.css
+++ b/styles.css
@@ -5752,6 +5752,95 @@ body.game-active .hand-overlay {
   text-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
 }
 
+.made-by-manu {
+  position: fixed;
+  inset: auto 0 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem clamp(1.2rem, 4vw, 2.5rem);
+  background: linear-gradient(90deg, rgba(20, 30, 40, 0.92), rgba(10, 15, 25, 0.88));
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 -14px 24px rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.86);
+  font-family: 'Chakra Petch', 'Exo 2', system-ui, sans-serif;
+  font-size: clamp(0.8rem, 1.4vw, 0.95rem);
+  letter-spacing: 0.05em;
+  backdrop-filter: blur(6px);
+}
+
+.made-by-manu__label {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: clamp(0.75rem, 1.2vw, 0.9rem);
+  color: rgba(173, 216, 255, 0.9);
+  text-shadow: 0 0 8px rgba(0, 153, 255, 0.4);
+}
+
+.made-by-manu__summary {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.6rem;
+}
+
+.made-by-manu__metric {
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.made-by-manu__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding-left: 0.65rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  font-size: clamp(0.75rem, 1.3vw, 0.9rem);
+  color: rgba(200, 230, 255, 0.85);
+}
+
+.made-by-manu[data-state='victory'] {
+  background: linear-gradient(90deg, rgba(49, 20, 12, 0.95), rgba(128, 36, 20, 0.92));
+  border-top-color: rgba(255, 176, 0, 0.35);
+  box-shadow: 0 -16px 32px rgba(128, 36, 20, 0.45);
+}
+
+.made-by-manu[data-state='victory'] .made-by-manu__label {
+  color: rgba(255, 200, 120, 0.95);
+  text-shadow: 0 0 12px rgba(255, 160, 60, 0.55);
+}
+
+.made-by-manu[data-state='victory'] .made-by-manu__status {
+  color: rgba(255, 230, 204, 0.9);
+}
+
+.made-by-manu[data-state='ready'] .made-by-manu__status {
+  color: rgba(144, 238, 144, 0.9);
+}
+
+.made-by-manu[data-state='transition'] .made-by-manu__status {
+  color: rgba(255, 214, 153, 0.92);
+}
+
+.made-by-manu[data-state='explore'] .made-by-manu__status {
+  color: rgba(200, 230, 255, 0.85);
+}
+
+@media (max-width: 900px) {
+  .made-by-manu {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+    font-size: clamp(0.78rem, 2.6vw, 0.9rem);
+  }
+
+  .made-by-manu__status {
+    border-left: none;
+    padding-left: 0;
+  }
+}
+
 @media (max-width: 720px) {
   .hand-overlay {
     right: clamp(1rem, 5vw, 1.8rem);


### PR DESCRIPTION
## Summary
- add a fixed "Made by Manu" footer with live score, dimension, and status text
- wire the simple experience HUD to drive the footer state machine and status updates
- document the footer regression check in the validation matrix

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d94e2f619c832b83fa6bfe72bf953a