### PR TITLE
Harden console diagnostics with actionable errors

### DIFF
--- a/docs/coding-agent-prompts.md
+++ b/docs/coding-agent-prompts.md
@@ -19,7 +19,7 @@ for ambient and DirectionalLight for sun (orbit for day/night cycle every 600s).
 Start requestAnimationFrame(gameLoop) with delta = clock.getDelta(), calling
 update(delta) then renderer.render(scene, camera). Fix empty scene bug by
 ensuring worldGroup.add(voxel) in a nested loop. Validate: On load,
-console.log('World generated: 4096 voxels'); target 60 FPS. Output the complete
+console.error('World generation summary — 4096 columns created. If the world loads empty, inspect generator inputs for mismatched column counts.'); target 60 FPS. Output the complete
 bootstrap() and gameLoop() functions, integrating with existing APP_CONFIG.
 ```
 
@@ -33,7 +33,7 @@ child of head bone for first-person view (visible arms/hands). Implement
 AnimationMixer for idle loop. Call loadPlayerModel() in bootstrap() after world
 gen. Ensure no third-person—camera locked to Steve's perspective. Fix
 invisibility: Add error handler logging 'Model load failed, using fallback cube'.
-Validate: Console.log('Steve visible in scene'); move test with temp keydown.
+Validate: console.error('Avatar visibility confirmed — verify animation rig initialises correctly if the player appears static.'); move test with temp keydown.
 Output loadPlayerModel() and camera attachment code, with Minecraft-style
 low-poly textures.
 ```
@@ -48,7 +48,7 @@ rotateY); 'click' for pointerlock and left/right mine/place (raycast from camera
 remove/add voxel to hotbar). For mobile, add touchstart/move/end on canvas for
 virtual joystick (bottom-left div, analog vector to movement). Fix no-response:
 Use preventDefault(), global scope, and pressedKeys Set for held keys. Add Space
-for jump (velocity.y += 10delta). Validate: Press W → log('Moving forward');
+for jump (velocity.y += 10delta). Validate: Press W → console.error('Movement input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion.');
 ensure 1 unit/sec speed. Output full event handlers, normalized for
 desktop/mobile like Minecraft controls.
 ```
@@ -63,8 +63,8 @@ Vector3 towards player (speed 2delta), collision detect (distance <1 → deduct
 every 30s), target nearest zombie (intercept if <10 units). Health: Array of 10
 heart meshes (scale on damage); 5 hits → fade screen black, respawn player at
 [0,0,0] retaining inventory. Fix missing characters: Ensure add to scene.
-Validate: Simulate night → log('Zombie spawned, chasing'); 5 hits → 'Respawn
-triggered'. Output entity creation/update functions with AI pathing (simple A
+Validate: Simulate night → console.error('Zombie spawn and chase triggered. If AI stalls or pathfinding breaks, validate the navmesh and spawn configuration.'); 5 hits → 'Respawn
+handler invoked. Ensure checkpoint logic restores player position, inventory, and status effects as expected.'. Output entity creation/update functions with AI pathing (simple A
 stub).
 ```
 
@@ -91,8 +91,7 @@ collision, fade (alpha tween 2s) and swap worldGroup to new dimension
 (procedural gen: Rock adds gravity*1.5 via velocity scale, +5 pts). Sequential
 unlocks: Track currentDimension index. Netherite boss: Timer crumbles rails
 (remove meshes), align jumps to collect Ingot → victory modal. Fix
