### PR TITLE
Fix score state initialisation order

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,6 +9,16 @@
 
   const assetResolutionWarnings = new Set();
 
+  const scoreState = {
+    score: 0,
+    recipes: new Set(),
+    dimensions: new Set(),
+    points: {
+      recipe: 0,
+      dimension: 0,
+    },
+  };
+
   function logAssetResolutionIssue(message, error, context = {}) {
     const consoleRef = typeof console !== 'undefined' ? console : globalScope.console;
     if (!consoleRef) {
@@ -1821,16 +1831,6 @@
           reason: partial.reason ?? existing.reason ?? null,
         };
       }
-
-      const scoreState = {
-        score: 0,
-        recipes: new Set(),
-        dimensions: new Set(),
-        points: {
-          recipe: 0,
-          dimension: 0,
-        },
-      };
 
       function applySummaryToState(summary) {
         const gameState = getActiveGameState();


### PR DESCRIPTION
## Summary
- define the shared scoreState object before any bootstrap logic runs so it is always available
- remove the later duplicate declaration to prevent ReferenceError during initialisation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcf54fd474832bb97236277f33c8d4