### PR TITLE
Fix duplicate global scope initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -776,14 +776,14 @@
   const SCOREBOARD_UTILS_FALLBACK = createScoreboardUtilsFallback();
   const COMBAT_UTILS_FALLBACK = createCombatUtilsFallback();
 
-  const globalScope = getGlobalScope();
-  const EMBEDDED_ASSETS = globalScope?.INFINITE_RAILS_EMBEDDED_ASSETS ?? null;
-  if (globalScope) {
-    if (!globalScope.ScoreboardUtils) {
-      globalScope.ScoreboardUtils = SCOREBOARD_UTILS_FALLBACK;
+  const runtimeGlobalScope = getGlobalScope();
+  const EMBEDDED_ASSETS = runtimeGlobalScope?.INFINITE_RAILS_EMBEDDED_ASSETS ?? null;
+  if (runtimeGlobalScope) {
+    if (!runtimeGlobalScope.ScoreboardUtils) {
+      runtimeGlobalScope.ScoreboardUtils = SCOREBOARD_UTILS_FALLBACK;
     }
-    if (!globalScope.CombatUtils) {
-      globalScope.CombatUtils = COMBAT_UTILS_FALLBACK;
+    if (!runtimeGlobalScope.CombatUtils) {
+      runtimeGlobalScope.CombatUtils = COMBAT_UTILS_FALLBACK;
     }
   }
 


### PR DESCRIPTION
## Summary
- stop redeclaring the runtime global scope inside the game bootstrap
- keep attaching fallback scoreboard and combat utilities to the shared scope without clobbering earlier bindings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcdd898780832b98c1c11b7bfa795d