### PR TITLE
Fix heart status initialization race

### DIFF
--- a/script.js
+++ b/script.js
@@ -1678,6 +1678,7 @@
     const pointerHintEl = document.getElementById('pointerHint');
     const handOverlayEl = document.getElementById('handOverlay');
     const handOverlayLabel = document.getElementById('handOverlayLabel');
+    let heartClipIdCounter = 0;
     const handOverlayIcon = document.getElementById('handOverlayIcon');
     const colorBlindToggle = document.getElementById('colorBlindMode');
     const subtitleToggle = document.getElementById('subtitleToggle');
@@ -17297,7 +17298,6 @@
     const SVG_NS = 'http://www.w3.org/2000/svg';
     const HEART_ICON_PATH =
       'M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z';
-    let heartClipIdCounter = 0;
 
     function createHeartIcon(fill, index) {
       const clampedFill = clamp(fill, 0, 1);


### PR DESCRIPTION
## Summary
- reset the heart clip id counter earlier in the bootstrap lifecycle to avoid temporal dead zone access errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd367ada38832ba55d27dbf1649f44