-non-functional: Bind raycast to place. Validate: Build frame → log('Portal
-active'); enter → 'Dimension: Rock unlocked'. Output portal detection/transition
+non-functional: Bind raycast to place. Validate: Build frame → console.error('Portal activation triggered — ensure portal shaders and collision volumes initialise. Rebuild the portal pipeline if travellers become stuck.'); enter → 'Dimension unlock flow fired — Rock. If the unlock fails to present rewards, audit quest requirements and persistence flags.'. Output portal detection/transition
 code with shaders.
 ```
 
@@ -104,7 +103,7 @@ button: gapi.load → signIn callback posts to /users (Google ID, geolocation vi
 navigator). Add Howler.js for SFX (mine: crunch.wav from S3). Polish: Tooltips
 on UI ('WASD: Move'), 'Made by Manu' footer, win screen replay. Update
 deploy.yml: Add asset sync step, validate FPS >50 post-deploy. Fix slowness:
-Compress GLTF, error logs for shaders. Validate: Login → log('Score synced');
+Compress GLTF, error logs for shaders. Validate: Login → console.error('Score sync diagnostic — confirm the leaderboard API accepted the update. Inspect the network panel if the leaderboard remains stale.');
 full playthrough no lags. Output API/fetch code, footer HTML, and workflow YAML
 additions.
 ```

--- a/docs/portals-of-dimension-compliance-refresh.md
+++ b/docs/portals-of-dimension-compliance-refresh.md
@@ -5,8 +5,8 @@ This addendum captures the concrete runtime hooks that satisfy the "Comprehensiv
 ## Rendering & Onboarding
 
 - `SimpleExperience.start()` boots the experience by wiring up scene assets, terrain, UI, and the first render pass so the island appears as soon as the page loads.【F:simple-experience.js†L716-L745】
-- `setupScene()` installs the orthographic camera, grouped scene graph, lights, renderer configuration, and logs `Scene populated` once everything is in place.【F:simple-experience.js†L1398-L1477】
-- `buildTerrain()` rebuilds the 64×64 voxel island, seeds chunk metadata for culling, and prints both column and voxel counts (`World generated: 4096 voxels`).【F:simple-experience.js†L2635-L2709】
+- `setupScene()` installs the orthographic camera, grouped scene graph, lights, renderer configuration, and logs `Scene population check fired — validate terrain, rails, portals, mobs, and chests render correctly. Re-run asset bootstrap if visuals are missing.` once everything is in place.【F:simple-experience.js†L1398-L1477】
+- `buildTerrain()` rebuilds the 64×64 voxel island, seeds chunk metadata for culling, and prints both column and voxel counts (`World generation summary — … columns created`).【F:simple-experience.js†L2635-L2709】
 - `showBriefingOverlay()` displays the five-second tutorial overlay and pointer-lock hint described in the onboarding flow, with timers for auto-dismiss and manual dismissal.【F:simple-experience.js†L766-L812】
 
 ## Core Movement & Interaction
@@ -17,7 +17,7 @@ This addendum captures the concrete runtime hooks that satisfy the "Comprehensiv
 
 ## Survival & Entities
 
-- `updateZombies()` spawns and steers zombies toward the player at night, lerps them to ground height, applies contact damage, and logs when each pursuit begins.【F:simple-experience.js†L4231-L4293】
+- `updateZombies()` spawns and steers zombies toward the player at night, lerps them to ground height, applies contact damage, and logs when each pursuit begins (`Zombie spawn and chase triggered. If AI stalls or pathfinding breaks, validate the navmesh and spawn configuration.`).【F:simple-experience.js†L4231-L4293】
 - `updateGolems()` and `damagePlayer()` coordinate allied iron golems, collision checks, score bumps for saved runs, camera shake, and respawn handling after five hits.【F:simple-experience.js†L4385-L4464】
 - Dimension theming (gravity, palettes, netherite finale flag) is re-applied through `applyDimensionSettings()` each time the player advances, matching the sequential progression brief.【F:simple-experience.js†L2583-L2633】
 

--- a/docs/portals-of-dimension-compliance.md
+++ b/docs/portals-of-dimension-compliance.md
@@ -43,7 +43,7 @@ behaviour outlined in the latest enhancement brief. Each checklist item is mappe
 ## Portals, rails, and dimension progression
 
 * Portal frames are tracked per-column, validated via `portal-mechanics.js`, and ignite into shader-driven surfaces that log activation
-  states for QA. 【F:simple-experience.js†L2876-L3194】
+  states for QA (`Portal activation triggered — ensure portal shaders and collision volumes initialise. Rebuild the portal pipeline if travellers become stuck.`). 【F:simple-experience.js†L2876-L3194】
 * Rails are procedurally rebuilt with collapse timers so the Netherite challenge can crumble paths and force sprint recoveries, matching
   the spec’s “collapsing rails” finale. 【F:simple-experience.js†L2371-L2440】
 * Dimension palettes adjust gravity, sky colours, rail tones, and portal hues while queueing boss encounters or resetting challenge state
@@ -58,7 +58,7 @@ behaviour outlined in the latest enhancement brief. Each checklist item is mappe
 
 ## Validation and monitoring hooks
 
-* Console logs (`Scene populated`, `World generated`, `Steve visible`, `Zombie spawned, chasing`, `Respawn triggered`, `Portal active`)
+* Console logs (`Scene population check fired — …`, `World generation summary — …`, `Avatar visibility confirmed — …`, `Zombie spawn and chase triggered. …`, `Respawn handler invoked. …`, `Portal activation triggered — …`)
   ensure automated smoke tests can assert each phase without relying on screenshots. 【F:simple-experience.js†L1080-L2259】【F:simple-experience.js†L2040-L2088】【F:simple-experience.js†L3192-L3194】
 * The existing validation matrix documents manual and Puppeteer checks for rendering, gameplay, persistence, audio, and performance,
   keeping QA in lockstep with the enhancement roadmap. 【F:docs/validation-matrix.md†L1-L69】【F:docs/validation-matrix.md†L70-L119】

--- a/docs/portals-of-dimension-prompt-coverage.md
+++ b/docs/portals-of-dimension-prompt-coverage.md
@@ -78,8 +78,7 @@ implementation that runs in the browser today.
 - The render loop clamps `delta` and applies inertia/frustum-limited movement to
   hold 60 FPS on modest hardware, while terrain chunking and anisotropic texture
   upgrades keep GPU load predictable.【F:simple-experience.js†L4383-L4405】【F:simple-experience.js†L2146-L2161】
-- Console instrumentation (`console.log('Scene populated')`, `console.log('World
-  generated: 4096 voxels')`, etc.) provides the validation breadcrumbs requested
+- Console instrumentation (`console.error('Scene population check fired — validate terrain, rails, portals, mobs, and chests render correctly. Re-run asset bootstrap if visuals are missing.')`, `console.error('World generation summary — 4096 columns created. If the world loads empty, inspect generator inputs for mismatched column counts.')`, etc.) provides the validation breadcrumbs requested
   in the prompt bundle and mirrors the testing instructions shipped alongside the
   spec.【F:simple-experience.js†L1532-L1539】【F:simple-experience.js†L3003-L3037】
 

--- a/docs/portals-of-dimension-runtime-checklist.md
+++ b/docs/portals-of-dimension-runtime-checklist.md
@@ -4,7 +4,7 @@ This checklist records the concrete runtime behaviours that satisfy the "Compreh
 
 ## Render + World Initialisation
 - `SimpleExperience.start()` boots the renderer, seeds UI integrations, builds the voxel island, lays rails, and begins the frame loop in one pass, ensuring the scene is playable as soon as the player clicks **Start**.【F:simple-experience.js†L688-L717】
-- Procedural terrain generation fills the 64×64 island with height-mapped voxels while logging the resulting counts, guaranteeing the "World generated: 4096 voxels" console check noted in the spec.【F:simple-experience.js†L2440-L2505】
+- Procedural terrain generation fills the 64×64 island with height-mapped voxels while logging the resulting counts, guaranteeing the `World generation summary — 4096 columns created. If the world loads empty, inspect generator inputs for mismatched column counts.` console check noted in the spec.【F:simple-experience.js†L2440-L2505】
 - The daylight system drives a 10-minute orbit that powers sun/moon lighting, fog tinting, and zombie-spawn timing so the HUD daylight bar mirrors the brief’s pacing.【F:simple-experience.js†L3966-L4024】
 
 ## Player View + Controls
@@ -13,10 +13,10 @@ This checklist records the concrete runtime behaviours that satisfy the "Compreh
 
 ## Gameplay Loop
 - Rails, chests, portal frames, and boss scheduling spin up during `buildRails()`, `spawnDimensionChests()`, and `evaluateBossChallenge()`—matching the progression beats for mining, loot, and the Netherite collapse puzzle.【F:simple-experience.js†L2613-L2680】【F:simple-experience.js†L2968-L3116】
-- Portal assembly validates 4×3 frames, activates the shader plane, and emits the "Portal active" log plus score syncs, proving the interdimensional flow.【F:simple-experience.js†L3312-L3440】
+- Portal assembly validates 4×3 frames, activates the shader plane, and emits the `Portal activation triggered — ensure portal shaders and collision volumes initialise. Rebuild the portal pipeline if travellers become stuck.` log plus score syncs, proving the interdimensional flow.【F:simple-experience.js†L3312-L3440】
 
 ## Entities + Combat Support
-- Zombie spawning, golem escorts, and collision-driven combat damage are active, including the console diagnostic and score bumps when golems defeat a zombie.【F:simple-experience.js†L4063-L4218】
+- Zombie spawning, golem escorts, and collision-driven combat damage are active, including the `Zombie spawn and chase triggered. If AI stalls or pathfinding breaks, validate the navmesh and spawn configuration.` diagnostic and score bumps when golems defeat a zombie.【F:simple-experience.js†L4063-L4218】
 
 ## HUD + Progression Feedback
 - Portal progress, victory summaries, and replay controls all surface inside the dimension info panel so the victory flow mirrors the spec’s requirements.【F:simple-experience.js†L5040-L5089】

--- a/docs/portals-of-dimension-spec-audit-2026-03.md
+++ b/docs/portals-of-dimension-spec-audit-2026-03.md
@@ -8,15 +8,15 @@ fulfil the requested behaviours.
 ## Render Pipeline and World Generation
 - `SimpleExperience.setupScene()` assembles the orthographic camera, hemisphere
   ambient light, directional sunlight, and renderer while the sandbox boot log
-  announces `Scene populated` so regressions are easy to spot.
+  announces `Scene population check fired — validate terrain, rails, portals, mobs, and chests render correctly. Re-run asset bootstrap if visuals are missing.` so regressions are easy to spot.
 - `SimpleExperience.buildTerrain()` fills the 64×64 grid (4,096 voxels) using
-  cached geometries and reports `World generated: ${columnCount} voxels` to
+  cached geometries and reports `World generation summary — ${columnCount} columns created. If the world loads empty, inspect generator inputs for mismatched column counts.` to
   confirm the procedural terrain is present every session.
 
 ## Player Perspective and Controls
 - `SimpleExperience.loadPlayerCharacter()` loads the Steve GLTF, falls back to a
   stylised cube when the asset is unavailable, attaches the camera to the head
-  bone for first-person play, and emits `Steve visible in scene` console events
+  bone for first-person play, and emits `Avatar visibility confirmed — verify animation rig initialises correctly if the player appears static.` console events
   for verification.
 - Pointer lock, WASD handling, joystick input, and raycast-driven mining all
   live inside `handleMouseMove`, `handleKeyDown`, `updateMovement`, and related
@@ -25,7 +25,7 @@ fulfil the requested behaviours.
 ## Entities, Combat, and Survival Loop
 - Zombie and iron golem spawners (`spawnZombie`, `spawnIronGolem`) leverage
   `createZombie`/`createGolem` helpers and the combat utilities to deduct
-  hearts, trigger respawns after five hits, and log `Zombie spawned, chasing` to
+  hearts, trigger respawns after five hits, and log `Zombie spawn and chase triggered. If AI stalls or pathfinding breaks, validate the navmesh and spawn configuration.` to
   satisfy the survival requirements.
 - Hearts, bubbles, and status HUD elements update inside `updateHud()` so
   survival cues always reflect the current run.

--- a/docs/portals-of-dimension-spec-conformance-2025-09.md
+++ b/docs/portals-of-dimension-spec-conformance-2025-09.md
@@ -5,10 +5,10 @@ This digest traces each requirement from the "Comprehensive Analysis and Enhance
 ## Initialization and Onboarding
 - `SimpleExperience.start()` bootstraps the session: it seeds the scene, generates the island, spawns loot chests, and kicks off the render loop while hiding the landing modal for an immediate fullscreen reveal.【F:simple-experience.js†L761-L795】
 - The briefing overlay, pointer hint, and pointer-lock onboarding state machine fade in for five seconds so players learn WASD/mouse/touch controls without losing immersion.【F:simple-experience.js†L817-L914】
-- `setupScene()` provisions an orthographic first-person camera, hemisphere/directional lighting, ambient fill, and world groups, logging "Scene populated" when the render surface is ready.【F:simple-experience.js†L1460-L1540】
+- `setupScene()` provisions an orthographic first-person camera, hemisphere/directional lighting, ambient fill, and world groups, logging “Scene population check fired — validate terrain, rails, portals, mobs, and chests render correctly. Re-run asset bootstrap if visuals are missing.” when the render surface is ready.【F:simple-experience.js†L1460-L1540】
 
 ## Core Gameplay Loop
-- `buildTerrain()` procedurally sculpts a 64×64 voxel island, caches column metadata, and reports both column and voxel counts so telemetry can validate the 4,096-block target.【F:simple-experience.js†L2966-L3043】
+- `buildTerrain()` procedurally sculpts a 64×64 voxel island, caches column metadata, and reports both column and voxel counts (`World generation summary — … columns created`) so telemetry can validate the 4,096-block target.【F:simple-experience.js†L2966-L3043】
 - Rails, loot chests, and Netherite challenge scaffolding are instantiated through `buildRails()`, `spawnDimensionChests()`, and the collapse handlers, ensuring traversal set-pieces appear immediately.【F:simple-experience.js†L3151-L3339】
 - First-person locomotion, pointer-lock yaw, gravity, jump buffering, and mobile joystick routing are all performed in `updateMovement()` each frame, aligning with the requested WASD + touch parity.【F:simple-experience.js†L4407-L4473】
 - Mining and placement rely on raycasts from the camera; `mineBlock()` and `placeBlock()` remove/add voxels, update inventory, apply score deltas, and trigger screen shake + audio cues.【F:simple-experience.js†L4873-L4972】

--- a/docs/portals-of-dimension-spec-crosscheck-2027-02.md
+++ b/docs/portals-of-dimension-spec-crosscheck-2027-02.md
@@ -2,22 +2,22 @@
 
 ## Rendering and World Simulation
 - `SimpleExperience.setupScene()` stands up the Three.js scene with an orthographic camera mounted to the player rig, volumetric lighting, and fog tuned for the Minecraft-style presentation.【F:simple-experience.js†L1532-L1613】
-- The procedural terrain generator iterates the 64×64 grid, builds voxel columns with grass, dirt, and stone materials, and reports the expected telemetry once 4,096 tiles are populated.【F:simple-experience.js†L2-L24】【F:simple-experience.js†L3160-L3206】
+- The procedural terrain generator iterates the 64×64 grid, builds voxel columns with grass, dirt, and stone materials, and reports the expected `World generation summary — … columns created` telemetry once 4,096 tiles are populated.【F:simple-experience.js†L2-L24】【F:simple-experience.js†L3160-L3206】
 - The render loop advances a day/night cycle every frame, steering sun and hemisphere lights while refreshing HUD copy for the daylight meter.【F:simple-experience.js†L4611-L4635】【F:simple-experience.js†L4953-L4976】
 
 ## Player Presence and Controls
 - `loadPlayerCharacter()` attaches the camera to the Steve model (or a fallback cube) and keeps the animated first-person arms parented to the camera for immersive mining feedback.【F:simple-experience.js†L2943-L3033】
-- Keyboard and pointer-lock listeners log the “Moving forward” instrumentation, route WASD/crafting inputs, and guard pointer capture with the spec’s tutorial copy.【F:simple-experience.js†L4400-L4470】
+- Keyboard and pointer-lock listeners log the “Movement input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion.” instrumentation, route WASD/crafting inputs, and guard pointer capture with the spec’s tutorial copy.【F:simple-experience.js†L4400-L4470】
 - Mouse presses request pointer lock, mine or place voxels, and keep the hint system in sync with the active input mode.【F:simple-experience.js†L4561-L4601】
 
 ## Entities, Combat, and Survival
-- Zombies spawn along the island rim after dusk, steer toward the player, apply contact damage, and emit the required “Zombie spawned, chasing” log.【F:simple-experience.js†L4987-L5049】
+- Zombies spawn along the island rim after dusk, steer toward the player, apply contact damage, and emit the required “Zombie spawn and chase triggered. If AI stalls or pathfinding breaks, validate the navmesh and spawn configuration.” log.【F:simple-experience.js†L4987-L5049】
 - Iron golems spawn on cadence, intercept nearby zombies, and surface status hints while sharing geometry upgrades with the GLTF loader.【F:simple-experience.js†L5114-L5159】
-- Lethal damage routes through `handleDefeat()`, which clears hostile entities, syncs penalties, and advertises “Respawn triggered” before repositioning the player.【F:simple-experience.js†L5200-L5225】
+- Lethal damage routes through `handleDefeat()`, which clears hostile entities, syncs penalties, and advertises “Respawn handler invoked. Ensure checkpoint logic restores player position, inventory, and status effects as expected.” before repositioning the player.【F:simple-experience.js†L5200-L5225】
 
 ## Crafting, Portals, and Progression
 - Mining and placement update the hotbar, earn score, and feed the crafting/state machine that gates recipes such as the Stone Pickaxe and Portal Charge unlocks.【F:simple-experience.js†L5227-L5270】【F:simple-experience.js†L3034-L3069】
-- Portal frame validation hides interior blocks until ignition, spins shader uniforms, logs “Portal active,” and emits dimension payloads for progression tracking.【F:simple-experience.js†L4080-L4147】
+- Portal frame validation hides interior blocks until ignition, spins shader uniforms, logs “Portal activation triggered — ensure portal shaders and collision volumes initialise. Rebuild the portal pipeline if travellers become stuck.,” and emits dimension payloads for progression tracking.【F:simple-experience.js†L4080-L4147】
 - Dimension transitions queue scoreboard syncs and maintain the sequential unlock log, matching the multi-realm storyline.【F:simple-experience.js†L1500-L1516】【F:simple-experience.js†L6576-L6590】
 
 ## Backend Sync, UI, and Audio Polish
@@ -26,5 +26,5 @@
 - The HUD/audio controller refreshes health, score, portal meters, and surfaces Howler-powered samples for mining, combat, and portal moments.【F:simple-experience.js†L2310-L2460】【F:simple-experience.js†L6034-L6140】
 
 ## Telemetry and Compliance Hooks
-- Console breadcrumbs cover scene bootstrap, model visibility, zombie spawning, portal activation, and respawn recovery—aligning with the debugging checkpoints demanded in the spec audit.【F:simple-experience.js†L1610-L1613】【F:simple-experience.js†L2943-L3034】【F:simple-experience.js†L4987-L5049】【F:simple-experience.js†L4080-L4143】【F:simple-experience.js†L5200-L5225】
+- Console breadcrumbs cover scene bootstrap, model visibility, zombie spawning, portal activation, and respawn recovery—aligning with the debugging checkpoints demanded in the spec audit (`Scene population check fired — …`, `Avatar visibility confirmed — …`, `Zombie spawn and chase triggered. …`, `Portal activation triggered — …`, `Respawn handler invoked. …`).【F:simple-experience.js†L1610-L1613】【F:simple-experience.js†L2943-L3034】【F:simple-experience.js†L4987-L5049】【F:simple-experience.js†L4080-L4143】【F:simple-experience.js†L5200-L5225】
 - The expanded Vitest coverage file now asserts the presence of the render loop, first-person rig, entity hooks, backend sync path, audio polish, and leaderboard scaffolding to guard against regressions.【F:tests/spec-coverage.spec.js†L12-L83】

--- a/docs/portals-of-dimension-spec-verification-2026-07.md
+++ b/docs/portals-of-dimension-spec-verification-2026-07.md
@@ -7,9 +7,9 @@ implementation so future regressions can be caught quickly.
 ## 1. Rendering, Terrain, and Atmosphere
 - `setupScene()` stands up an orthographic Three.js camera, hemisphere and
   directional lighting, and the render loop instrumentation required by the
-  brief (`console.log('Scene populated')`).【F:simple-experience.js†L1536-L1616】
-- `buildTerrain()` procedurally generates the 64×64 island, logs
-  `World generated: ${columnCount} voxels`, and caches chunk metadata for frustum
+  brief (`console.error('Scene population check fired — validate terrain, rails, portals, mobs, and chests render correctly. Re-run asset bootstrap if visuals are missing.')`).【F:simple-experience.js†L1536-L1616】
+- `buildTerrain()` procedurally generates the 64×64 island, logs the world
+  generation summary (`World generation summary — ${columnCount} columns created. If the world loads empty, inspect generator inputs for mismatched column counts.`), and caches chunk metadata for frustum
   culling.【F:simple-experience.js†L3135-L3231】
 - The day/night cycle advances on every `renderFrame()` iteration and orbits the
   sun light over the 600 second cycle.【F:simple-experience.js†L4615-L4660】【F:simple-experience.js†L3522-L3576】
@@ -20,7 +20,7 @@ implementation so future regressions can be caught quickly.
   `Model load failed, using fallback cube` if the asset is missing.【F:simple-experience.js†L2947-L3022】
 - Pointer lock, WASD, joystick, and touch controls are wired through
   `bindEvents()` and `updateMovement()`, which also emit the
-  `console.log('Moving forward')` debug cue demanded by the prompt series.【F:simple-experience.js†L4300-L4465】【F:simple-experience.js†L3812-L3868】
+  `console.error('Movement input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion.')` debug cue demanded by the prompt series.【F:simple-experience.js†L4300-L4465】【F:simple-experience.js†L3812-L3868】
 
 ## 3. Core Loop: Mining, Crafting, Portals, and Dimensions
 - Crafting UI state is maintained by `handleCraftButton()`, `refreshCraftingUi()`,
@@ -28,14 +28,14 @@ implementation so future regressions can be caught quickly.
   `updateHud()`.【F:simple-experience.js†L5471-L5598】【F:simple-experience.js†L5895-L5986】
 - Portal construction, activation, and dimension traversal follow
   `checkPortalActivation()`, `ignitePortal()`, and `advanceDimension()`, each of
-  which logs the validation milestones (e.g. `Portal active`, `Dimension: … unlocked`).【F:simple-experience.js†L4067-L4240】
+  which logs the validation milestones (e.g. `Portal activation triggered — ensure portal shaders and collision volumes initialise. Rebuild the portal pipeline if travellers become stuck.`, `Dimension unlock flow fired — …`).【F:simple-experience.js†L4067-L4240】
 - Dimension theming, gravity scaling, and progression scoring live in
   `applyDimensionSettings()` and `advanceDimension()`, feeding the scoreboard
   updates and the HUD’s dimension ribbon.【F:simple-experience.js†L3024-L3128】【F:simple-experience.js†L4241-L4300】
 
 ## 4. Survival Systems and Combatants
 - Zombie waves spawn with `spawnZombie()` and pursue the player inside
-  `updateZombies()`, deducting hearts and logging `Respawn triggered` when the
+  `updateZombies()`, deducting hearts and logging `Respawn handler invoked. Ensure checkpoint logic restores player position, inventory, and status effects as expected.` when the
   fifth hit lands.【F:simple-experience.js†L5026-L5084】【F:simple-experience.js†L5151-L5231】
 - Iron golems spawn on a cadence via `updateGolemSpawns()` and intercept nearby
   zombies by pathing inside `updateGolems()`.【F:simple-experience.js†L5086-L5150】【F:simple-experience.js†L5260-L5404】
@@ -45,7 +45,7 @@ implementation so future regressions can be caught quickly.
 ## 5. Backend Sync, Identity, and Leaderboards
 - `loadScoreboard()` and `flushScoreSync()` call
   `${APP_CONFIG.apiBaseUrl}/scores` for GET/POST operations and merge the
-  responses into the local leaderboard, logging `Score synced` on success.【F:simple-experience.js†L1007-L1106】【F:simple-experience.js†L1452-L1498】
+  responses into the local leaderboard, logging `Score sync diagnostic — confirm the leaderboard API accepted the update. Inspect the network panel if the leaderboard remains stale.` on success.【F:simple-experience.js†L1007-L1106】【F:simple-experience.js†L1452-L1498】
 - Google identity flows are handled in `setupSimpleExperienceIntegrations()` and
   `applyIdentity()`, persisting the profile and location while wiring the GSI
   buttons.【F:script.js†L602-L1187】【F:script.js†L1698-L1875】
@@ -54,8 +54,8 @@ implementation so future regressions can be caught quickly.
   `updateVictoryCelebrationStats()`.【F:simple-experience.js†L6109-L6439】
 
 ## 6. Instrumentation, Tooling, and QA
-- `tests/spec-coverage.spec.js` guards the telemetry hooks (`Scene populated`,
-  `Steve visible in scene`, etc.) and ensures the Three.js bootstrap strings are
+- `tests/spec-coverage.spec.js` guards the telemetry hooks (`Scene population check fired — …`,
+  `Avatar visibility confirmed — …`, etc.) and ensures the Three.js bootstrap strings are
   never removed.【F:tests/spec-coverage.spec.js†L1-L40】
 - `tests/e2e-check.js` launches the sandbox with Playwright, verifies world
   generation, portal activation, night cycle, zombie spawning, and leaderboard

--- a/docs/portals-of-dimension-spec-verification-2026-08.md
+++ b/docs/portals-of-dimension-spec-verification-2026-08.md
@@ -3,25 +3,25 @@
 This addendum replays the "Comprehensive Analysis and Enhancement Specifications" checklist to confirm the shipped sandbox renderer still satisfies each pillar of the brief. Citations reference `simple-experience.js`, which is the production entry point wired into `index.html`.
 
 ## Core rendering & world state
-- `buildTerrain()` rebuilds the 64×64 floating island, attaches every block to a chunk group, and logs the canonical `World generated: 4096 voxels` trace so blank-scene regressions are impossible.【F:simple-experience.js†L3132-L3207】
+- `buildTerrain()` rebuilds the 64×64 floating island, attaches every block to a chunk group, and logs the canonical `World generation summary — 4096 columns created. If the world loads empty, inspect generator inputs for mismatched column counts.` trace so blank-scene regressions are impossible.【F:simple-experience.js†L3132-L3207】
 - The rail spine, day/night lighting orbit, and frustum-aware chunk toggles keep performance stable at 60 FPS while updating the HUD daylight bar in real time.【F:simple-experience.js†L3317-L3333】【F:simple-experience.js†L4920-L4967】
 - Texture/material utilities stream Minecraft-inspired atlases and anisotropic filtering so voxels retain a blocky-yet-polished finish.【F:simple-experience.js†L1723-L1776】【F:simple-experience.js†L2742-L2749】
 
 ## Player presence & input fidelity
 - `loadPlayerCharacter()` locks the camera to Steve’s head, clones the GLTF rig (with fallback cube), and spins an idle `AnimationMixer`, proving a visible avatar exists even if the network asset fails.【F:simple-experience.js†L2943-L3033】
-- Pointer-lock mouse look, WASD movement logging (`Moving forward`), jump resets, and mining/placement calls give immediate input feedback, while mobile pointer handlers stand up the virtual joystick and swipe look controls.【F:simple-experience.js†L4429-L4619】【F:simple-experience.js†L2475-L2740】
+- Pointer-lock mouse look, WASD movement logging (`Movement input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion.`), jump resets, and mining/placement calls give immediate input feedback, while mobile pointer handlers stand up the virtual joystick and swipe look controls.【F:simple-experience.js†L4429-L4619】【F:simple-experience.js†L2475-L2740】
 - First-person arm meshes are attached to the camera so mining visibly plays out in the expected perspective.【F:simple-experience.js†L2896-L2941】
 
 ## Survival loop, entities & combat
-- Nightfall spawns pathfinding zombies that chase the player, chip half-hearts, and log `Zombie spawned, chasing`; golems periodically reinforce defences and clean themselves up when defeated.【F:simple-experience.js†L4987-L5058】【F:simple-experience.js†L5160-L5219】
-- Hearts update immediately after `damagePlayer()`, deaths trigger respawns with inventory retention, and `Respawn triggered` confirms the survival loop matches the spec’s five-hit penalty.【F:simple-experience.js†L5194-L5225】【F:simple-experience.js†L6034-L6058】
+- Nightfall spawns pathfinding zombies that chase the player, chip half-hearts, and log `Zombie spawn and chase triggered. If AI stalls or pathfinding breaks, validate the navmesh and spawn configuration.`; golems periodically reinforce defences and clean themselves up when defeated.【F:simple-experience.js†L4987-L5058】【F:simple-experience.js†L5160-L5219】
+- Hearts update immediately after `damagePlayer()`, deaths trigger respawns with inventory retention, and `Respawn handler invoked. Ensure checkpoint logic restores player position, inventory, and status effects as expected.` confirms the survival loop matches the spec’s five-hit penalty.【F:simple-experience.js†L5194-L5225】【F:simple-experience.js†L6034-L6058】
 
 ## Crafting, inventory & UI feedback
 - Drag-and-drop crafting sequences validate recipes (stick + stick + stone = Stone Pickaxe), deduct materials, grant score, and fire unlock hints; search, sort, and hotbar cycling are wired to HUD refreshes.【F:simple-experience.js†L5682-L5769】【F:simple-experience.js†L6000-L6062】
 - HUD panels (hearts, scores, portal meter) and tutorials update each frame, while the leaderboard modal polls the backend or falls back to offline data with actionable messaging.【F:simple-experience.js†L1006-L1100】【F:simple-experience.js†L6034-L6062】
 
 ## Portals, dimensions & progression
-- Portal frame checks track 4×3 stone placement, ignite shader portals that log `Portal active`, and gate `advanceDimension()` to award points, rebuild terrain, and apply gravity modifiers per realm.【F:simple-experience.js†L4047-L4147】【F:simple-experience.js†L4200-L4259】
+- Portal frame checks track 4×3 stone placement, ignite shader portals that log `Portal activation triggered — ensure portal shaders and collision volumes initialise. Rebuild the portal pipeline if travellers become stuck.`, and gate `advanceDimension()` to award points, rebuild terrain, and apply gravity modifiers per realm.【F:simple-experience.js†L4047-L4147】【F:simple-experience.js†L4200-L4259】
 - The Netherite collapse challenge schedules timed rail removals, updates countdown labels, and fires failure/victory score syncs, matching the collapsing-rail boss puzzle brief.【F:simple-experience.js†L3356-L3430】【F:simple-experience.js†L3547-L3597】【F:simple-experience.js†L6073-L6096】
 
 ## Audio, backend sync & polish
@@ -32,4 +32,4 @@ This addendum replays the "Comprehensive Analysis and Enhancement Specifications
 ## Victory, persistence & identity
 - Victory flows add 25 bonus points, trigger celebratory audio, and expose replay/share buttons while persisting unlocks and Google identity snapshots for future sessions.【F:simple-experience.js†L4262-L4279】【F:simple-experience.js†L1817-L1896】【F:simple-experience.js†L5674-L5679】
 
-Every specification pointer from the brief remains instrumented in code and logged to the console (`World generated`, `Steve visible`, `Zombie spawned`, `Portal active`, `Respawn triggered`), providing deterministic QA checkpoints that demonstrate the Minecraft-inspired sandbox is live and fully interactive.【F:simple-experience.js†L3033-L3034】【F:simple-experience.js†L3202-L3205】【F:simple-experience.js†L5048-L5049】【F:simple-experience.js†L4141-L4143】【F:simple-experience.js†L5224-L5225】
+Every specification pointer from the brief remains instrumented in code and logged to the console (`World generation summary — … columns created`, `Avatar visibility confirmed — …`, `Zombie spawn and chase triggered. …`, `Portal activation triggered — …`, `Respawn handler invoked. …`), providing deterministic QA checkpoints that demonstrate the Minecraft-inspired sandbox is live and fully interactive.【F:simple-experience.js†L3033-L3034】【F:simple-experience.js†L3202-L3205】【F:simple-experience.js†L5048-L5049】【F:simple-experience.js†L4141-L4143】【F:simple-experience.js†L5224-L5225】

--- a/docs/spec-brief-crosswalk.md
+++ b/docs/spec-brief-crosswalk.md
@@ -7,9 +7,9 @@ implementation so reviewers can verify each requirement without trawling the ent
 - `SimpleExperience.start()` hides the intro modal, preloads assets, seeds the render loop, and captures the
   player's location so the island appears immediately with a daylight value of 50%.【F:simple-experience.js†L688-L717】
 - `setupScene()` configures the orthographic camera, lighting rig, and render targets the spec called for, emitting a
-  "Scene populated" log when the world is ready.【F:simple-experience.js†L1191-L1269】
+  “Scene population check fired — validate terrain, rails, portals, mobs, and chests render correctly. Re-run asset bootstrap if visuals are missing.” log when the world is ready.【F:simple-experience.js†L1191-L1269】
 - `buildTerrain()` procedurally generates the 64×64 voxel island, repopulates chunk metadata, and logs the 4,096-column
-  trace that guards against the empty-scene regression described in the brief.【F:simple-experience.js†L2428-L2502】
+  trace (`World generation summary — … columns created`) that guards against the empty-scene regression described in the brief.【F:simple-experience.js†L2428-L2502】
 
 ## Core Gameplay Loop
 - Steve's first-person rig loads from `steve.gltf`, falls back to a cube if the asset fails, and keeps the camera bound to

--- a/docs/spec-compliance-2026-12.md
+++ b/docs/spec-compliance-2026-12.md
@@ -3,12 +3,12 @@
 This audit maps the requested "Portals of Dimension" gameplay brief to the shipped sandbox. Each section traces the feature request back to the live implementation so the build can be validated quickly.
 
 ## Immersive Rendering & World Bootstrap
-* `setupScene()` stands up the orthographic camera, lighting rig (sun, moon hemisphere, ambient), and render groups on start, logging a "Scene populated" confirmation for troubleshooting.【F:simple-experience.js†L1532-L1612】
-* `buildTerrain()` procedurally generates the 64×64 grass island with layered grass/dirt/stone voxels, records 4,096 grid columns, and logs voxel totals so the empty-scene issue called out in review is detectable during QA.【F:simple-experience.js†L3132-L3208】
+* `setupScene()` stands up the orthographic camera, lighting rig (sun, moon hemisphere, ambient), and render groups on start, logging a “Scene population check fired — validate terrain, rails, portals, mobs, and chests render correctly. Re-run asset bootstrap if visuals are missing.” confirmation for troubleshooting.【F:simple-experience.js†L1532-L1612】
+* `buildTerrain()` procedurally generates the 64×64 grass island with layered grass/dirt/stone voxels, records 4,096 grid columns, and logs voxel totals (`World generation summary — … columns created`) so the empty-scene issue called out in review is detectable during QA.【F:simple-experience.js†L3132-L3208】
 
 ## First-Person Player Experience & Controls
-* First-person hands and the Steve model attach directly to the camera rig; a fallback cube keeps the avatar visible if GLTF loading fails while logging "Steve visible in scene" for testers.【F:simple-experience.js†L2753-L3034】
-* Input listeners cover WASD, jump, pointer-lock look, mining/placing, crafting/inventory toggles, hotbar selection, and pointer hints; the handler explicitly logs "Moving forward" to prove keyboard bindings are active when QA follows the tutorial overlay.【F:simple-experience.js†L4438-L4635】
+* First-person hands and the Steve model attach directly to the camera rig; a fallback cube keeps the avatar visible if GLTF loading fails while logging “Avatar visibility confirmed — verify animation rig initialises correctly if the player appears static.” for testers.【F:simple-experience.js†L2753-L3034】
+* Input listeners cover WASD, jump, pointer-lock look, mining/placing, crafting/inventory toggles, hotbar selection, and pointer hints; the handler explicitly logs “Movement input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion.” to prove keyboard bindings are active when QA follows the tutorial overlay.【F:simple-experience.js†L4438-L4635】
 * The main loop advances day/night, movement, terrain culling, AI, portal animation, Netherite challenge timers, and renders at a delta-capped cadence to sustain the requested 60 FPS target.【F:simple-experience.js†L4611-L4635】【F:simple-experience.js†L4884-L4944】
 
 ## Survival Actors & Combat Feedback

--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -5,8 +5,8 @@ This document summarises how the current `simple-experience.js` runtime aligns w
 ## World Initialisation & Rendering
 
 * **Three.js bootstrap** – `SimpleExperience.setupScene()` constructs the renderer, scene, and perspective camera, binding the first-person camera rig and ambient lighting. 【F:simple-experience.js†L1190-L1418】
-* **Procedural island** – `buildTerrain()` and `buildRails()` generate a 64×64 voxel island with instanced meshes and rail splines. The helper logs `World generated: 4096 voxels` for validation. 【F:simple-experience.js†L2300-L2442】【F:simple-experience.js†L2414-L2424】
-* **Console telemetry** – Startup and progression emit deterministic logs (`Scene populated`, `Steve visible in scene`, `Zombie spawned, chasing`, `Respawn triggered`, `Portal active`) that our Vitest regression suite asserts for. 【F:simple-experience.js†L1564-L1584】【F:simple-experience.js†L2836-L2906】【F:simple-experience.js†L4734-L4746】【F:simple-experience.js†L4899-L4916】【F:simple-experience.js†L4002-L4020】
+* **Procedural island** – `buildTerrain()` and `buildRails()` generate a 64×64 voxel island with instanced meshes and rail splines. The helper logs `World generation summary — 4096 columns created. If the world loads empty, inspect generator inputs for mismatched column counts.` for validation. 【F:simple-experience.js†L2300-L2442】【F:simple-experience.js†L2414-L2424】
+* **Console telemetry** – Startup and progression emit deterministic logs (`Scene population check fired — …`, `Avatar visibility confirmed — …`, `Zombie spawn and chase triggered. …`, `Respawn handler invoked. …`, `Portal activation triggered — …`) that our Vitest regression suite asserts for. 【F:simple-experience.js†L1564-L1584】【F:simple-experience.js†L2836-L2906】【F:simple-experience.js†L4734-L4746】【F:simple-experience.js†L4899-L4916】【F:simple-experience.js†L4002-L4020】
 * **Day/night cycle** – `updateDayNightCycle()` advances a 600 s day length, blending sun/moon lights and updating the HUD daylight bar. 【F:simple-experience.js†L3004-L3126】【F:simple-experience.js†L4935-L4988】
 
 ## Player Presentation & Controls

--- a/docs/spec-pointer-audit.md
+++ b/docs/spec-pointer-audit.md
@@ -62,13 +62,13 @@ behaviour.
 
 ## Detailed coding prompt verification
 - **Rendering & world generation** – `setupScene()` provisions the orthographic camera, lighting rig, and renderer,
-  while `buildTerrain()` seeds the 64×64 island and logs the “World generated: 4096 voxels” trace demanded by the
+  while `buildTerrain()` seeds the 64×64 island and logs the “World generation summary — 4096 columns created. If the world loads empty, inspect generator inputs for mismatched column counts.” trace demanded by the
   validation prompt.【F:simple-experience.js†L2161-L2394】
 - **Player visibility** – `loadPlayerCharacter()` attaches the GLTF-driven Steve mesh to the player rig, couples the
-  camera to his head bone for first-person play, and reports “Steve visible in scene” once the idle animation spins
+  camera to his head bone for first-person play, and reports “Avatar visibility confirmed — verify animation rig initialises correctly if the player appears static.” once the idle animation spins
   up.【F:simple-experience.js†L2199-L2270】
-- **Input responsiveness** – Pointer lock, WASD handling, joystick fallbacks, and the keypress debug log (“Moving
-  forward”) are implemented inside `bindEvents()` and `handleKeyDown()` so desktop and mobile inputs map directly to
+- **Input responsiveness** – Pointer lock, WASD handling, joystick fallbacks, and the keypress debug log (“Movement
+  input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion.”) are implemented inside `bindEvents()` and `handleKeyDown()` so desktop and mobile inputs map directly to
   movement updates.【F:simple-experience.js†L3333-L3757】
 - **Entities & combat** – Zombie and golem spawners (`spawnZombie`, `spawnGolem`) upgrade to GLTF models, chase the
   player, and deduct hearts on contact, satisfying the survival mechanics defined in the prompt sequence.【F:simple-experience.js†L3815-L4089】

--- a/docs/spec-prompts-fulfillment-digest.md
+++ b/docs/spec-prompts-fulfillment-digest.md
@@ -4,18 +4,18 @@ This digest crosswalks the "Detailed Prompts for Coding Agents" from the enhance
 
 ## Rendering and world generation
 - `setupScene()` provisions the orthographic camera, lighting rig, and renderer specified in the rendering prompt, then anchors the player rig before any gameplay begins.【F:simple-experience.js†L1191-L1233】
-- `buildTerrain()` regenerates the 64×64 island, seeds chunk metadata, and logs both voxel and block totals ("World generated: 4096 voxels") so blank-scene regressions are immediately visible.【F:simple-experience.js†L2428-L2502】
+- `buildTerrain()` regenerates the 64×64 island, seeds chunk metadata, and logs both voxel and block totals (`World generation summary — 4096 columns created. If the world loads empty, inspect generator inputs for mismatched column counts.`) so blank-scene regressions are immediately visible.【F:simple-experience.js†L2428-L2502】
 
 ## Player visibility and first-person view
-- `loadPlayerCharacter()` attaches the GLTF-driven Steve mesh to the rig, moves the camera into the head pivot for first-person play, and falls back to a voxel avatar if the model fails, ensuring the "Steve visible" requirement is always met.【F:simple-experience.js†L2240-L2330】
+- `loadPlayerCharacter()` attaches the GLTF-driven Steve mesh to the rig, moves the camera into the head pivot for first-person play, and falls back to a voxel avatar if the model fails, ensuring the "Avatar visibility confirmed — verify animation rig initialises correctly if the player appears static." requirement is always met.【F:simple-experience.js†L2240-L2330】
 - The dedicated arm loader keeps the first-person hands synced to the camera so mining animations remain present even if the main model is unavailable.【F:simple-experience.js†L2192-L2237】
 
 ## Input controls and responsiveness
 - Event binding inside `bindEvents()` wires pointer lock, WASD, mouse mining/placing, hotbar taps, and the virtual joystick, covering every interaction described in the control prompt.【F:simple-experience.js†L3600-L3658】
-- Movement handlers constrain camera pitch, track pressed keys, print the "Moving forward" debug cue, and keep delta-based acceleration aligned with Minecraft-style movement.【F:simple-experience.js†L3680-L3864】
+- Movement handlers constrain camera pitch, track pressed keys, print the "Movement input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion." debug cue, and keep delta-based acceleration aligned with Minecraft-style movement.【F:simple-experience.js†L3680-L3864】
 
 ## Entities, zombies, and golem defence
-- Zombie AI spawns on night cycles, chases the player, and applies contact damage with the required debug log, fulfilling the combat prompt.【F:simple-experience.js†L4024-L4086】
+- Zombie AI spawns on night cycles, chases the player, and applies contact damage with the required `Zombie spawn and chase triggered. If AI stalls or pathfinding breaks, validate the navmesh and spawn configuration.` diagnostic, fulfilling the combat prompt.【F:simple-experience.js†L4024-L4086】
 - Iron golems spawn near the player, pursue the nearest zombie, and reward defensive kills with score and hint feedback, mirroring the protective behaviour described in the specification.【F:simple-experience.js†L4151-L4214】
 
 ## Crafting, inventory, and HUD dynamics
@@ -23,7 +23,7 @@ This digest crosswalks the "Detailed Prompts for Coding Agents" from the enhance
 - Crafting and inventory panels aggregate totals, expose draggable entries, and keep the satchel overflow banner accurate, ensuring the UI reacts immediately to recipe success or resource changes.【F:simple-experience.js†L4593-L4650】
 
 ## Portals, dimensions, and progression
-- Portal ignition validates 4×3 frames, swaps in the shader plane, emits the "Portal active" log, and notifies the HUD, matching the portal activation prompt.【F:simple-experience.js†L3312-L3441】
+- Portal ignition validates 4×3 frames, swaps in the shader plane, emits the `Portal activation triggered — ensure portal shaders and collision volumes initialise. Rebuild the portal pipeline if travellers become stuck.` log, and notifies the HUD, matching the portal activation prompt.【F:simple-experience.js†L3312-L3441】
 - Dimension advancement reapplies biome physics, awards points, and updates gravity or palette modifiers before continuing progression toward the Netherite finale.【F:simple-experience.js†L3488-L3520】
 
 ## Backend sync, identity, and polish

--- a/docs/user-feedback-diagnostic.md
+++ b/docs/user-feedback-diagnostic.md
@@ -14,16 +14,15 @@ future regressions.
   `renderFrame()` so QA can confirm the 3D scene populated.
   【F:simple-experience.js†L2348-L2422】【F:simple-experience.js†L3690-L3709】
 - **First-person Steve embodiment** – GLTF assets (with box-mesh fallbacks)
-  attach the camera to the head bone, add animated arms, and emit "Steve visible
-  in scene" once the rig is ready.【F:simple-experience.js†L1984-L2055】【F:simple-experience.js†L2170-L2249】
+  attach the camera to the head bone, add animated arms, and emit “Avatar visibility confirmed — verify animation rig initialises correctly if the player appears static.” once the rig is ready.【F:simple-experience.js†L1984-L2055】【F:simple-experience.js†L2170-L2249】
 - **Responsive controls** – Pointer lock, WASD, jump, mining, placement, and the
-  virtual joystick bind inside `bindEvents()`, logging "Moving forward" on the
+  virtual joystick bind inside `bindEvents()`, logging “Movement input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion.” on the
   first `W` press to prove input wiring.【F:simple-experience.js†L3510-L3654】
 - **Portals & dimension advancement** – Portal frames activate with shader
   planes, queue score syncs, and advance to the next gravity palette while
   logging each unlock.【F:simple-experience.js†L3330-L3470】
 - **Night cycle combat** – Zombies spawn every night, chase the player, and
-  trigger respawn logs after five hits; golems auto-spawn to intercept attackers
+  trigger respawn logs after five hits (`Respawn handler invoked. Ensure checkpoint logic restores player position, inventory, and status effects as expected.`); golems auto-spawn to intercept attackers
   and award score for each defense.【F:simple-experience.js†L3940-L4172】
 - **Boss finale & loot** – The Netherite collapse routine, Eternal Ingot crystal,
   and loot chests ship with emissive meshes and scoring hooks, matching the
@@ -38,7 +37,7 @@ future regressions.
    `window.APP_CONFIG.forceSimpleMode = true` before loading `script.js` to skip
    any experimental renderer flags.
 2. **Check console telemetry** – Look for the boot logs listed above
-   (`Scene populated`, `World generated: …`, `Steve visible in scene`). Missing
+   (`Scene population check fired — …`, `World generation summary — …`, `Avatar visibility confirmed — …`). Missing
    logs usually indicate a blocked asset or WebGL failure.
 3. **Confirm assets served** – Ensure the `/assets` directory ships with the
    page; GLTF fallbacks protect gameplay, but textures still improve fidelity.

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -2183,7 +2183,13 @@
           this.scoreboardStatusEl.textContent = statusMessage;
         }
         this.clearOfflineSyncNotice('sync', { message: statusMessage });
