### PR TITLE
Add in-game debug mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -520,7 +520,19 @@
         <section class="log-panel" aria-live="polite">
           <header>
             <h2>Event Log</h2>
+            <button
+              type="button"
+              class="ghost small log-panel__debug-toggle"
+              id="debugModeToggle"
+              aria-pressed="false"
+              data-hint="Enable verbose diagnostics"
+            >
+              Enable Debug Mode
+            </button>
           </header>
+          <p class="log-panel__debug-status" id="debugModeStatus" role="status" aria-live="polite">
+            Standard diagnostics active.
+          </p>
           <ul id="eventLog"></ul>
         </section>
       </aside>

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -7026,6 +7026,18 @@
               ? details.error.message
               : String(details.error);
           failureDetail.error = errorMessage;
+          if (typeof details.error?.name === 'string' && details.error.name.trim().length) {
+            failureDetail.errorName = details.error.name.trim();
+          }
+          if (typeof details.error?.stack === 'string' && details.error.stack.trim().length) {
+            failureDetail.stack = details.error.stack.trim();
+          }
+        }
+        if (!failureDetail.stack && typeof details.errorStack === 'string' && details.errorStack.trim().length) {
+          failureDetail.stack = details.errorStack.trim();
+        }
+        if (!failureDetail.errorName && typeof details.errorName === 'string' && details.errorName.trim().length) {
+          failureDetail.errorName = details.errorName.trim();
         }
       }
       this.emitGameEvent('renderer-failure', failureDetail);
@@ -10032,6 +10044,58 @@
         ignitePortal: (tool) => this.debugIgnitePortal(tool),
         advanceDimension: () => this.debugAdvanceDimension(),
         assetLoads: (limit) => this.getAssetLoadLog(limit),
+        setVerboseMode: (enabled) => {
+          const controls = scope.InfiniteRails?.debug;
+          if (controls && typeof controls.setEnabled === 'function') {
+            controls.setEnabled(Boolean(enabled), { source: 'debug-interface' });
+            return true;
+          }
+          return false;
+        },
+        enableVerboseMode: () => {
+          const controls = scope.InfiniteRails?.debug;
+          if (controls && typeof controls.setEnabled === 'function') {
+            controls.setEnabled(true, { source: 'debug-interface' });
+            return true;
+          }
+          return false;
+        },
+        disableVerboseMode: () => {
+          const controls = scope.InfiniteRails?.debug;
+          if (controls && typeof controls.setEnabled === 'function') {
+            controls.setEnabled(false, { source: 'debug-interface' });
+            return true;
+          }
+          return false;
+        },
+        toggleVerboseMode: () => {
+          const controls = scope.InfiniteRails?.debug;
+          if (controls && typeof controls.toggle === 'function') {
+            controls.toggle({ source: 'debug-interface' });
+            return true;
+          }
+          if (controls && typeof controls.setEnabled === 'function' && typeof controls.isEnabled === 'function') {
+            try {
+              const current = Boolean(controls.isEnabled());
+              controls.setEnabled(!current, { source: 'debug-interface' });
+              return true;
+            } catch (error) {
+              console.debug('Verbose mode toggle failed', error);
+            }
+          }
+          return false;
+        },
+        isVerboseModeEnabled: () => {
+          const controls = scope.InfiniteRails?.debug;
+          if (controls && typeof controls.isEnabled === 'function') {
+            try {
+              return Boolean(controls.isEnabled());
+            } catch (error) {
+              console.debug('Verbose mode probe failed', error);
+            }
+          }
+          return false;
+        },
       };
       try {
         scope.dispatchEvent(

--- a/styles.css
+++ b/styles.css
@@ -4363,6 +4363,32 @@ body[data-crafting-drag='true'] {
   }
 }
 
+.log-panel header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.log-panel header h2 {
+  margin-bottom: 0;
+}
+
+.log-panel__debug-toggle {
+  white-space: nowrap;
+}
+
+.log-panel__debug-status {
+  margin: 0.35rem 0 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(233, 245, 220, 0.7);
+}
+
+body[data-debug-mode='verbose'] .log-panel__debug-status {
+  color: rgba(134, 204, 255, 0.9);
+}
+
 .log-panel ul {
   list-style: none;
   display: grid;
@@ -4379,6 +4405,37 @@ body[data-crafting-drag='true'] {
   border-radius: 12px;
   padding: 0.5rem 0.7rem;
   border: 1px solid rgba(73, 242, 255, 0.08);
+}
+
+body[data-debug-mode='verbose'] .log-panel li {
+  border-color: rgba(73, 242, 255, 0.22);
+  box-shadow: 0 0 0 1px rgba(73, 242, 255, 0.12) inset;
+}
+
+.event-log__message {
+  line-height: 1.35;
+  letter-spacing: 0.04em;
+}
+
+.event-log__debug {
+  margin-top: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 8px;
+  background: rgba(6, 16, 32, 0.78);
+  border: 1px solid rgba(73, 242, 255, 0.2);
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
+  font-size: 0.7rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 220px;
+  overflow: auto;
+  color: rgba(214, 236, 255, 0.9);
+}
+
+body[data-debug-mode='verbose'] .event-log__debug {
+  background: rgba(9, 24, 48, 0.88);
+  border-color: rgba(134, 204, 255, 0.45);
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- add an event log debug toggle with status messaging so players can switch verbose diagnostics on and off in-game
- extend runtime debug plumbing to persist the mode, enrich event log entries, and surface renderer failure details when verbose mode is enabled
- expose verbose toggle helpers through the existing debug interface and include stack information in renderer failure payloads for tooling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de0552f3a8832baf91f4c42b00fe77