### PR TITLE
Add QA verification digest for sandbox renderer

### DIFF
--- a/docs/portals-of-dimension-qa-verification.md
+++ b/docs/portals-of-dimension-qa-verification.md
@@ -1,0 +1,26 @@
+# Portals of Dimension QA Verification
+
+This note consolidates the evidence that the sandbox renderer now fulfils the "Comprehensive Analysis and Enhancement Specifications" brief. Each section links the requested behaviour to the shipped implementation so future reviews can jump straight to the relevant source.
+
+## Rendering, onboarding, and world generation
+- `SimpleExperience.start()` wires the full boot sequence: it hides the intro modal, sets up the Three.js scene, procedurally builds the island, positions Steve, spawns loot chests, binds inputs, and displays the five second tutorial overlay so play begins immediately.【F:simple-experience.js†L761-L796】【F:simple-experience.js†L798-L888】
+- Terrain generation fills the 64×64 grid with layered voxels, attaches each block to chunk groups for culling, and logs the expected "World generated" diagnostic to prove the render loop is live.【F:simple-experience.js†L3000-L3045】
+
+## Player presentation and controls
+- `loadPlayerCharacter()` loads the Steve GLTF (or a fallback cube) into the first-person rig, attaches the camera to the head bone, keeps the animated arms visible, and reports success via console logs when assets degrade.【F:simple-experience.js†L2777-L2845】
+- Movement is delta-timed for WASD, mobile joystick, and touch buttons, blending gravity, jump physics, and pointer-lock yaw so responsiveness matches the brief on desktop and handheld devices.【F:simple-experience.js†L4390-L4473】
+
+## Survival loop: zombies, golems, and health
+- Nightfall triggers `updateZombies()`, which spawns edge zombies, lerps them to rail height, attacks on contact, and logs each chase for telemetry.【F:simple-experience.js†L4633-L4695】
+- Iron golems patrol through `spawnGolem()` / `updateGolems()`, intercepting zombies, awarding score bonuses, and surfacing HUD hints when they save the player.【F:simple-experience.js†L4760-L4824】
+
+## Portals, dimensions, and victory
+- The portal system validates 4×3 frames, awards progress when complete, and calls `ignitePortal()` to trigger shader activation, score rewards, and hint messaging the moment the torch interaction fires.【F:simple-experience.js†L3852-L3879】【F:simple-experience.js†L4010-L4028】
+- `advanceDimension()` applies the next realm’s gravity and palette, rebuilds terrain and rails, respawns defences, tallies the +5 score, and emits the analytics events requested by the spec before launching the Netherite challenge and eventual victory flow.【F:simple-experience.js†L4031-L4094】
+
+## Crafting, HUD, and backend synchronisation
+- Scoreboard and HUD integrations initialise alongside the renderer, fetching leaderboard data when an API base URL is configured and falling back to local storage otherwise, with clear status messaging for offline sessions.【F:simple-experience.js†L935-L980】
+- `scheduleScoreSync()` and `flushScoreSync()` push ordered run summaries (score, recipes, dimensions, location) to `${apiBaseUrl}/scores`, keeping DynamoDB-backed leaderboards in sync with crafting, portal, and victory milestones.【F:simple-experience.js†L1380-L1420】
+
+## Debug and QA affordances
+- The render loop logs "World generated" and "Zombie spawned, chasing" while the debug interface exposes portal completion helpers, giving QA engineers deterministic checkpoints to verify the sandbox against future regression reports.【F:simple-experience.js†L3000-L3045】【F:simple-experience.js†L4633-L4695】【F:simple-experience.js†L6184-L6285】


### PR DESCRIPTION
## Summary
- document how the sandbox renderer satisfies the Portals of Dimension brief with line-level references
- highlight rendering, control, survival, portal, and backend behaviours so reviewers can audit requirements quickly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d97d89cda8832b9b404e83ddf58b87