### PR TITLE
Add configurable keyboard bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,31 @@ These steps restore the intended first-person experience when a deployment or ca
 
 | Platform | Input |
 | --- | --- |
-| Desktop | `WASD` / arrow keys to move, `Space` to interact, `Q` to place blocks, `E` inventory, `R` build portals, `F` interact, `V` toggle view, `Shift` to sprint |
+| Desktop | `WASD` / arrow keys to move, `Space` to jump, `F` interact/ignite, `Q` place blocks, `E` crafting, `I` inventory, `R` reset position, `V` toggle view, `1–9` hotbar slots |
 | Mobile | Swipe to move between rails, tap/hold to mine or place, tap the action buttons for crafting and portals |
+
+Desktop key bindings now live in a centralised map with sensible defaults (WASD and the arrow keys for movement). Provide overrides via configuration or at runtime:
+
+```html
+<script>
+  window.APP_CONFIG = {
+    keyBindings: {
+      moveForward: ['KeyI', 'ArrowUp'],
+      interact: ['KeyE'],
+      hotbar1: ['Digit1', 'Numpad1'],
+    },
+  };
+</script>
+```
+
+Once you have a reference to the `SimpleExperience` instance (returned from `SimpleExperience.create(options)`), call its helpers to adjust bindings dynamically. Changes persist to `localStorage` under `infinite-rails-keybindings` so players keep their preferences across sessions:
+
+```js
+experience.setKeyBinding('jump', ['KeyZ']);
+experience.setKeyBindings({ moveForward: ['KeyI'], moveBackward: ['KeyK'] });
+// Restore the defaults from configuration/localStorage
+experience.resetKeyBindings();
+```
 
 ## Identity, location & scoreboard endpoints
 

--- a/index.html
+++ b/index.html
@@ -318,7 +318,7 @@
           hidden
           data-hint="Reminder to capture the pointer for desktop controls."
         >
-          Click the viewport to capture your mouse, then use WASD to move and left-click to mine.
+          Click the viewport to capture your mouse, then use WASD or the arrow keys to move and left-click to mine.
         </div>
         <div class="hand-overlay" id="handOverlay" aria-hidden="true" data-item="fist" data-hint="Currently equipped item.">
           <div
@@ -487,8 +487,8 @@
         <div>
           <h3>Desktop Controls</h3>
           <p>
-            WASD/Arrows move · Space interact · Q place block · E inventory · R build portal · F use · Shift sprint · Click or
-            tap to gather
+            WASD/Arrows move · Space jump · F interact/ignite · Q place block · E crafting · I inventory · R reset position ·
+            V toggle view · 1–9 hotbar
           </p>
         </div>
         <div>
@@ -908,18 +908,33 @@
                 <td>Tap interact icon</td>
               </tr>
               <tr>
-                <th scope="row">Inventory</th>
+                <th scope="row">Crafting</th>
                 <td><kbd>E</kbd></td>
+                <td>Crafting button</td>
+              </tr>
+              <tr>
+                <th scope="row">Inventory</th>
+                <td><kbd>I</kbd></td>
                 <td>Inventory button</td>
               </tr>
               <tr>
-                <th scope="row">Portal planner</th>
+                <th scope="row">Place block</th>
+                <td><kbd>Q</kbd></td>
+                <td>Tap build icon</td>
+              </tr>
+              <tr>
+                <th scope="row">Toggle camera</th>
+                <td><kbd>V</kbd></td>
+                <td>&mdash;</td>
+              </tr>
+              <tr>
+                <th scope="row">Reset position</th>
                 <td><kbd>R</kbd></td>
-                <td>Portal overlay toggle</td>
+                <td>&mdash;</td>
               </tr>
               <tr>
                 <th scope="row">Quick deploy</th>
-                <td><kbd>1</kbd>–<kbd>5</kbd> hotbar</td>
+                <td><kbd>1</kbd>–<kbd>9</kbd> hotbar</td>
                 <td>Hotbar tap</td>
               </tr>
             </tbody>


### PR DESCRIPTION
## Summary
- centralize default control mappings and persist optional overrides for the simple experience
- expose runtime helpers for updating/resetting bindings and honor them in input handling and movement
- refresh documentation and UI copy to reflect the new default controls and customization flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68da7d1d6a2c832b8967629f7f88b252