### PR TITLE
Add function key defaults and UI for key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ These steps restore the intended first-person experience when a deployment or ca
 
 | Platform | Input |
 | --- | --- |
-| Desktop | `WASD` / arrow keys to move, `Space` to jump, `F` interact/use, `Q` place blocks, `R` ignite portal, `E` crafting, `I` inventory, `T` reset position, `V` toggle view, `1–0` hotbar slots |
+| Desktop | `WASD` / arrow keys to move, `Space` to jump, `F` interact/use, `Q` place blocks, `R` ignite portal, `E` crafting, `I` inventory, `T` reset position, `V` toggle view, `F1` guide, `F2` settings, `F3` leaderboard, `1–0` hotbar slots |
 | Mobile | Swipe to move between rails, tap/hold to mine or place, tap the action buttons for crafting and portals |
 
 Desktop key bindings now live in a centralised map with sensible defaults (WASD and the arrow keys for movement). Players can remap every control from the in-game **Settings → Key bindings** panel, or you can provide overrides via configuration or at runtime:

--- a/index.html
+++ b/index.html
@@ -984,6 +984,21 @@
                 <td>&mdash;</td>
               </tr>
               <tr>
+                <th scope="row">Game guide</th>
+                <td data-keybinding-table="openGuide"><kbd>F1</kbd></td>
+                <td>&mdash;</td>
+              </tr>
+              <tr>
+                <th scope="row">Settings</th>
+                <td data-keybinding-table="openSettings"><kbd>F2</kbd></td>
+                <td>&mdash;</td>
+              </tr>
+              <tr>
+                <th scope="row">Leaderboard</th>
+                <td data-keybinding-table="openLeaderboard"><kbd>F3</kbd></td>
+                <td>&mdash;</td>
+              </tr>
+              <tr>
                 <th scope="row">Quick deploy</th>
                 <td data-keybinding-table="hotbar"><kbd>1</kbd>–<kbd>9</kbd> hotbar</td>
                 <td>Hotbar tap</td>

--- a/script.js
+++ b/script.js
@@ -956,6 +956,9 @@
       placeBlock: ['KeyQ'],
       toggleCrafting: ['KeyE'],
       toggleInventory: ['KeyI'],
+      openGuide: ['F1'],
+      openSettings: ['F2'],
+      openLeaderboard: ['F3'],
       buildPortal: ['KeyR'],
       resetPosition: ['KeyT'],
       toggleCameraPerspective: ['KeyV'],
@@ -1012,6 +1015,15 @@
         { id: 'toggleInventory', label: 'Toggle inventory' },
         { id: 'toggleCameraPerspective', label: 'Toggle camera view' },
         { id: 'closeMenus', label: 'Close menus' },
+      ],
+    },
+    {
+      id: 'interface',
+      title: 'Guides & overlays',
+      actions: [
+        { id: 'openGuide', label: 'Toggle game guide' },
+        { id: 'openSettings', label: 'Toggle settings' },
+        { id: 'openLeaderboard', label: 'Toggle leaderboard' },
       ],
     },
     {
@@ -1979,6 +1991,9 @@
       placeBlock: document.querySelector('[data-keybinding-table="placeBlock"]'),
       toggleCameraPerspective: document.querySelector('[data-keybinding-table="toggleCameraPerspective"]'),
       resetPosition: document.querySelector('[data-keybinding-table="resetPosition"]'),
+      openGuide: document.querySelector('[data-keybinding-table="openGuide"]'),
+      openSettings: document.querySelector('[data-keybinding-table="openSettings"]'),
+      openLeaderboard: document.querySelector('[data-keybinding-table="openLeaderboard"]'),
       hotbar: document.querySelector('[data-keybinding-table="hotbar"]'),
     };
 
@@ -22135,6 +22150,18 @@
       if (cameraSummary) {
         segments.push(`${cameraSummary} toggle view`);
       }
