### PR TITLE
Add chunk validation logs to terrain generation

### DIFF
--- a/script.js
+++ b/script.js
@@ -7531,8 +7531,25 @@
         horizontalRadius * horizontalRadius * 2 + verticalRadius * verticalRadius
       );
       if (typeof console !== 'undefined') {
+        let chunkColumns = 0;
+        if (islandMesh && Number.isFinite(islandMesh.count)) {
+          chunkColumns = islandMesh.count;
+        } else if (fallbackGroup) {
+          chunkColumns = fallbackGroup.children?.length ?? 0;
+        }
+        if (chunkColumns <= 0 && tileCount > 0) {
+          chunkColumns = tileCount;
+        }
         console.log(`World generated: ${tileCount} voxels`);
         console.log(`Terrain blocks placed: ${voxelCount}`);
+        console.log(`Terrain chunks populated: ${chunkColumns}`);
+        if (chunkColumns <= 0 || voxelCount <= 0) {
+          console.warn('Procedural island generation produced no voxel columns or blocks.', {
+            chunkColumns,
+            voxelCount,
+            voxelBudget,
+          });
+        }
         if (cappedColumns > 0) {
           console.info(
             `Terrain voxel budget applied: ${cappedColumns} columns trimmed to stay under ${voxelBudget} voxels`,

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -4262,8 +4262,19 @@
       this.terrainVoxelUsage = voxelsUsed;
       if (typeof console !== 'undefined') {
         const columnCount = WORLD_SIZE * WORLD_SIZE;
+        const chunkCount = Array.isArray(this.terrainChunkGroups)
+          ? this.terrainChunkGroups.length
+          : 0;
         console.log(`World generated: ${columnCount} voxels`);
         console.log(`Terrain blocks placed: ${voxelCount}`);
+        console.log(`Terrain chunks populated: ${chunkCount}`);
+        if (chunkCount <= 0 || voxelCount <= 0) {
+          console.warn('Terrain generation produced no active chunk groups or voxels.', {
+            chunkCount,
+            voxelCount,
+            voxelBudget,
+          });
+        }
         if (cappedColumns > 0) {
           console.info(
             `Terrain voxel budget applied: ${cappedColumns} columns trimmed to stay under ${voxelBudget} voxels`,


### PR DESCRIPTION
## Summary
- log terrain chunk totals when the advanced renderer builds the procedural island
- expose chunk counts and empty-terrain warnings from the simple experience world builder

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd5cc6ae94832b96ebfed20cae23e1