### PR TITLE
Add key binding health checks and warning UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,6 +629,7 @@
               Click a control, then press a key to remap it. Press Backspace to restore an individual default or reset all
               bindings below.
             </p>
+            <div class="keybinding-warning" id="keyBindingWarning" role="alert" hidden></div>
             <div class="keybinding-groups" id="settingsKeyBindingsList"></div>
             <div class="settings-modal__key-actions">
               <button type="button" class="ghost small" id="resetKeyBindingsButton">Reset all to defaults</button>

--- a/styles.css
+++ b/styles.css
@@ -4560,6 +4560,21 @@ input[type='search'] {
   margin: 0;
 }
 
+.keybinding-warning {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 196, 0, 0.45);
+  background: linear-gradient(135deg, rgba(255, 196, 0, 0.12), rgba(255, 153, 0, 0.08));
+  color: #f9d87e;
+  padding: 0.85rem 1rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  display: block;
+}
+
+.keybinding-warning[hidden] {
+  display: none;
+}
+
 .keybinding-groups {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- add key binding health analysis that sanitises overrides and flags missing or unrecognised actions
- surface key binding issues through a settings modal warning and refresh flows
- style and render the warning container in the key binding preferences panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dcd24fb4f8832bac5c551c6310a0aa