### PR TITLE
Add scoreboard utility regression tests and document validation coverage

### DIFF
--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -33,6 +33,7 @@ Use it as a quick reference when planning manual or automated regression passes.
 | --- | --- | --- | --- |
 | MP-01 / MP-02 | AWS console queries combined with multi-device login tests; Puppeteer launches dual tabs for sync timing. | • State synchronises in under two seconds (observed 1.4s tab-to-tab).<br>• Leaderboard updates live using mock scores. | • Scenario: Log in on mobile, play a session, then switch to desktop—score persists. |
 | MP-03 | Browser geolocation prompt exercised via Playwright; verify localStorage snapshot. | • Location prompt appears on first launch.<br>• Leaderboard rows include anonymised lat/lon label on approval.<br>• Decline path stores “Location permission denied” without crashes. | • Scenario: Accept geolocation once, refresh, confirm stored coordinates hydrate UI before new request. |
+| MP-04 | Automated unit test (`vitest run`) covering scoreboard normalisation helpers. | • Entries are sorted deterministically by score.<br>• Dimension labels deduplicate across mixed data sources.<br>• Location formatting degrades gracefully when metadata is missing. | • Scenario: Execute `vitest run`—the `scoreboard-utils` suite asserts ID ordering and formatted labels for mock payloads. |
 
 ## Audio experience
 

--- a/tests/scoreboard-utils.spec.js
+++ b/tests/scoreboard-utils.spec.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import scoreboardUtilsModule from '../scoreboard-utils.js';
+
+const scoreboardUtils = scoreboardUtilsModule.default ?? scoreboardUtilsModule;
+
+describe('scoreboard-utils', () => {
+  it('normalises entries and sorts descending by score while aggregating dimension labels', () => {
+    const entries = [
+      {
+        id: 'a',
+        score: 12,
+        dimensions: ['Origin', 'Rock'],
+        dimensionLabels: ['Tar'],
+      },
+      {
+        id: 'b',
+        points: 50,
+        dimensionSummary: 'Stone | Marble',
+      },
+      {
+        id: 'c',
+        score: 4,
+        dimensionNames: [
+          { id: 'netherite', name: 'Netherite' },
+          { id: 'origin', label: 'Origin' },
+        ],
+      },
+    ];
+
+    const normalised = scoreboardUtils.normalizeScoreEntries(entries);
+
+    expect(normalised.map((entry) => entry.id)).toEqual(['b', 'a', 'c']);
+    expect(normalised[0].dimensionLabels).toEqual(['Stone', 'Marble']);
+    expect(normalised[1].dimensionLabels).toEqual(['Tar', 'Origin', 'Rock']);
+    expect(normalised[2].dimensionLabels).toEqual(['Netherite', 'Origin']);
+  });
+
+  it('upserts entries preserving the highest score achieved', () => {
+    const initial = [
+      { id: 'player-1', score: 20, name: 'Explorer' },
+      { id: 'player-2', score: 10, name: 'Adventurer' },
+    ];
+
+    const afterImprovedScore = scoreboardUtils.upsertScoreEntry(initial, {
+      id: 'player-2',
+      score: 25,
+      dimensionCount: 3,
+    });
+
+    expect(afterImprovedScore.find((entry) => entry.id === 'player-2')).toMatchObject({
+      score: 25,
+      dimensionCount: 3,
+    });
+
+    const afterLowerScore = scoreboardUtils.upsertScoreEntry(afterImprovedScore, {
+      id: 'player-1',
+      score: 15,
+      dimensionCount: 2,
+    });
+
+    expect(afterLowerScore.find((entry) => entry.id === 'player-1')).toMatchObject({
+      score: 20,
+      dimensionCount: 2,
+    });
+  });
+
+  it('formats run time and location labels consistently', () => {
+    expect(scoreboardUtils.formatRunTime(65)).toBe('1m 5s');
+    expect(scoreboardUtils.formatRunTime(3725)).toBe('1h 2m');
+    expect(scoreboardUtils.formatRunTime(null)).toBe('—');
+
+    expect(
+      scoreboardUtils.formatLocationLabel({
+        location: { latitude: 51.5074, longitude: -0.1278 },
+      }),
+    ).toBe('Lat 51.5, Lon -0.1');
+
+    expect(
+      scoreboardUtils.formatLocationLabel({
+        locationLabel: 'Neo Grassland',
+        location: { latitude: 1, longitude: 2 },
+      }),
+    ).toBe('Neo Grassland');
+  });
+});


### PR DESCRIPTION
## Summary
- add a vitest suite for `scoreboard-utils` to verify score ordering, dimension label merging, and formatting helpers
- document the new automated coverage in the validation matrix under the multiplayer and persistence requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d96381515c832b99317b0ef819b2f9