### PR TITLE
Ensure terrain chunks spawn with visible meshes

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -3969,15 +3969,16 @@
                 : blockType === 'dirt'
                   ? this.materials.dirt
                   : this.materials.stone;
-            const mesh = new THREE.Mesh(this.blockGeometry, material);
-            mesh.castShadow = isSurface;
-            mesh.receiveShadow = true;
-            mesh.position.set(worldX, level * BLOCK_SIZE + BLOCK_SIZE / 2, worldZ);
-            mesh.userData = {
-              columnKey,
-              level,
-              gx,
-              gz,
+          const mesh = new THREE.Mesh(this.blockGeometry, material);
+          mesh.castShadow = isSurface;
+          mesh.receiveShadow = true;
+          mesh.position.set(worldX, level * BLOCK_SIZE + BLOCK_SIZE / 2, worldZ);
+          mesh.visible = true;
+          mesh.userData = {
+            columnKey,
+            level,
+            gx,
+            gz,
               blockType,
               chunkKey: this.getTerrainChunkKey(gx, gz),
             };
@@ -4050,6 +4051,7 @@
       const chunkZ = Number.parseInt(chunkZRaw ?? '0', 10) || 0;
       chunk = new THREE.Group();
       chunk.name = `TerrainChunk-${chunkX}-${chunkZ}`;
+      chunk.visible = true;
       chunk.userData = {
         chunkX,
         chunkZ,

--- a/tests/simple-experience-terrain.test.js
+++ b/tests/simple-experience-terrain.test.js
@@ -91,5 +91,8 @@ describe('simple experience terrain generation', () => {
     expect(experience.terrainGroup.children.length).toBeGreaterThan(0);
     expect(experience.terrainChunkGroups.length).toBeGreaterThan(0);
     expect(experience.terrainChunkGroups.every((chunk) => chunk.children.length > 0)).toBe(true);
+    expect(experience.terrainChunkGroups.every((chunk) => chunk.visible !== false)).toBe(true);
+    const blockMeshes = Array.from(experience.columns.values()).flat();
+    expect(blockMeshes.every((mesh) => mesh.visible !== false)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- mark newly created terrain chunks as visible and ensure block meshes default to visible when spawned
- extend the terrain generation test to verify chunk and block meshes are visible immediately after build

## Testing
- npm test -- tests/simple-experience-terrain.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dbe5892400832b9d9b2fefcbb3ca95