+      const guideSummary = getActionKeySummary('openGuide', { fallback: 'F1' });
+      if (guideSummary) {
+        segments.push(`${guideSummary} guide`);
+      }
+      const settingsSummary = getActionKeySummary('openSettings', { fallback: 'F2' });
+      if (settingsSummary) {
+        segments.push(`${settingsSummary} settings`);
+      }
+      const leaderboardSummary = getActionKeySummary('openLeaderboard', { fallback: 'F3' });
+      if (leaderboardSummary) {
+        segments.push(`${leaderboardSummary} leaderboard`);
+      }
       const closeMenusSummary = getActionKeySummary('closeMenus', { fallback: 'Esc' });
       if (closeMenusSummary) {
         segments.push(`${closeMenusSummary} close menus`);
@@ -22150,8 +22177,20 @@
       if (!controlReferenceCells) {
         return;
       }
-      const { movement, jump, interact, toggleCrafting, toggleInventory, placeBlock, toggleCameraPerspective, resetPosition, hotbar } =
-        controlReferenceCells;
+      const {
+        movement,
+        jump,
+        interact,
+        toggleCrafting,
+        toggleInventory,
+        placeBlock,
+        toggleCameraPerspective,
+        resetPosition,
+        openGuide,
+        openSettings,
+        openLeaderboard,
+        hotbar,
+      } = controlReferenceCells;
       if (movement) {
         const { primary, secondary } = getMovementKeySets();
         const parts = [];
@@ -22189,6 +22228,15 @@
       }
       if (resetPosition) {
         resetPosition.innerHTML = formatKbdSequence(getActionKeyLabels('resetPosition'), { fallback: '—' });
+      }
+      if (openGuide) {
+        openGuide.innerHTML = formatKbdSequence(getActionKeyLabels('openGuide'), { fallback: '—' });
+      }
+      if (openSettings) {
+        openSettings.innerHTML = formatKbdSequence(getActionKeyLabels('openSettings'), { fallback: '—' });
+      }
+      if (openLeaderboard) {
+        openLeaderboard.innerHTML = formatKbdSequence(getActionKeyLabels('openLeaderboard'), { fallback: '—' });
       }
       if (hotbar) {
         const hotbarLabel = getHotbarRange({ asMarkup: true });
@@ -22347,6 +22395,49 @@
             return;
           }
         }
+        if (isKeyForAction('openGuide', code)) {
+          event.preventDefault();
+          if (guideModal && guideModal.hidden === false) {
+            closeGuideModal();
+          } else {
+            closeCraftingModal({ focusTrigger: false });
+            closeInventoryModal(false);
+            closeSettingsModal(false);
+            closeLeaderboardModal(false);
+            openGuideModal();
+          }
+          return;
+        }
+        if (isKeyForAction('openSettings', code)) {
+          event.preventDefault();
+          if (settingsModal && settingsModal.hidden === false) {
+            closeSettingsModal(false);
+          } else {
+            if (guideModal && guideModal.hidden === false) {
+              closeGuideModal();
+            }
+            closeCraftingModal({ focusTrigger: false });
+            closeInventoryModal(false);
+            closeLeaderboardModal(false);
+            openSettingsModal();
+          }
+          return;
+        }
+        if (isKeyForAction('openLeaderboard', code)) {
+          event.preventDefault();
+          if (leaderboardModal && leaderboardModal.hidden === false) {
+            closeLeaderboardModal(false);
+          } else {
+            if (guideModal && guideModal.hidden === false) {
+              closeGuideModal();
+            }
+            closeCraftingModal({ focusTrigger: false });
+            closeInventoryModal(false);
+            closeSettingsModal(false);
+            openLeaderboardModal();
+          }
+          return;
+        }
         if (
           target instanceof HTMLElement &&
           (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
@@ -22354,6 +22445,9 @@
           const allowedInInput =
             isKeyForAction('toggleInventory', code) ||
             isKeyForAction('toggleCrafting', code) ||
+            isKeyForAction('openGuide', code) ||
+            isKeyForAction('openSettings', code) ||
+            isKeyForAction('openLeaderboard', code) ||
             isKeyForAction('closeMenus', code);
           if (!allowedInInput) {
             return;

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -43,6 +43,9 @@
       toggleCameraPerspective: ['KeyV'],
       toggleCrafting: ['KeyE'],
       toggleInventory: ['KeyI'],
+      openGuide: ['F1'],
+      openSettings: ['F2'],
+      openLeaderboard: ['F3'],
       closeMenus: ['Escape'],
     };
     for (let slot = 1; slot <= HOTBAR_SLOTS; slot += 1) {

--- a/tests/keybindings-defaults.test.js
+++ b/tests/keybindings-defaults.test.js
@@ -181,6 +181,9 @@ describe('key binding defaults', () => {
     expect(defaults.interact).toEqual(['KeyF']);
     expect(defaults.placeBlock).toEqual(['KeyQ']);
     expect(defaults.toggleCrafting).toEqual(['KeyE']);
+    expect(defaults.openGuide).toEqual(['F1']);
+    expect(defaults.openSettings).toEqual(['F2']);
+    expect(defaults.openLeaderboard).toEqual(['F3']);
     expect(defaults.buildPortal).toEqual(['KeyR']);
   });
 
@@ -199,6 +202,9 @@ describe('key binding defaults', () => {
     expect(defaults.interact).toEqual(['KeyF']);
     expect(defaults.placeBlock).toEqual(['KeyQ']);
     expect(defaults.toggleCrafting).toEqual(['KeyE']);
+    expect(defaults.openGuide).toEqual(['F1']);
+    expect(defaults.openSettings).toEqual(['F2']);
+    expect(defaults.openLeaderboard).toEqual(['F3']);
     expect(defaults.buildPortal).toEqual(['KeyR']);
   });
 });


### PR DESCRIPTION
## Summary
- add F1/F2/F3 defaults for opening the guide, settings, and leaderboard and wire the shortcuts into the main loop
- surface the new shortcuts across the key binding UI, control reference table, and documentation
- keep the simple experience and key binding tests in sync with the expanded defaults

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd6abefbd4832b8bbfd7b307dbf0c5