### PR TITLE
Ensure loading overlay covers asset failures

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -6967,6 +6967,20 @@
         this.pointerHintEl.hidden = true;
         this.pointerHintEl.classList.remove('is-visible');
       }
+      const failureDetail = { message: typeof message === 'string' ? message : 'Renderer unavailable' };
+      if (details && typeof details === 'object') {
+        if (details.stage && typeof details.stage === 'string') {
+          failureDetail.stage = details.stage;
+        }
+        if (details.error) {
+          const errorMessage =
+            typeof details.error?.message === 'string'
+              ? details.error.message
+              : String(details.error);
+          failureDetail.error = errorMessage;
+        }
+      }
+      this.emitGameEvent('renderer-failure', failureDetail);
       this.publishStateSnapshot('renderer-failure');
     }
 


### PR DESCRIPTION
## Summary
- add a bootstrap overlay controller that shows a loading spinner immediately and swaps to an error state when renderer init fails
- wire simple renderer bootstrap and fallback paths to update the overlay so users never see a blank screen during asset issues
- emit a renderer-failure event from the simple experience to drive the overlay error messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddf81f7958832bae0dc2ae7a88c7cb