### PR TITLE
Ensure Steve avatar resets each session

### DIFF
--- a/script.js
+++ b/script.js
@@ -15120,7 +15120,7 @@
       state.player.satchel = [];
       state.player.selectedSlot = 0;
       state.craftSequence = [];
-      ensurePlayerAvatarReady({ resetAnimations: true });
+      ensurePlayerAvatarReady({ forceReload: true, resetAnimations: true });
       renderVictoryBanner();
       loadDimension(startDimensionId);
       if (!startingWithRestoredProgress && state.dayCycle) {
@@ -16110,7 +16110,7 @@
         state.player.zombieHits = 0;
       }
       loadDimension('origin');
-      ensurePlayerAvatarReady({ resetAnimations: true });
+      ensurePlayerAvatarReady({ forceReload: true, resetAnimations: true });
       if (combatUtils?.restoreInventory) {
         combatUtils.restoreInventory(state.player, inventorySnapshot);
       } else {

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -777,6 +777,7 @@
       if (!this.verifyWebglSupport()) {
         return;
       }
+      this.resetPlayerCharacterState();
       this.started = true;
       this.unloadBeaconSent = false;
       this.rendererUnavailable = false;
@@ -1527,6 +1528,61 @@
       this.hideVictoryCelebration(true);
       this.hideVictoryBanner();
       this.victoryShareBusy = false;
+      this.resetPlayerCharacterState();
+      this.started = false;
+    }
+
+    resetPlayerCharacterState() {
+      if (this.playerMixer) {
+        try {
+          this.playerMixer.stopAllAction();
+          if (this.playerAvatar && typeof this.playerMixer.uncacheRoot === 'function') {
+            this.playerMixer.uncacheRoot(this.playerAvatar);
+          }
+        } catch (error) {
+          console.debug('Unable to stop player mixer cleanly.', error);
+        }
+      }
+      this.playerMixer = null;
+      this.playerIdleAction = null;
+
+      if (this.camera && this.camera.parent && typeof this.camera.parent.remove === 'function') {
+        try {
+          this.camera.parent.remove(this.camera);
+        } catch (error) {
+          console.debug('Failed to detach camera from previous parent.', error);
+        }
+      }
+      if (this.playerRig && this.camera && typeof this.playerRig.add === 'function') {
+        try {
+          this.playerRig.add(this.camera);
+          this.camera.position.set(0, 0, 0);
+        } catch (error) {
+          console.debug('Unable to reset camera rig state.', error);
+        }
+      }
+
+      if (this.playerAvatar) {
+        if (this.playerRig && typeof this.playerRig.remove === 'function') {
+          this.playerRig.remove(this.playerAvatar);
+        }
+        disposeObject3D(this.playerAvatar);
+        this.playerAvatar = null;
+      }
+
+      if (this.handGroup) {
+        if (this.handGroup.parent && typeof this.handGroup.parent.remove === 'function') {
+          this.handGroup.parent.remove(this.handGroup);
+        }
+        if (typeof this.handGroup.clear === 'function') {
+          this.handGroup.clear();
+        }
+        this.handGroup = null;
+      }
+
+      this.handMaterials = [];
+      this.handMaterialsDynamic = true;
+      this.handModelLoaded = false;
     }
 
     setupScene() {


### PR DESCRIPTION
## Summary
- force the main experience to reload Steve's mesh and animation rig whenever a new session begins or the player respawns
- add a reset helper for the simple experience so the player rig and first-person arms are torn down between runs and always reattached when starting again

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da283a6a70832b81e24db4774831a5