### PR TITLE
Align zombie strikes with regenerating hearts

### DIFF
--- a/tests/combat-utils.test.js
+++ b/tests/combat-utils.test.js
@@ -48,6 +48,40 @@ describe('Combat utilities', () => {
     expect(state.player.selectedSlot).toBe(snapshot.selectedSlot);
   });
 
+  it('resets the effective zombie hit counter as hearts regenerate', () => {
+    const logs = [];
+    const state = {
+      player: {
+        maxHearts: 10,
+        hearts: 10,
+        maxAir: 10,
+        air: 10,
+        zombieHits: 0,
+      },
+    };
+
+    let outcome = CombatUtils.applyZombieStrike(state, {
+      onStrike: (message) => logs.push(message),
+    });
+
+    expect(outcome.defeated).toBe(false);
+    expect(outcome.hits).toBe(1);
+    expect(outcome.remainingHearts).toBeCloseTo(8);
+    expect(state.player.zombieHits).toBe(1);
+
+    state.player.hearts = 9.5;
+
+    outcome = CombatUtils.applyZombieStrike(state, {
+      onStrike: (message) => logs.push(message),
+    });
+
+    expect(outcome.defeated).toBe(false);
+    expect(outcome.hits).toBe(1);
+    expect(outcome.remainingHearts).toBeCloseTo(7.5);
+    expect(state.player.zombieHits).toBe(1);
+    expect(logs.length).toBe(2);
+  });
+
   it('guides golems to intercept zombies in more than 70% of chase simulations', () => {
     const gridSize = 16;
     const pathfinder = CombatUtils.createGridPathfinder({


### PR DESCRIPTION
## Summary
- base zombie strike damage on the player’s current hearts so healing restores survivability
- update the in-game fallback logic to mirror the new hit accounting and messaging
- add a combat utils test that verifies zombie hits reset after the player regenerates hearts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcb72a0644832b80c25bab6a635f1c