### PR TITLE
Handle offline leaderboard sync fallback

### DIFF
--- a/script.js
+++ b/script.js
@@ -376,6 +376,33 @@
     }
   }
 
+  if (typeof globalScope.addEventListener === 'function') {
+    globalScope.addEventListener('infinite-rails:score-sync-offline', (event) => {
+      const detail = event?.detail ?? {};
+      const fallback = 'Leaderboard offline — runs stored locally until connection returns.';
+      const message =
+        typeof detail.message === 'string' && detail.message.trim().length ? detail.message.trim() : fallback;
+      updateScoreboardStatus(message);
+    });
+
+    globalScope.addEventListener('infinite-rails:score-sync-restored', (event) => {
+      const detail = event?.detail ?? {};
+      if (typeof detail.message === 'string' && detail.message.trim().length) {
+        updateScoreboardStatus(detail.message.trim());
+        return;
+      }
+      if (!identityState.apiBaseUrl) {
+        return;
+      }
+      const activeIdentity = identityState.identity ?? null;
+      if (activeIdentity?.googleId) {
+        updateScoreboardStatus(`Signed in as ${activeIdentity.name}. Leaderboard sync active.`);
+      } else {
+        updateScoreboardStatus('Leaderboard connected — sign in to publish your run.');
+      }
+    });
+  }
+
   function createAnonymousIdentity(base) {
     const location = base?.location && typeof base.location === 'object' ? { ...base.location } : null;
     const locationLabel =


### PR DESCRIPTION
## Summary
- persist run progress locally and surface HUD hints when leaderboard sync attempts fail
- dispatch offline/restore events so the global scoreboard status mirrors backend connectivity

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68ddea29bd7c832bb43a92472d2bdb5c