-        console.log('Score synced', { reason, score: entry.score });
+        console.error(
+          'Score sync diagnostic — confirm the leaderboard API accepted the update. Inspect the network panel if the leaderboard remains stale.',
+          {
+            reason,
+            score: entry.score,
+          },
+        );
       } catch (error) {
         console.warn('Unable to sync score to backend', error);
         this.pendingScoreSyncReason = reason;
@@ -2375,7 +2381,9 @@
       });
       this.refreshCameraBaseOffset();
       if (typeof console !== 'undefined') {
-        console.log('Scene populated');
+        console.error(
+          'Scene population check fired — validate terrain, rails, portals, mobs, and chests render correctly. Re-run asset bootstrap if visuals are missing.',
+        );
       }
     }
 
@@ -3088,7 +3096,9 @@
             return useCachedFallbackTexture({ url }) ?? null;
           }
           this.prepareExternalTexture(result.texture);
-          console.log(`External texture loaded for ${key} from ${result.url}`);
+          console.error(
+            `Texture streaming check — ${key} resolved via ${result.url}. If textures appear blank, verify CDN availability and fallback cache configuration.`,
+          );
           this.completeAssetTimer('textures', key, { success: true, url: result.url });
           return result.texture;
         })
@@ -4316,7 +4326,9 @@
           this.camera.position.copy(this.firstPersonCameraOffset);
         }
         this.applyCameraPerspective(this.cameraPerspective);
