### PR TITLE
Handle Google auth instances without thenables

### DIFF
--- a/script.js
+++ b/script.js
@@ -2732,10 +2732,18 @@
                       window.gapi.auth2.init({
                         client_id: appConfig.googleClientId,
                       });
-                    instance
-                      .then(() => {
-                        googleAuthInstance = instance;
-                        resolve(instance);
+                    const whenReady =
+                      typeof instance?.then === 'function'
+                        ? new Promise((resolveInstance, rejectInstance) => {
+                            instance
+                              .then(() => resolveInstance(instance))
+                              .catch(rejectInstance);
+                          })
+                        : Promise.resolve(instance);
+                    whenReady
+                      .then((resolvedInstance) => {
+                        googleAuthInstance = resolvedInstance;
+                        resolve(resolvedInstance);
                       })
                       .catch(reject);
                   } catch (error) {
@@ -23104,12 +23112,20 @@
                     window.gapi.auth2.init({
                       client_id: appConfig.googleClientId,
                     });
-                  instance
-                    .then(() => {
-                      googleAuthInstance = instance;
+                  const whenReady =
+                    typeof instance?.then === 'function'
+                      ? new Promise((resolveInstance, rejectInstance) => {
+                          instance
+                            .then(() => resolveInstance(instance))
+                            .catch(rejectInstance);
+                        })
+                      : Promise.resolve(instance);
+                  whenReady
+                    .then((resolvedInstance) => {
+                      googleAuthInstance = resolvedInstance;
                       identityState.googleInitialized = true;
                       updateIdentityUI();
-                      resolve(instance);
+                      resolve(resolvedInstance);
                     })
                     .catch((error) => {
                       identityState.googleInitialized = false;


### PR DESCRIPTION
## Summary
- handle Google auth initialisation when the auth instance does not expose a promise-like `then`
- keep identity UI updates consistent once the auth instance resolves

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd57c57b90832ba288447b63375c14