### PR TITLE
Fix model asset support constant initialisation order

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,6 +38,10 @@
 
   const assetResolutionWarnings = new Set();
 
+  const SUPPORTS_MODEL_ASSETS =
+    typeof window === 'undefined' ||
+    (typeof window.location !== 'undefined' && window.location.protocol !== 'file:');
+
   const scoreState = {
     score: 0,
     recipes: new Set(),
@@ -1234,9 +1238,6 @@
         return code;
     }
   }
-
-  const SUPPORTS_MODEL_ASSETS =
-    typeof window === 'undefined' || (typeof window.location !== 'undefined' && window.location.protocol !== 'file:');
 
   const originalConsoleWarn = console.warn?.bind(console);
   if (originalConsoleWarn) {


### PR DESCRIPTION
## Summary
- define the SUPPORTS_MODEL_ASSETS flag before any code that relies on it
- prevent the renderer bootstrap from throwing a temporal dead zone error when loading model assets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd2a0670f4832b9e7f78caf0654377