### PR TITLE
Improve scoreboard offline handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -1240,6 +1240,7 @@
     googleError: null,
     identity: null,
     scoreboardMessage: '',
+    scoreboardOffline: false,
     endpoints: {
       scores: buildScoreboardUrl(apiBaseUrl),
       users: apiBaseUrl ? `${apiBaseUrl.replace(/\/$/, '')}/users` : null,
@@ -2414,12 +2415,20 @@
   let googleInitPromise = null;
   let googleIdentityScriptPromise = null;
 
-  function updateScoreboardStatus(message) {
+  function updateScoreboardStatus(message, options = {}) {
+    if (typeof options.offline === 'boolean') {
+      identityState.scoreboardOffline = options.offline;
+    }
     if (typeof message === 'string' && message.trim().length > 0) {
       identityState.scoreboardMessage = message.trim();
     }
     if (scoreboardStatusEl) {
       scoreboardStatusEl.textContent = identityState.scoreboardMessage;
+      if (identityState.scoreboardOffline) {
+        scoreboardStatusEl.dataset.offline = 'true';
+      } else {
+        delete scoreboardStatusEl.dataset.offline;
+      }
     }
   }
 
@@ -3725,6 +3734,9 @@
       });
       googleInitPromise = null;
       initialiseGoogleSignIn();
+    },
+    setScoreboardStatus(message, options = {}) {
+      updateScoreboardStatus(message, options);
     },
   };
 

--- a/styles.css
+++ b/styles.css
@@ -3159,6 +3159,10 @@ body.sidebar-open .player-hint {
   min-height: 1.25rem;
 }
 
+.leaderboard-status[data-offline='true'] {
+  color: var(--accent-strong);
+}
+
 .leaderboard-controls {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary
- track scoreboard offline state alongside the identity scoreboard message and expose a setter for other modules
- centralise scoreboard status updates in the simple experience so scoring events refresh immediately and offline failures persist locally
- highlight offline scoreboard states with a warning colour in the leaderboard modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de5deff020832b97f548a14bf38087