### PR TITLE
Improve Three.js bootstrapping and camera perspective

### DIFF
--- a/index.html
+++ b/index.html
@@ -1551,7 +1551,7 @@
         });
       })();
     </script>
-    <script src="vendor/three.min.js" defer></script>
+    <script src="vendor/three.min.js" data-preload-three="true" defer></script>
     <script src="asset-resolver.js" defer></script>
     <script src="assets/offline-assets.js" defer></script>
     <script src="audio-aliases.js" defer></script>

--- a/tests/spec-coverage.spec.js
+++ b/tests/spec-coverage.spec.js
@@ -12,7 +12,7 @@ const scriptSource = fs.readFileSync(scriptPath, 'utf8');
 describe('Portals of Dimension spec regression checks', () => {
   it('keeps the procedural island and render loop configuration intact', () => {
     expect(simpleExperienceSource).toMatch(/const WORLD_SIZE = 64/);
-    expect(simpleExperienceSource).toMatch(/new THREE\.OrthographicCamera/);
+    expect(simpleExperienceSource).toMatch(/new THREE\.PerspectiveCamera/);
     expect(
       simpleExperienceSource.includes(
         'World generation summary — ${columnCount} columns created. If the world loads empty, inspect generator inputs for mismatched column counts.',
@@ -69,7 +69,7 @@ describe('Portals of Dimension spec regression checks', () => {
   });
 
   it('keeps the first-person rig and day/night pipeline wired as specced', () => {
-    expect(simpleExperienceSource).toMatch(/this\.camera = new THREE\.OrthographicCamera/);
+    expect(simpleExperienceSource).toMatch(/this\.camera = new THREE\.PerspectiveCamera/);
     expect(simpleExperienceSource).toMatch(/this\.camera\.add\(this\.handGroup\);/);
     expect(simpleExperienceSource).toMatch(/this\.elapsed = DAY_LENGTH_SECONDS \* 0\.5;/);
     expect(simpleExperienceSource).toMatch(/updateDayNightCycle\(\)/);


### PR DESCRIPTION
## Summary
- add a preload marker for the bundled Three.js script and wait on it before attempting CDN fallbacks
- convert the sandbox renderer to a perspective camera, updating resize handling and spec coverage expectations
- resume suspended audio contexts on interaction to ensure in-browser sounds play reliably

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68de3078394c832b91be11d5b7d6687f