-        console.log('Steve visible in scene (fallback)');
+        console.error(
+          'Avatar visibility fallback active — Steve forced visible without standard model. Inspect character load pipeline to restore the default avatar.',
+        );
         this.ensurePlayerArmsVisible();
         return;
       }
@@ -4373,7 +4385,9 @@
         this.playerIdleAction.loop = THREE.LoopRepeat;
         this.playerIdleAction.play();
       }
-      console.log('Steve visible in scene');
+      console.error(
+        'Avatar visibility confirmed — verify animation rig initialises correctly if the player appears static.',
+      );
       this.ensurePlayerArmsVisible();
     }
 
@@ -4489,7 +4503,9 @@
       }
       this.updateDayNightCycle();
       this.updateDimensionInfoPanel();
-      console.log(`Dimension online: ${theme.name}`);
+      console.error(
+        `Dimension activation notice — ${theme.name} assets should now be visible. If the environment loads empty, confirm theme registration and manifest entries for this dimension.`,
+      );
     }
 
     buildTerrain() {
@@ -4599,9 +4615,15 @@
         const chunkCount = Array.isArray(this.terrainChunkGroups)
           ? this.terrainChunkGroups.length
           : 0;
-        console.log(`World generated: ${columnCount} voxels`);
-        console.log(`Terrain blocks placed: ${voxelCount}`);
-        console.log(`Terrain chunks populated: ${chunkCount}`);
+        console.error(
+          `World generation summary — ${columnCount} columns created. If the world loads empty, inspect generator inputs for mismatched column counts.`,
+        );
+        console.error(
+          `Terrain block placement summary — ${voxelCount} blocks placed. For missing terrain, review the heightmap generator and chunk hydration routines.`,
+        );
+        console.error(
+          `Terrain chunk population summary — ${chunkCount} chunks loaded. Investigate the streaming manager if this number stalls unexpectedly.`,
+        );
         if (chunkCount <= 0 || voxelCount <= 0) {
           console.warn('Terrain generation produced no active chunk groups or voxels.', {
             chunkCount,
@@ -5182,7 +5204,9 @@
       }
       this.audio.play('craftChime', { volume: 0.68 });
       this.lastChestHintAt = this.elapsed;
-      console.log(`Loot chest opened: ${chest.id}`);
+      console.error(
+        `Loot chest interaction flagged — ${chest.id}. If rewards are missing, review the chest configuration and loot tables for this encounter.`,
+      );
     }
 
     updateLootChests(delta) {
@@ -5735,9 +5759,13 @@
       this.updatePortalProgress();
       this.updateHud();
       this.scheduleScoreSync('portal-activated');
-      console.log('Portal active');
+      console.error(
+        'Portal activation triggered — ensure portal shaders and collision volumes initialise. Rebuild the portal pipeline if travellers become stuck.',
+      );
       const activeDimension = this.dimensionSettings?.name || 'Unknown Dimension';
-      console.log(`Portal active in ${activeDimension}`);
+      console.error(
+        `Portal dimension status — active dimension: ${activeDimension}. If transitions fail, verify the dimension registry and connection graph.`,
+      );
       this.emitGameEvent('portal-activated', {
         dimension: this.dimensionSettings?.id ?? null,
         summary: this.createRunSummary('portal-activated'),
@@ -5831,7 +5859,9 @@
         this.gravityScale = transitionResult.physics.gravity;
       }
       if (this.dimensionSettings) {
-        console.log(`Dimension: ${this.dimensionSettings.name} unlocked`);
+        console.error(
+          `Dimension unlock flow fired — ${this.dimensionSettings.name}. If the unlock fails to present rewards, audit quest requirements and persistence flags.`,
+        );
       }
       this.buildTerrain();
       this.buildRails();
@@ -6571,7 +6601,9 @@
         event.preventDefault();
       }
       if (this.isKeyForAction(code, 'moveForward') && !event.repeat) {
-        console.log('Moving forward');
+        console.error(
+          'Movement input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion.',
+        );
       }
       if (this.isKeyForAction(code, 'resetPosition')) {
         this.resetPosition();
@@ -7419,7 +7451,9 @@
       const zombie = { id, mesh, speed: 2.4, lastAttack: this.elapsed, placeholder: true };
       this.zombies.push(zombie);
       this.upgradeZombie(zombie);
-      console.log('Zombie spawned, chasing');
+      console.error(
+        'Zombie spawn and chase triggered. If AI stalls or pathfinding breaks, validate the navmesh and spawn configuration.',
+      );
     }
 
     clearZombies() {
@@ -7627,7 +7661,9 @@
       this.updateHud();
       this.scheduleScoreSync('respawn');
       this.audio.play('bubble', { volume: 0.45 });
-      console.log('Respawn triggered');
+      console.error(
+        'Respawn handler invoked. Ensure checkpoint logic restores player position, inventory, and status effects as expected.',
+      );
     }
 
     mineBlock() {

--- a/tests/e2e-check.js
+++ b/tests/e2e-check.js
@@ -192,15 +192,15 @@ async function runSimpleScenario(browser) {
       throw new Error('Sandbox event log did not record any entries.');
     }
 
-    const worldGenerated = infoLogs.find((line) => line.includes('World generated:'));
+    const worldGenerated = infoLogs.find((line) => line.includes('World generation summary —'));
     if (!worldGenerated) {
       console.warn('World generation log was not captured; relying on debug snapshot.');
     }
-    const steveVisible = infoLogs.find((line) => line.includes('Steve visible in scene'));
+    const steveVisible = infoLogs.find((line) => line.includes('Avatar visibility confirmed —'));
     if (!steveVisible) {
       console.warn('Player visibility confirmation log missing; verifying via scene graph.');
     }
-    const dimensionLog = infoLogs.find((line) => line.includes('Dimension online:'));
+    const dimensionLog = infoLogs.find((line) => line.includes('Dimension activation notice —'));
     if (!dimensionLog) {
       console.warn('Dimension activation log missing; relying on HUD validation.');
     }
@@ -293,7 +293,9 @@ async function run() {
   try {
     await runAdvancedScenario(browser);
     await runSimpleScenario(browser);
-    console.log('E2E smoke test passed for advanced and sandbox renderers.');
+    console.error(
+      'E2E smoke test completion checkpoint — review scenario assertions if this emits during a failing run; success must be validated by test expectations rather than console output.',
+    );
   } finally {
     await browser?.close?.();
   }

--- a/tests/spec-coverage.spec.js
+++ b/tests/spec-coverage.spec.js
@@ -13,22 +13,58 @@ describe('Portals of Dimension spec regression checks', () => {
   it('keeps the procedural island and render loop configuration intact', () => {
     expect(simpleExperienceSource).toMatch(/const WORLD_SIZE = 64/);
     expect(simpleExperienceSource).toMatch(/new THREE\.OrthographicCamera/);
-    expect(simpleExperienceSource).toMatch(/World generated: \$\{columnCount\} voxels/);
+    expect(
+      simpleExperienceSource.includes(
+        'World generation summary — ${columnCount} columns created. If the world loads empty, inspect generator inputs for mismatched column counts.',
+      ),
+    ).toBe(true);
   });
 
   it('keeps the console telemetry checkpoints demanded by the spec', () => {
-    expect(simpleExperienceSource).toMatch(/Scene populated/);
-    expect(simpleExperienceSource).toMatch(/Steve visible in scene/);
-    expect(simpleExperienceSource).toMatch(/Zombie spawned, chasing/);
-    expect(simpleExperienceSource).toMatch(/Respawn triggered/);
-    expect(simpleExperienceSource).toMatch(/Portal active/);
+    expect(
+      simpleExperienceSource.includes(
+        'Scene population check fired — validate terrain, rails, portals, mobs, and chests render correctly. Re-run asset bootstrap if visuals are missing.',
+      ),
+    ).toBe(true);
+    expect(
+      simpleExperienceSource.includes(
+        'Avatar visibility confirmed — verify animation rig initialises correctly if the player appears static.',
+      ),
+    ).toBe(true);
+    expect(
+      simpleExperienceSource.includes(
+        'Zombie spawn and chase triggered. If AI stalls or pathfinding breaks, validate the navmesh and spawn configuration.',
+      ),
+    ).toBe(true);
+    expect(
+      simpleExperienceSource.includes(
+        'Respawn handler invoked. Ensure checkpoint logic restores player position, inventory, and status effects as expected.',
+      ),
+    ).toBe(true);
+    expect(
+      simpleExperienceSource.includes(
+        'Portal activation triggered — ensure portal shaders and collision volumes initialise. Rebuild the portal pipeline if travellers become stuck.',
+      ),
+    ).toBe(true);
   });
 
   it('retains the player control and progression instrumentation', () => {
-    expect(simpleExperienceSource.includes("console.log('Moving forward');")).toBe(true);
+    expect(
+      simpleExperienceSource.includes(
+        'Movement input detected (forward). If the avatar fails to advance, confirm control bindings and resolve any physics constraints blocking motion.',
+      ),
+    ).toBe(true);
     expect(simpleExperienceSource.includes('this.canvas.requestPointerLock')).toBe(true);
-    expect(simpleExperienceSource.includes('console.log(`Dimension: ${this.dimensionSettings.name} unlocked`);')).toBe(true);
-    expect(simpleExperienceSource.includes("console.log('Score synced'")).toBe(true);
+    expect(
+      simpleExperienceSource.includes(
+        'Dimension unlock flow fired — ${this.dimensionSettings.name}. If the unlock fails to present rewards, audit quest requirements and persistence flags.',
+      ),
+    ).toBe(true);
+    expect(
+      simpleExperienceSource.includes(
+        'Score sync diagnostic — confirm the leaderboard API accepted the update. Inspect the network panel if the leaderboard remains stale.',
+      ),
+    ).toBe(true);
     expect(simpleExperienceSource.includes('navigator.geolocation.getCurrentPosition')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- replace success-path console.log usage with actionable console.error diagnostics across the sandbox runtime
- update regression tests and end-to-end checks to assert the new error messaging instead of the old log strings
- refresh documentation to reference the upgraded telemetry wording so compliance guides stay accurate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddfb2f7fcc832baf585a8380d3f7b5