### PR TITLE
Add Compose-styled overlays for leaderboard loading and error states

### DIFF
--- a/index.html
+++ b/index.html
@@ -1019,6 +1019,45 @@
           </table>
           <p class="leaderboard-empty" id="leaderboardEmptyMessage">Sign in to publish your victories and see the live rankings.</p>
         </div>
+        <div
+          class="compose-overlay"
+          id="leaderboardOverlay"
+          hidden
+          aria-hidden="true"
+          data-mode="idle"
+        >
+          <div
+            class="compose-overlay__dialog"
+            id="leaderboardOverlayDialog"
+            tabindex="-1"
+            role="dialog"
+            aria-modal="false"
+            aria-labelledby="leaderboardOverlayTitle"
+            aria-describedby="leaderboardOverlayMessage"
+          >
+            <div class="compose-overlay__spinner" id="leaderboardOverlaySpinner" aria-hidden="true"></div>
+            <div class="compose-overlay__body">
+              <h3 class="compose-overlay__title" id="leaderboardOverlayTitle">Syncing leaderboard</h3>
+              <p class="compose-overlay__message" id="leaderboardOverlayMessage" aria-live="polite"></p>
+              <div class="compose-overlay__actions" id="leaderboardOverlayActions">
+                <button
+                  type="button"
+                  class="ghost small compose-overlay__action"
+                  id="leaderboardOverlayDismiss"
+                >
+                  Dismiss
+                </button>
+                <button
+                  type="button"
+                  class="accent small compose-overlay__action"
+                  id="leaderboardOverlayRetry"
+                >
+                  Retry
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -2495,6 +2495,8 @@ body.sidebar-open .player-hint {
   text-align: left;
   display: grid;
   gap: 1.5rem;
+  position: relative;
+  overflow: hidden;
 }
 
 .leaderboard-modal__header {
@@ -2836,6 +2838,87 @@ body.sidebar-open .player-hint {
 }
 
 @keyframes leaderboard-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.compose-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgba(6, 12, 26, 0.74);
+  backdrop-filter: blur(7px);
+  z-index: 15;
+}
+
+.compose-overlay__dialog {
+  width: min(360px, 100%);
+  border-radius: 16px;
+  padding: 1.75rem 1.5rem;
+  background: rgba(9, 17, 34, 0.96);
+  box-shadow: 0 28px 48px rgba(2, 6, 18, 0.55);
+  outline: none;
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+  text-align: center;
+  color: var(--text-primary, #f5f7fb);
+}
+
+.compose-overlay__body {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.compose-overlay__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.compose-overlay__message {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.compose-overlay__spinner {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 3px solid rgba(73, 242, 255, 0.26);
+  border-top-color: #49f2ff;
+  animation: compose-spin 0.9s linear infinite;
+}
+
+.compose-overlay__actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.compose-overlay__actions[hidden] {
+  display: none;
+}
+
+.compose-overlay__action {
+  min-width: 96px;
+}
+
+.compose-overlay[data-mode='error'] .compose-overlay__spinner {
+  display: none;
+}
+
+@keyframes compose-spin {
   from {
     transform: rotate(0deg);
   }


### PR DESCRIPTION
## Summary
- add a compose overlay inside the leaderboard modal to surface leaderboard loading and error states with retry and dismiss affordances
- style the new overlay and adjust the modal container so the dialog can float above the table content
- drive overlay state from the identity layer by tracking scoreboard messages, updating the status copy, and wiring retry/dismiss actions that reset progress messaging immediately on failure

## Testing
- npm test
- npm run test:e2e *(skipped: Playwright browser download required)*

------
https://chatgpt.com/codex/tasks/task_e_68da3ac6d720832bb167a77be7088108