### PR TITLE
Allow mining/placing before camera initialises

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -5890,7 +5890,7 @@
     }
 
     handleMouseDown(event) {
-      if (!this.camera) return;
+      if (!this.canvas) return;
       this.markInteraction();
       const isPrimary = event.button === 0;
       const isSecondary = event.button === 2;


### PR DESCRIPTION
## Summary
- allow mouse interactions to work before the camera has been created by only requiring a canvas

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68dca6b4e724832bb14d3b4a081ed0bb