### PR TITLE
Ensure mobile controls stay visible on touch devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -1114,7 +1114,7 @@
       </div>
     </div>
 
-    <div class="mobile-controls" id="mobileControls">
+    <div class="mobile-controls" id="mobileControls" data-active="false" aria-hidden="true">
       <div class="virtual-joystick" id="virtualJoystick" aria-hidden="true">
         <div class="virtual-joystick__thumb"></div>
       </div>

--- a/script.js
+++ b/script.js
@@ -5669,6 +5669,56 @@
       joystickState.pointerId = null;
     }
 
+    function updateMobileControlsVisibility(preferredScheme = null) {
+      if (!mobileControls) return;
+      const shouldActivate =
+        preferredScheme === 'touch' ||
+        (preferredScheme !== 'desktop' && prefersTouchControls());
+      mobileControls.dataset.active = shouldActivate ? 'true' : 'false';
+      mobileControls.setAttribute('aria-hidden', shouldActivate ? 'false' : 'true');
+      if (virtualJoystickEl) {
+        virtualJoystickEl.setAttribute('aria-hidden', shouldActivate ? 'false' : 'true');
+      }
+      if (!shouldActivate) {
+        resetJoystickVector();
+      }
+    }
+
+    updateMobileControlsVisibility();
+
+    const handlePointerPreferenceChange = (event) => {
+      if (event?.matches) {
+        updateMobileControlsVisibility('touch');
+      } else {
+        updateMobileControlsVisibility('desktop');
+      }
+    };
+
+    if (coarsePointerQuery) {
+      if (typeof coarsePointerQuery.addEventListener === 'function') {
+        coarsePointerQuery.addEventListener('change', handlePointerPreferenceChange);
+      } else if (typeof coarsePointerQuery.addListener === 'function') {
+        coarsePointerQuery.addListener(handlePointerPreferenceChange);
+      }
+    }
+
+    const handleGlobalPointerDown = (event) => {
+      if (!event) return;
+      const type = event.pointerType || '';
+      if (type === 'touch' || type === 'pen') {
+        updateMobileControlsVisibility('touch');
+      } else if (type === 'mouse') {
+        updateMobileControlsVisibility('desktop');
+      }
+    };
+
+    window.addEventListener('pointerdown', handleGlobalPointerDown, { passive: true });
+    window.addEventListener(
+      'touchstart',
+      () => updateMobileControlsVisibility('touch'),
+      { passive: true },
+    );
+
     function handleVirtualJoystickMove(event) {
       if (!virtualJoystickEl) return;
       const rect = virtualJoystickEl.getBoundingClientRect();

--- a/styles.css
+++ b/styles.css
@@ -5489,6 +5489,10 @@ body.colorblind-assist .subtitle-overlay {
   justify-content: center;
 }
 
+.mobile-controls[data-active='true'] {
+  display: flex;
+}
+
 .virtual-joystick {
   position: relative;
   width: 96px;
@@ -5544,12 +5548,6 @@ body.colorblind-assist .subtitle-overlay {
 
 .site-footer p {
   margin: 0;
-}
-
-@media (pointer: coarse) {
-  .mobile-controls {
-    display: flex;
-  }
 }
 
 


### PR DESCRIPTION
## Summary
- mark the mobile controls container with an explicit inactive state and update CSS to only reveal it when the runtime toggles data-active
- teach the advanced renderer to watch coarse pointer media queries and pointer/touch activity so joystick controls appear immediately on touch devices
- harden the simple experience mobile control lifecycle with pointer preference observers and touch fallbacks to keep the joystick responsive in PWAs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc8d84dc4832b991e26d10fe3fd1f