### PR TITLE
Ensure simple experience start reports readiness

### DIFF
--- a/script.js
+++ b/script.js
@@ -1310,6 +1310,12 @@
         const launchSimple = () => {
           try {
             simpleExperience.start();
+            if (!simpleExperience.started) {
+              throw new Error('Simple experience start completed without reporting an active session.');
+            }
+            if (console?.info) {
+              console.info('Simple experience ready — immersive sandbox initialised.');
+            }
           } catch (error) {
             console.error('Simple experience start failed; falling back to advanced mode.', error);
             startFailed = true;
@@ -1322,7 +1328,7 @@
           startButton.addEventListener('click', launchSimple, { once: true });
         }
         launchSimple();
-        if (!startFailed) {
+        if (!startFailed && simpleExperience.started) {
           setupSimpleExperienceIntegrations(simpleExperience);
           return;
         }


### PR DESCRIPTION
## Summary
- guard the simple experience bootstrap so integrations only attach when the 3D sandbox successfully marks itself as started
- add an informational log to confirm when the immersive sandbox is ready and fail fast if start() did not flip the started flag

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d95e63b73c832bbf93f45001a5be28