### PR TITLE
Fix renderer start event name

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -13438,7 +13438,7 @@
       };
       try {
         scope.dispatchEvent(
-          new CustomEvent('infinite-rails:start', {
+          new CustomEvent('infinite-rails:started', {
             detail: {
               mode: 'simple',
               timestamp: Date.now(),


### PR DESCRIPTION
## Summary
- ensure the bootstrap overlay listens for the actual renderer start event
- prevent the loading screen from getting stuck when the renderer initialises

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7d3bc0dc832b8cbb22f16331bea2