### PR TITLE
Ensure deployment syncs required runtime modules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,6 +105,8 @@ jobs:
             --include "styles.css" \
             --include "asset-resolver.js" \
             --include "audio-aliases.js" \
+            --include "combat-utils.js" \
+            --include "crafting.js" \
             --include "script.js" \
             --include "simple-experience.js" \
             --include "portal-mechanics.js" \

--- a/tests/deployment-assets.test.js
+++ b/tests/deployment-assets.test.js
@@ -78,4 +78,26 @@ describe('deployment workflow asset coverage', () => {
 
     expect(missing).toEqual([]);
   });
+
+  it('explicitly syncs core runtime modules needed in production', () => {
+    const includePatterns = extractIncludePatterns(workflowContents);
+    const requiredModules = [
+      'asset-resolver.js',
+      'audio-aliases.js',
+      'combat-utils.js',
+      'crafting.js',
+      'portal-mechanics.js',
+      'scoreboard-utils.js',
+      'simple-experience.js',
+      'script.js',
+      'assets/offline-assets.js',
+      'vendor/three.min.js',
+    ];
+
+    const missing = requiredModules.filter((asset) =>
+      !includePatterns.some((pattern) => patternMatchesAsset(pattern, asset)),
+    );
+
+    expect(missing).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- include combat-utils and crafting modules in the deployment sync whitelist
- extend the deployment asset test to verify all runtime modules are covered

## Testing
- npm test -- deployment-assets.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd3fcd4334832b97175587dec3fba8