### PR TITLE
Improve portal frame collision feedback

### DIFF
--- a/tests/block-interactions-updates.test.js
+++ b/tests/block-interactions-updates.test.js
@@ -97,6 +97,10 @@ describe('block placement and mining update world state', () => {
       },
     ]);
 
+    experience.hotbar = Array.from({ length: 9 }, () => ({ item: null, quantity: 0 }));
+    experience.selectedHotbarIndex = 0;
+    experience.hotbar[0] = { item: 'stone', quantity: 1 };
+
     experience.placeBlock();
 
     expect(experience.useSelectedItem).toHaveBeenCalledTimes(1);

--- a/tests/portal-mechanics.test.js
+++ b/tests/portal-mechanics.test.js
@@ -32,6 +32,31 @@ describe('portal mechanics', () => {
     expect(collisions[0].reason).toBe('tree');
   });
 
+  it('detects blocking occupants such as players and chests', () => {
+    const footprint = buildPortalFrame({ x: 3, y: 3 }, { x: 0, y: 1 });
+    const grid = Array.from({ length: 8 }, () =>
+      Array.from({ length: 8 }, () => ({ type: 'grass', walkable: true })),
+    );
+    const interiorTile = footprint.interior[0];
+    grid[interiorTile.y][interiorTile.x] = {
+      type: 'grass',
+      walkable: true,
+      occupant: 'player',
+    };
+    const collisions = detectPortalCollision(grid, footprint);
+    const reasons = collisions.map((entry) => entry.reason);
+    expect(reasons).toContain('player');
+    const secondInterior = footprint.interior[1];
+    grid[secondInterior.y][secondInterior.x] = {
+      type: 'grass',
+      walkable: true,
+      occupants: ['chest'],
+    };
+    const collisionsWithChest = detectPortalCollision(grid, footprint);
+    const chestReasons = collisionsWithChest.map((entry) => entry.reason);
+    expect(chestReasons).toContain('chest');
+  });
+
   it('activates the shader immediately when ignited with a torch', () => {
     const footprint = buildPortalFrame({ x: 5, y: 5 }, { x: 0, y: 1 });
     const result = ignitePortalFrame(footprint, { tool: 'torch' });


### PR DESCRIPTION
## Summary
- align portal tile collision detection with occupant metadata so player, chest, and tree blockers match the 3D experience
- add portal frame slot obstruction checks in `placeBlock`, logging and surfacing hints when placement is rejected
- extend unit tests to cover the new collision handling and placement guard rails

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de69c5c598832b8e6bc3c1b6663fb8