### PR TITLE
Ensure Steve avatar loads during init

### DIFF
--- a/script.js
+++ b/script.js
@@ -12413,13 +12413,26 @@
       playerMeshSessionId = 0;
       resetPlayerAnimationState();
 
+      const loadSessionId = sessionId;
+      playerModelLoading = true;
+      const loadEmbeddedSteve = () => {
+        parseEmbeddedModel(
+          'steve',
+          (embeddedGltf) => {
+            handlePlayerGltfLoad(embeddedGltf, loadSessionId);
+          },
+          (parseError) => {
+            console.error('Failed to parse embedded Steve model.', parseError);
+            useFallbackPlayerMesh(loadSessionId);
+          }
+        );
+      };
+
       if (!SUPPORTS_MODEL_ASSETS) {
-        useFallbackPlayerMesh(sessionId);
+        loadEmbeddedSteve();
         return;
       }
 
-      const loadSessionId = sessionId;
-      playerModelLoading = true;
       getGltfLoaderInstance()
         .then((loader) => {
           loader.load(
@@ -12430,29 +12443,13 @@
             undefined,
             (error) => {
               console.error('Failed to load Steve model.', error);
-              parseEmbeddedModel(
-                'steve',
-                (embeddedGltf) => {
-                  handlePlayerGltfLoad(embeddedGltf, loadSessionId);
-                },
-                () => {
-                  useFallbackPlayerMesh(loadSessionId);
-                }
-              );
+              loadEmbeddedSteve();
             }
           );
         })
         .catch((error) => {
           console.error('GLTFLoader is unavailable; cannot create the Steve model.', error);
-          parseEmbeddedModel(
-            'steve',
-            (embeddedGltf) => {
-              handlePlayerGltfLoad(embeddedGltf, loadSessionId);
-            },
-            () => {
-              useFallbackPlayerMesh(loadSessionId);
-            }
-          );
+          loadEmbeddedSteve();
         });
     }
 


### PR DESCRIPTION
## Summary
- ensure the Steve avatar is always loaded during initialization by parsing the embedded GLTF when external asset fetching is unavailable
- reuse the embedded loading path for GLTF loader failures so the model still enters the scene graph before falling back to primitives

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbd9f8a0b8832b8ed31531859cb247