### PR TITLE
Enable hotbar expansion and drag-and-drop inventory management

### DIFF
--- a/script.js
+++ b/script.js
@@ -1902,6 +1902,8 @@
           portalProgressLabel,
           portalProgressBar,
           hotbarEl,
+          hotbarExpandButton: toggleExtendedBtn,
+          extendedInventoryEl,
           playerHintEl,
           dimensionIntroEl,
           dimensionIntroNameEl,
@@ -1939,7 +1941,6 @@
             inventorySortButton,
             inventoryOverflowEl,
             closeInventoryButton,
-            openInventoryButtons: [toggleExtendedBtn].filter(Boolean),
             pointerHintEl,
             footerEl: document.getElementById('siteFooter'),
             footerScoreEl: document.getElementById('footerScore'),
@@ -15250,6 +15251,10 @@
     }
 
     function toggleHotbarExpansion(forceValue) {
+      if (simpleExperience && typeof simpleExperience.toggleHotbarExpansion === 'function') {
+        simpleExperience.toggleHotbarExpansion(forceValue);
+        return;
+      }
       const nextState = typeof forceValue === 'boolean' ? forceValue : !state.ui.hotbarExpanded;
       state.ui.hotbarExpanded = nextState;
       updateHotbarExpansionUi();

--- a/styles.css
+++ b/styles.css
@@ -3196,6 +3196,57 @@ body.sidebar-open .player-hint {
   gap: 0.5rem;
 }
 
+.hotbar-slot {
+  border-radius: 14px;
+  border: 1px solid rgba(73, 242, 255, 0.2);
+  background: rgba(6, 14, 28, 0.8);
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: rgba(255, 255, 255, 0.92);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+  user-select: none;
+  padding: 0.35rem;
+  text-align: center;
+  background-clip: padding-box;
+}
+
+.hotbar-slot:hover,
+.hotbar-slot:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(73, 242, 255, 0.25);
+}
+
+.hotbar-slot:focus-visible {
+  outline: none;
+}
+
+.hotbar-slot[draggable='true'] {
+  cursor: grab;
+}
+
+.hotbar-slot.dragging {
+  opacity: 0.7;
+  cursor: grabbing;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(73, 242, 255, 0.35);
+}
+
+.hotbar-slot.drag-over {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(73, 242, 255, 0.35);
+}
+
+.hotbar-slot[data-active='true'] {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(73, 242, 255, 0.35);
+}
+
 .inventory-slot {
   border-radius: 14px;
   border: 1px solid rgba(73, 242, 255, 0.2);
@@ -3264,6 +3315,18 @@ body.sidebar-open .player-hint {
 
 .extended.open {
   display: grid;
+}
+
+.inventory-extended__empty {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 0.75rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+  border: 1px dashed rgba(73, 242, 255, 0.22);
+  border-radius: 12px;
+  background: rgba(6, 14, 28, 0.6);
 }
 
 .inventory-modal {


### PR DESCRIPTION
## Summary
- add an extended inventory grid and expansion toggle to the simple experience HUD
- enable drag-and-drop reordering of hotbar slots with state updates across crafting and modal views
- connect the UI bootstrap to the new controls and style hotbar slots for hover/drag feedback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dab8f9da70832b885951e078a1a953