### PR TITLE
Handle canvas focus capability for broader browser support

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -839,7 +839,17 @@
       if (hudRootEl) {
         document.body.classList.add('game-active');
       }
-      this.canvas.focus({ preventScroll: true });
+      if (this.canvas && typeof this.canvas.focus === 'function') {
+        try {
+          this.canvas.focus({ preventScroll: true });
+        } catch (error) {
+          try {
+            this.canvas.focus();
+          } catch (nestedError) {
+            console.debug('Canvas focus unavailable in this browser.', nestedError);
+          }
+        }
+      }
     }
 
     showBriefingOverlay() {


### PR DESCRIPTION
## Summary
- guard the intro dismissal focus call so browsers without focus options no longer throw and abort startup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da043f6b18832bb594034a806de5d2