### PR TITLE
Add tests validating key binding defaults and remapping

### DIFF
--- a/tests/keybindings-defaults.test.js
+++ b/tests/keybindings-defaults.test.js
@@ -1,0 +1,228 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+function extractDefaultBindings({ source, hotbarConstantName, hotbarCount }) {
+  const marker = 'const DEFAULT_KEY_BINDINGS = (() => {';
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error('Failed to locate DEFAULT_KEY_BINDINGS definition.');
+  }
+  const end = source.indexOf('})();', start);
+  if (end === -1) {
+    throw new Error('Failed to locate the end of DEFAULT_KEY_BINDINGS definition.');
+  }
+  const snippet = source.slice(start, end + 5);
+  const factory = new Function(
+    hotbarConstantName,
+    "'use strict';\n" + snippet + '\nreturn DEFAULT_KEY_BINDINGS;',
+  );
+  return factory(hotbarCount);
+}
+
+function createCanvasStub() {
+  const loseContextStub = { loseContext: () => {} };
+  const webglContext = {
+    getExtension: () => loseContextStub,
+  };
+  const context2d = {
+    fillStyle: '#000000',
+    fillRect: () => {},
+    drawImage: () => {},
+    clearRect: () => {},
+    beginPath: () => {},
+    arc: () => {},
+    fill: () => {},
+  };
+  const canvas = {
+    width: 512,
+    height: 512,
+    clientWidth: 512,
+    clientHeight: 512,
+    style: {},
+    classList: { add: () => {}, remove: () => {}, contains: () => false },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    setAttribute: () => {},
+    focus: () => {},
+    requestPointerLock: () => ({ catch: () => {} }),
+    releasePointerCapture: () => {},
+    setPointerCapture: () => {},
+    toDataURL: () => 'data:image/png;base64,',
+    getContext: (type) => {
+      if (type === '2d') {
+        return context2d;
+      }
+      if (type === 'webgl' || type === 'webgl2' || type === 'experimental-webgl') {
+        return webglContext;
+      }
+      return null;
+    },
+  };
+  canvas.contains = (target) => target === canvas;
+  return canvas;
+}
+
+let simpleExperienceLoaded = false;
+let originalWindow;
+let originalDocument;
+let originalNavigator;
+let originalPerformance;
+let originalRequestAnimationFrame;
+let originalCancelAnimationFrame;
+
+function ensureSimpleExperienceLoaded() {
+  if (simpleExperienceLoaded) {
+    return;
+  }
+
+  const documentStub = {
+    createElement: (tag) => {
+      if (tag === 'canvas') {
+        return createCanvasStub();
+      }
+      return { getContext: () => null };
+    },
+    body: { classList: { contains: () => false, add: () => {}, remove: () => {} } },
+    getElementById: () => null,
+    querySelector: () => null,
+  };
+
+  const windowStub = {
+    APP_CONFIG: {},
+    devicePixelRatio: 1,
+    location: { search: '' },
+    matchMedia: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame: () => {},
+    document: documentStub,
+    dispatchEvent: () => {},
+    CustomEvent: class CustomEvent {
+      constructor(type, init = {}) {
+        this.type = type;
+        this.detail = init.detail;
+      }
+    },
+  };
+
+  Object.assign(windowStub, { THREE, THREE_GLOBAL: THREE });
+
+  originalWindow = globalThis.window;
+  originalDocument = globalThis.document;
+  originalNavigator = globalThis.navigator;
+  originalPerformance = globalThis.performance;
+  originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+  globalThis.window = windowStub;
+  globalThis.document = documentStub;
+  globalThis.navigator = { geolocation: { getCurrentPosition: () => {} } };
+  globalThis.performance = { now: () => Date.now() };
+  globalThis.requestAnimationFrame = windowStub.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = windowStub.cancelAnimationFrame;
+
+  const scriptSource = fs.readFileSync(path.join(repoRoot, 'simple-experience.js'), 'utf8');
+  vm.runInThisContext(scriptSource);
+  simpleExperienceLoaded = true;
+}
+
+function restoreGlobals() {
+  globalThis.window = originalWindow;
+  globalThis.document = originalDocument;
+  globalThis.navigator = originalNavigator;
+  globalThis.performance = originalPerformance;
+  globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+  globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+}
+
+function createSimpleExperienceInstance() {
+  ensureSimpleExperienceLoaded();
+  const canvas = createCanvasStub();
+  const experience = window.SimpleExperience.create({ canvas, ui: {} });
+  return { experience, canvas };
+}
+
+beforeAll(() => {
+  ensureSimpleExperienceLoaded();
+});
+
+afterEach(() => {
+  if (globalThis.window?.SimpleExperience?.destroyAll) {
+    try {
+      globalThis.window.SimpleExperience.destroyAll();
+    } catch (error) {
+      // ignore cleanup errors in tests
+    }
+  }
+});
+
+describe('key binding defaults', () => {
+  it('provides WASD and action defaults for the advanced experience', () => {
+    const scriptSource = fs.readFileSync(path.join(repoRoot, 'script.js'), 'utf8');
+    const defaults = extractDefaultBindings({
+      source: scriptSource,
+      hotbarConstantName: 'HOTBAR_SLOT_COUNT',
+      hotbarCount: 10,
+    });
+    expect(defaults.moveForward).toEqual(['KeyW', 'ArrowUp']);
+    expect(defaults.moveBackward).toEqual(['KeyS', 'ArrowDown']);
+    expect(defaults.moveLeft).toEqual(['KeyA', 'ArrowLeft']);
+    expect(defaults.moveRight).toEqual(['KeyD', 'ArrowRight']);
+    expect(defaults.jump).toEqual(['Space']);
+    expect(defaults.interact).toEqual(['KeyF']);
+    expect(defaults.placeBlock).toEqual(['KeyQ']);
+    expect(defaults.toggleCrafting).toEqual(['KeyE']);
+    expect(defaults.buildPortal).toEqual(['KeyR']);
+  });
+
+  it('provides matching defaults for the simple experience', () => {
+    const simpleSource = fs.readFileSync(path.join(repoRoot, 'simple-experience.js'), 'utf8');
+    const defaults = extractDefaultBindings({
+      source: simpleSource,
+      hotbarConstantName: 'HOTBAR_SLOTS',
+      hotbarCount: 9,
+    });
+    expect(defaults.moveForward).toEqual(['KeyW', 'ArrowUp']);
+    expect(defaults.moveBackward).toEqual(['KeyS', 'ArrowDown']);
+    expect(defaults.moveLeft).toEqual(['KeyA', 'ArrowLeft']);
+    expect(defaults.moveRight).toEqual(['KeyD', 'ArrowRight']);
+    expect(defaults.jump).toEqual(['Space']);
+    expect(defaults.interact).toEqual(['KeyF']);
+    expect(defaults.placeBlock).toEqual(['KeyQ']);
+    expect(defaults.toggleCrafting).toEqual(['KeyE']);
+    expect(defaults.buildPortal).toEqual(['KeyR']);
+  });
+});
+
+describe('simple experience key remapping', () => {
+  it('allows remapping and resetting key bindings', () => {
+    const { experience } = createSimpleExperienceInstance();
+    const initial = experience.getKeyBindings().moveForward;
+    expect(initial).toEqual(['KeyW', 'ArrowUp']);
+
+    const changed = experience.setKeyBinding('moveForward', ['KeyZ'], { persist: false });
+    expect(changed).toBe(true);
+    expect(experience.getKeyBindings().moveForward).toEqual(['KeyZ']);
+
+    const reset = experience.setKeyBinding('moveForward', [], { persist: false });
+    expect(reset).toBe(true);
+    expect(experience.getKeyBindings().moveForward).toEqual(['KeyW', 'ArrowUp']);
+
+    if (typeof experience.destroy === 'function') {
+      experience.destroy();
+    }
+  });
+});
+
+afterAll(() => {
+  restoreGlobals();
+});


### PR DESCRIPTION
## Summary
- add coverage that parses the advanced and simplified experiences to verify the default key bindings include WASD, arrow, and action keys
- exercise simple experience key binding APIs to confirm remapping and reset behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcd078fb8c832b9c4b0a2107ec2187