### PR TITLE
Bundle local Three.js and add failure reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "three": "^0.161.0"
+        "three": "0.161.0"
       },
       "devDependencies": {
         "esbuild": "^0.25.10",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "three": "^0.161.0"
+    "three": "0.161.0"
   }
 }

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -390,11 +390,7 @@
     ],
   };
 
-  const GLTF_LOADER_URLS = [
-    'vendor/GLTFLoader.js',
-    'https://unpkg.com/three@0.161.0/examples/js/loaders/GLTFLoader.js',
-    'https://cdn.jsdelivr.net/npm/three@0.161.0/examples/js/loaders/GLTFLoader.js',
-  ];
+  const GLTF_LOADER_URLS = ['vendor/GLTFLoader.js'];
 
   const assetResolver =
     (typeof window !== 'undefined' && window.InfiniteRailsAssetResolver) ||


### PR DESCRIPTION
## Summary
- remove CDN fallbacks for Three.js/GLTFLoader and rely on bundled assets
- pin the Three.js dependency to a known-good version and surface load failures to players
- update renderer bootstrap tests for the new loading flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de3a5f5300832bac7e371876f98d78