### PR TITLE
Ensure asset paths resolve relative to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1211,6 +1211,7 @@
       })();
     </script>
     <script src="vendor/three.min.js" defer></script>
+    <script src="asset-resolver.js" defer></script>
     <script src="assets/offline-assets.js" defer></script>
     <script src="audio-aliases.js" defer></script>
     <script src="scoreboard-utils.js" defer></script>


### PR DESCRIPTION
## Summary
- add a shared asset resolver helper that normalises asset base URLs and exposes it globally
- update the main runtime and simple experience loaders to resolve audio and GLTF assets through the helper
- load the new resolver script from index.html so assets are consistently served relative to the page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbc320cb4c832bb29187ba778e1c6b