### PR TITLE
Ensure renderer initializations log stack traces

### DIFF
--- a/script.js
+++ b/script.js
@@ -6970,6 +6970,12 @@
         }
       } catch (error) {
         renderer = null;
+        if (typeof console !== 'undefined') {
+          console.error('Renderer initialisation failed; activating fallback renderer.', error);
+          if (error && error.stack) {
+            console.error('Renderer initialisation stack trace:', error.stack);
+          }
+        }
         return activateRendererFallback({
           reason: 'initialisation-error',
           error,

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -2102,6 +2102,9 @@
         renderer = new THREE.WebGLRenderer({ canvas: this.canvas, antialias: true });
       } catch (error) {
         console.error('Failed to initialise Three.js renderer.', error);
+        if (error && error.stack) {
+          console.error('Renderer initialisation stack trace:', error.stack);
+        }
         this.renderer = null;
         throw error;
       }


### PR DESCRIPTION
## Summary
- log the stack trace when sandbox renderer setup fails
- log the stack trace before activating the advanced renderer fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd473bc44c832b94c3197052209bfc