### PR TITLE
Add configurable key bindings to advanced experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ experience.setKeyBindings({ moveForward: ['KeyI'], moveBackward: ['KeyK'] });
 experience.resetKeyBindings();
 ```
 
+The advanced renderer exposes the same helpers on `window.InfiniteRails` once `script.js` boots. Call them at runtime to tweak bindings without reloading:
+
+```js
+window.InfiniteRails.setKeyBinding('interact', ['KeyG']);
+window.InfiniteRails.resetKeyBindings();
+```
+
 ## Identity, location & scoreboard endpoints
 
 Expose an `APP_CONFIG` object before loading `script.js` to wire up Google SSO and DynamoDB-backed endpoints:


### PR DESCRIPTION
## Summary
- centralize the advanced renderer's keyboard controls behind a default binding map with localStorage/app config overrides
- expose runtime helpers via `window.InfiniteRails` and update in-game hints to render the active key labels
- normalize guide demos and portal prompts to respect remapped movement, hotbar, and ignite inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da87eeaec4832b9a44aa0e5e6dac11