### PR TITLE
Fix keybinding initialization timing in bootstrap

### DIFF
--- a/script.js
+++ b/script.js
@@ -2543,9 +2543,6 @@
       googleClientId: window.APP_CONFIG?.googleClientId ?? null,
     };
 
-    initializeKeyBindings();
-    refreshKeyBindingDependentCopy();
-
     const TILE_UNIT = 1;
     const BASE_GEOMETRY = new THREE.BoxGeometry(TILE_UNIT, TILE_UNIT, TILE_UNIT);
     const PLANE_GEOMETRY = new THREE.PlaneGeometry(TILE_UNIT, TILE_UNIT);
@@ -14593,6 +14590,9 @@
         }
       }
     }
+
+    initializeKeyBindings();
+    refreshKeyBindingDependentCopy();
 
     state.player.heartsAtLastDamage = state.player.hearts;
 


### PR DESCRIPTION
## Summary
- delay key binding initialisation until after the main game state is constructed
- ensure dependent UI copy only refreshes once state references exist, preventing bootstrap failures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dae7110c04832b88494ad4c3a4d72b