### PR TITLE
Add camera perspective toggle and harden Steve session init

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ These steps restore the intended first-person experience when a deployment or ca
 
 | Platform | Input |
 | --- | --- |
-| Desktop | `WASD` / arrow keys to move, `Space` to interact, `Q` to place blocks, `E` inventory, `R` build portals, `F` interact, `Shift` to sprint |
+| Desktop | `WASD` / arrow keys to move, `Space` to interact, `Q` to place blocks, `E` inventory, `R` build portals, `F` interact, `V` toggle view, `Shift` to sprint |
 | Mobile | Swipe to move between rails, tap/hold to mine or place, tap the action buttons for crafting and portals |
 
 ## Identity, location & scoreboard endpoints


### PR DESCRIPTION
## Summary
- ensure the Steve rig and animation mixer reset for every session by tracking active session ids and guarding asynchronous loads
- add a camera boom plus first- and third-person perspective controls (toggled with `V`) while keeping first-person hands visible only when appropriate
- document the new view toggle in the controls table

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da2f9dc4e4832b8304146f25dd6862