### PR TITLE
Handle asset base paths when loading renderer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Expose an `APP_CONFIG` object before loading `script.js` to wire up Google SSO a
 - **Scoreboard** – the app loads scores via `GET ${apiBaseUrl}/scores` and upserts the player’s run with `POST ${apiBaseUrl}/scores`. The payload mirrors the UI fields: `name`, `score`, `dimensionCount`, `runTimeSeconds`, `inventoryCount`, plus optional `location` or `locationLabel` fields.
 - **Offline-friendly** – when `apiBaseUrl` is absent the UI persists identities and scores to `localStorage` and displays sample leaderboard entries so the page remains fully interactive.
 - **Mode selection** – the bundled configuration already opts into the advanced renderer. Set `forceSimpleMode: true` when you need to fall back to the lighter sandbox, or override any flag above to suit your deployment.
+- **Static asset base paths** – when the experience is served from a subdirectory (for example, `https://cdn.example.com/compose/`), provide `assetBaseUrl` to point at the folder containing `vendor/` and other shared bundles. The bootstrapper automatically uses the page URL as a default, but explicitly setting the base prevents 404s when assets live outside the current directory.
 - **Texture packs** – set `textureBaseUrl` to a bucket such as `https://your-bucket.s3.amazonaws.com/blocks` (or provide a `textures` / `textureManifest` map) to stream PNG tile maps for `grass`, `dirt`, and `stone`. The sandbox swaps them in at runtime with frustum-aware anisotropy while keeping the procedural textures as an offline fallback.
 
 ### Deploying the AWS backend

--- a/index.html
+++ b/index.html
@@ -1178,6 +1178,16 @@
           defaultMode: 'advanced',
           forceAdvanced: true,
           forceSimpleMode: false,
+          assetBaseUrl: (function () {
+            if (typeof window === 'undefined' || !window.location?.href) {
+              return null;
+            }
+            try {
+              return new URL('./', window.location.href).href;
+            } catch (error) {
+              return null;
+            }
+          })(),
         },
         window.APP_CONFIG || {},
       );


### PR DESCRIPTION
## Summary
- add helper functions that derive local candidate URLs for renderer dependencies using APP_CONFIG.assetBaseUrl, the current script directory, and the page origin
- default assetBaseUrl to the current page location and document the new option in the README so CDN subdirectory deployments continue to work

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dae012d20c832b8decb77999865bce