### PR TITLE
Wait for CloudFront invalidations to complete during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -375,8 +375,14 @@ jobs:
             echo '::warning::Cache invalidation request completed but no ID was returned.'
           else
             echo "::notice::Submitted CloudFront invalidation ${INVALIDATION_ID}"
+
+            echo "Waiting for CloudFront invalidation ${INVALIDATION_ID} to complete..."
+            aws cloudfront wait invalidation-completed \
+              --distribution-id "${DISTRIBUTION_ID}" \
+              --id "${INVALIDATION_ID}"
+
             {
-              echo '### 🧹 CloudFront cache invalidated'
+              echo '### 🧹 CloudFront cache flushed'
               echo ''
               echo "- Distribution ID: \`${DISTRIBUTION_ID}\`"
               echo "- Invalidation ID: \`${INVALIDATION_ID}\`"

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ This repository ships with a GitHub Actions workflow that deploys the static sit
 1. Workflow validates that all required AWS secrets exist. Missing secrets trigger an actionable failure with setup steps.
 2. AWS credentials are configured via `aws-actions/configure-aws-credentials`.
 3. Repository contents (excluding version control and workflow files) are synchronised to the target S3 bucket.
-4. The workflow automatically discovers the CloudFront distribution attached to the S3 origin, invalidates its cache, and exposes both the distribution ID and URL as job outputs. The URL is also written to the run summary for quick access.
+4. The workflow automatically discovers the CloudFront distribution attached to the S3 origin, invalidates its cache, waits for the flush to finish, and exposes both the distribution ID and URL as job outputs. The URL is also written to the run summary for quick access.
 
 If no CloudFront distribution matches the S3 bucket, the workflow fails with instructions to create or tag one before redeploying.
 


### PR DESCRIPTION
## Summary
- block the deployment workflow until the CloudFront invalidation request finishes so new assets are always served
- update the documentation to note the cache flush happens before the job completes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de100f66a8832bade6906439c5c9ef