### PR TITLE
Document spec audit and extend telemetry regression tests

### DIFF
--- a/docs/portals-of-dimension-spec-audit-2026-03.md
+++ b/docs/portals-of-dimension-spec-audit-2026-03.md
@@ -1,0 +1,52 @@
+# Portals of Dimension Spec Audit — March 2026
+
+This audit cross-references the latest sandbox implementation with the
+"Comprehensive Analysis and Enhancement Specifications" brief. Each section
+calls out the concrete systems in `simple-experience.js` and `script.js` that
+fulfil the requested behaviours.
+
+## Render Pipeline and World Generation
+- `SimpleExperience.setupScene()` assembles the orthographic camera, hemisphere
+  ambient light, directional sunlight, and renderer while the sandbox boot log
+  announces `Scene populated` so regressions are easy to spot.
+- `SimpleExperience.buildTerrain()` fills the 64×64 grid (4,096 voxels) using
+  cached geometries and reports `World generated: ${columnCount} voxels` to
+  confirm the procedural terrain is present every session.
+
+## Player Perspective and Controls
+- `SimpleExperience.loadPlayerCharacter()` loads the Steve GLTF, falls back to a
+  stylised cube when the asset is unavailable, attaches the camera to the head
+  bone for first-person play, and emits `Steve visible in scene` console events
+  for verification.
+- Pointer lock, WASD handling, joystick input, and raycast-driven mining all
+  live inside `handleMouseMove`, `handleKeyDown`, `updateMovement`, and related
+  helpers so keyboard, mouse, and touch players all receive immediate feedback.
+
+## Entities, Combat, and Survival Loop
+- Zombie and iron golem spawners (`spawnZombie`, `spawnIronGolem`) leverage
+  `createZombie`/`createGolem` helpers and the combat utilities to deduct
+  hearts, trigger respawns after five hits, and log `Zombie spawned, chasing` to
+  satisfy the survival requirements.
+- Hearts, bubbles, and status HUD elements update inside `updateHud()` so
+  survival cues always reflect the current run.
+
+## Crafting, Inventory, and Progression
+- The hotbar, crafting modal, and drag-and-drop recipe sequencing are wired via
+  `renderInventoryUi`, `refreshCraftingUi`, and the `handleCraft*` handler
+  family, unlocking recipes, updating the score HUD, and surfacing `Craft
+  success` notifications.
+- Portal frames, portal ignition, and dimension hand-offs are covered by
+  `refreshPortalState()`, `ignitePortal()`, and `advanceDimension()`, including
+  shader-driven portal planes and gravity adjustments per dimension.
+
+## Backend Integration and Polish
+- REST calls to `APP_CONFIG.apiBaseUrl` flow through `loadScoreboard()` and
+  `flushScoreSync()` to synchronise the DynamoDB scoreboard, while Google SSO
+  and geolocation capture hydrate player profiles before each run.
+- Audio feedback uses the shared Howler controller, tooltip hints cover the HUD
+  buttons, and the "Made by Manu" footer plus victory screen hooks maintain the
+  requested polish.
+
+The repo therefore embeds the full gameplay loop – rendering, interaction,
+entities, crafting, portals, and backend sync – demanded by the enhancement
+brief while keeping console instrumentation in place for automated validation.

--- a/tests/spec-coverage.spec.js
+++ b/tests/spec-coverage.spec.js
@@ -24,6 +24,14 @@ describe('Portals of Dimension spec regression checks', () => {
     expect(simpleExperienceSource).toMatch(/Portal active/);
   });
 
+  it('retains the player control and progression instrumentation', () => {
+    expect(simpleExperienceSource.includes("console.log('Moving forward');")).toBe(true);
+    expect(simpleExperienceSource.includes('this.canvas.requestPointerLock')).toBe(true);
+    expect(simpleExperienceSource.includes('console.log(`Dimension: ${this.dimensionSettings.name} unlocked`);')).toBe(true);
+    expect(simpleExperienceSource.includes("console.log('Score synced'")).toBe(true);
+    expect(simpleExperienceSource.includes('navigator.geolocation.getCurrentPosition')).toBe(true);
+  });
+
   it('ships the expected character and entity assets', () => {
     expect(simpleExperienceSource).toMatch(/MODEL_URLS\s*=\s*\{/);
     expect(simpleExperienceSource).toMatch(/steve\.gltf/);


### PR DESCRIPTION
## Summary
- add a March 2026 spec audit note that maps the enhancement brief to the shipped sandbox systems
- extend the spec coverage regression test to guard the movement, pointer lock, dimension, score sync, and geolocation telemetry hooks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9fd37db8c832ba6f7179278fd7304