### PR TITLE
Enhance portal status cues and dimension entry messaging

### DIFF
--- a/audio-aliases.js
+++ b/audio-aliases.js
@@ -12,6 +12,7 @@
     zombieGroan: existing.zombieGroan || ['miningB', 'crunch'],
     portalActivate: existing.portalActivate || ['victoryCheer', 'miningA'],
     portalDormant: existing.portalDormant || ['bubble', 'crunch'],
+    portalPrimed: existing.portalPrimed || ['bubble', 'miningA'],
   });
 
   scope.INFINITE_RAILS_AUDIO_ALIASES = aliasConfig;

--- a/index.html
+++ b/index.html
@@ -287,7 +287,10 @@
               data-hint="Shows whether the current portal is dormant, primed, or active."
             >
               <span class="portal-status__icon" aria-hidden="true"></span>
-              <span class="portal-status__text">Portal dormant</span>
+              <span class="portal-status__text">
+                <span class="portal-status__state">Portal dormant</span>
+                <span class="portal-status__detail">Awaiting ignition sequence</span>
+              </span>
             </div>
             <div
               class="portal-progress"

--- a/portal-mechanics.js
+++ b/portal-mechanics.js
@@ -153,15 +153,17 @@ function enterPortal(portal, dimension) {
     shaderProfile: dimension?.physics?.shaderProfile ?? 'default',
   };
   const rules = formatDimensionRules(dimension);
+  const announcement = `Entering ${name} — ${rules}`;
   return {
     fade: true,
     resetPosition: { x: 0, y: 0 },
-    log: `Entered ${name}.`,
+    log: announcement,
     pointsAwarded: Number.isFinite(dimension?.unlockPoints) ? dimension.unlockPoints : 5,
     physics,
     shaderProfile: physics.shaderProfile,
     dimensionName: name,
     dimensionRules: rules,
+    announcement,
   };
 }
 
@@ -182,6 +184,7 @@ const api = {
   detectPortalCollision,
   ignitePortalFrame,
   enterPortal,
+  formatDimensionRules,
   getPortalMechanicsSummary,
 };
 

--- a/script.js
+++ b/script.js
@@ -814,6 +814,8 @@
     const portalProgressLabel = portalProgressEl?.querySelector('.label') ?? null;
     const portalProgressBar = portalProgressEl?.querySelector('.bar') ?? null;
     const portalStatusText = portalStatusEl?.querySelector('.portal-status__text') ?? null;
+    const portalStatusStateText = portalStatusEl?.querySelector('.portal-status__state') ?? null;
+    const portalStatusDetailText = portalStatusEl?.querySelector('.portal-status__detail') ?? null;
     const portalStatusIcon = portalStatusEl?.querySelector('.portal-status__icon') ?? null;
     const dimensionIntroEl = document.getElementById('dimensionIntro');
     const dimensionIntroNameEl = document.getElementById('dimensionIntroName');
@@ -1583,6 +1585,8 @@
           scoreDimensionsEl,
           portalStatusEl,
           portalStatusText,
+          portalStatusStateText,
+          portalStatusDetailText,
           portalStatusIcon,
           portalProgressLabel,
           portalProgressBar,
@@ -15827,7 +15831,19 @@
       }
       updateStatusBars();
       flagProgressDirty('dimension');
-      logEvent(`Entered ${dim.name}.`);
+      const formatRulesFn =
+        (typeof window !== 'undefined' && window.PortalMechanics?.formatDimensionRules) || null;
+      const ruleSummary =
+        typeof formatRulesFn === 'function'
+          ? formatRulesFn({
+              name: dim.name,
+              id: dim.id,
+              rules: dim.rules?.descriptions ?? dim.rules?.list ?? dim.rules,
+              physics: dim.physics,
+              description: dim.description,
+            })
+          : dim.description ?? 'Adapt quickly to the realm\'s rules to survive.';
+      logEvent(`Entering ${dim.name} — ${ruleSummary}`);
     }
 
     const TARGET_FRAME_TIME = 1 / 60;

--- a/styles.css
+++ b/styles.css
@@ -1845,8 +1845,6 @@ body.game-active #gameCanvas {
   border-radius: 999px;
   background: rgba(6, 10, 24, 0.7);
   color: #f4f7ff;
-  text-transform: uppercase;
-  letter-spacing: 0.32em;
   font-size: 0.78rem;
   font-weight: 600;
   box-shadow: 0 16px 36px rgba(0, 0, 0, 0.4), 0 0 16px rgba(90, 115, 255, 0.25);
@@ -1861,7 +1859,28 @@ body.game-active #gameCanvas {
 }
 
 .portal-status__text {
-  white-space: nowrap;
+  display: flex;
+  flex-direction: column;
+  gap: 0.08rem;
+  white-space: normal;
+  line-height: 1.05;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.portal-status__state {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  line-height: 1;
+}
+
+.portal-status__detail {
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: none;
+  opacity: 0.88;
+  white-space: normal;
 }
 
 .portal-status__icon {

--- a/tests/portal-mechanics.test.js
+++ b/tests/portal-mechanics.test.js
@@ -53,7 +53,10 @@ describe('portal mechanics', () => {
     const result = enterPortal(portal, dimension);
     expect(result.fade).toBe(true);
     expect(result.resetPosition).toEqual({ x: 0, y: 0 });
-    expect(result.log).toBe('Entered Rock Dimension.');
+    expect(result.log).toBe(
+      'Entering Rock Dimension — Gravity ×1.50 — Heavier world with dense ore clusters.',
+    );
+    expect(result.announcement).toBe(result.log);
     expect(result.physics.gravity).toBeCloseTo(1.5);
     expect(result.pointsAwarded).toBe(5);
     expect(result.dimensionRules).toContain('Gravity ×1.50');


### PR DESCRIPTION
## Summary
- restructure the HUD portal status panel to show explicit state/detail text with refreshed styling and audio cues
- expose formatted dimension rule summaries during portal entry and update portal mechanics logging/tests accordingly
- add a primed portal sound alias so activation, ready, and inactive states have distinct feedback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da74bcc2a4832b8f5e3a1f7471ed3a