### PR TITLE
Add detailed crafting validation feedback

### DIFF
--- a/tests/crafting.test.js
+++ b/tests/crafting.test.js
@@ -6,6 +6,7 @@ const {
   stackHotbarItem,
   searchRecipes,
   DEFAULT_RECIPES,
+  validateCraftAttempt,
 } = require('../crafting.js');
 
 describe('crafting system', () => {
@@ -39,5 +40,43 @@ describe('crafting system', () => {
     const { relevance, matches } = searchRecipes(DEFAULT_RECIPES, 'stone');
     expect(matches.length).toBeGreaterThan(0);
     expect(relevance).toBeGreaterThan(0.8);
+  });
+
+  it('identifies order mismatches even when ingredients are present', () => {
+    const state = createCraftingState({
+      inventory: { stick: 2, stone: 1 },
+      unlockedDimensions: ['origin', 'rock', 'stone'],
+    });
+    const result = craftSequence(state, ['stone', 'stick', 'stick']);
+    expect(result.success).toBe(false);
+    expect(result.validation?.reason).toBe('order-mismatch');
+    expect(result.alert).toBe('Recipe ingredients detected, but the order is incorrect.');
+  });
+
+  it('details missing ingredients during validation', () => {
+    const state = createCraftingState({
+      inventory: { stick: 1 },
+      unlockedDimensions: ['origin', 'rock', 'stone'],
+    });
+    const validation = validateCraftAttempt(state, ['stick', 'stick', 'stone']);
+    expect(validation.valid).toBe(false);
+    expect(validation.reason).toBe('missing-ingredients');
+    expect(Array.isArray(validation.missing)).toBe(true);
+    const missingStick = validation.missing.find((entry) => entry.itemId === 'stick');
+    expect(missingStick?.missing).toBe(1);
+  });
+
+  it('returns visual feedback metadata on successful crafts', () => {
+    const state = createCraftingState({
+      inventory: { stick: 2, stone: 1 },
+      unlockedDimensions: ['origin', 'rock', 'stone'],
+    });
+    const result = craftSequence(state, ['stick', 'stick', 'stone']);
+    expect(result.success).toBe(true);
+    expect(result.feedback).toEqual({
+      type: 'success',
+      visual: 'craft-confetti',
+      message: 'Craft success',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add ingredient and order validation helpers for crafting sequences and return structured feedback metadata
- extend crafting results with success confetti cues while preserving inventory updates
- expand crafting tests to cover order mismatches, missing ingredient reports, and success feedback payloads

## Testing
- npm test -- crafting

------
https://chatgpt.com/codex/tasks/task_e_68dcb65001d4832bbd995a1cb18d1575