### PR TITLE
Ensure heart clip counter initializes before status updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,6 +38,8 @@
 
   const assetResolutionWarnings = new Set();
 
+  let heartClipIdCounter = 0;
+
   const SUPPORTS_MODEL_ASSETS =
     typeof window === 'undefined' ||
     (typeof window.location !== 'undefined' && window.location.protocol !== 'file:');
@@ -1678,7 +1680,7 @@
     const pointerHintEl = document.getElementById('pointerHint');
     const handOverlayEl = document.getElementById('handOverlay');
     const handOverlayLabel = document.getElementById('handOverlayLabel');
-    let heartClipIdCounter = 0;
+    heartClipIdCounter = 0;
     const handOverlayIcon = document.getElementById('handOverlayIcon');
     const colorBlindToggle = document.getElementById('colorBlindMode');
     const subtitleToggle = document.getElementById('subtitleToggle');


### PR DESCRIPTION
## Summary
- initialize the heart clip counter when the script loads so it is always defined before status bar updates run
- reset the counter during bootstrap so subsequent updates continue to work as expected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd48573d50832b989d7f6a4a9a1eb7