### PR TITLE
Document and test console telemetry checkpoints

### DIFF
--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -6,6 +6,7 @@ This document summarises how the current `simple-experience.js` runtime aligns w
 
 * **Three.js bootstrap** – `SimpleExperience.setupScene()` constructs the renderer, scene, and perspective camera, binding the first-person camera rig and ambient lighting. 【F:simple-experience.js†L1190-L1418】
 * **Procedural island** – `buildTerrain()` and `buildRails()` generate a 64×64 voxel island with instanced meshes and rail splines. The helper logs `World generated: 4096 voxels` for validation. 【F:simple-experience.js†L2300-L2442】【F:simple-experience.js†L2414-L2424】
+* **Console telemetry** – Startup and progression emit deterministic logs (`Scene populated`, `Steve visible in scene`, `Zombie spawned, chasing`, `Respawn triggered`, `Portal active`) that our Vitest regression suite asserts for. 【F:simple-experience.js†L1564-L1584】【F:simple-experience.js†L2836-L2906】【F:simple-experience.js†L4734-L4746】【F:simple-experience.js†L4899-L4916】【F:simple-experience.js†L4002-L4020】
 * **Day/night cycle** – `updateDayNightCycle()` advances a 600 s day length, blending sun/moon lights and updating the HUD daylight bar. 【F:simple-experience.js†L3004-L3126】【F:simple-experience.js†L4935-L4988】
 
 ## Player Presentation & Controls

--- a/tests/spec-coverage.spec.js
+++ b/tests/spec-coverage.spec.js
@@ -16,6 +16,14 @@ describe('Portals of Dimension spec regression checks', () => {
     expect(simpleExperienceSource).toMatch(/World generated: \$\{columnCount\} voxels/);
   });
 
+  it('keeps the console telemetry checkpoints demanded by the spec', () => {
+    expect(simpleExperienceSource).toMatch(/Scene populated/);
+    expect(simpleExperienceSource).toMatch(/Steve visible in scene/);
+    expect(simpleExperienceSource).toMatch(/Zombie spawned, chasing/);
+    expect(simpleExperienceSource).toMatch(/Respawn triggered/);
+    expect(simpleExperienceSource).toMatch(/Portal active/);
+  });
+
   it('ships the expected character and entity assets', () => {
     expect(simpleExperienceSource).toMatch(/MODEL_URLS\s*=\s*\{/);
     expect(simpleExperienceSource).toMatch(/steve\.gltf/);


### PR DESCRIPTION
## Summary
- add a regression assertion that the simple experience retains required console log telemetry strings
- document the console log checkpoints in the spec coverage report so QA can trace the Vitest guardrails

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9f29ab314832b9357f2e842c4d0a1