### PR TITLE
Add spec regression guard

### DIFF
--- a/tests/spec-coverage.spec.js
+++ b/tests/spec-coverage.spec.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(__dirname, '..');
+const simpleExperiencePath = path.join(repoRoot, 'simple-experience.js');
+const scriptPath = path.join(repoRoot, 'script.js');
+
+const simpleExperienceSource = fs.readFileSync(simpleExperiencePath, 'utf8');
+const scriptSource = fs.readFileSync(scriptPath, 'utf8');
+
+describe('Portals of Dimension spec regression checks', () => {
+  it('keeps the procedural island and render loop configuration intact', () => {
+    expect(simpleExperienceSource).toMatch(/const WORLD_SIZE = 64/);
+    expect(simpleExperienceSource).toMatch(/new THREE\.OrthographicCamera/);
+    expect(simpleExperienceSource).toMatch(/World generated: \$\{columnCount\} voxels/);
+  });
+
+  it('ships the expected character and entity assets', () => {
+    expect(simpleExperienceSource).toMatch(/MODEL_URLS\s*=\s*\{/);
+    expect(simpleExperienceSource).toMatch(/steve\.gltf/);
+    expect(simpleExperienceSource).toMatch(/zombie\.gltf/);
+    expect(simpleExperienceSource).toMatch(/iron_golem\.gltf/);
+  });
+
+  it('exposes combat, portal, and crafting systems', () => {
+    expect(simpleExperienceSource).toMatch(/spawnZombie\(/);
+    expect(simpleExperienceSource).toMatch(/ignitePortal\(/);
+    expect(simpleExperienceSource).toMatch(/handleCraftButton\(/);
+  });
+
+  it('keeps backend sync hooks in place', () => {
+    expect(simpleExperienceSource).toMatch(/loadScoreboard\(/);
+    expect(simpleExperienceSource).toMatch(/flushScoreSync\(/);
+    expect(scriptSource.includes("apiBaseUrl.replace(/\\/$/, '')}/scores")).toBe(true);
+    expect(scriptSource.includes('google.accounts.id')).toBe(true);
+  });
+
+  it('publishes the sandbox constructor for the bootstrapper', () => {
+    expect(simpleExperienceSource).toMatch(/window\.SimpleExperience =/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Vitest regression test that watches for the key Portals of Dimension features already implemented in `simple-experience.js`

## Testing
- npm test
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d97bb815c8832bab11fd53bd7f76ca