### PR TITLE
Dismiss bootstrap overlay once renderer is ready for input

### DIFF
--- a/script.js
+++ b/script.js
@@ -3509,6 +3509,29 @@
     if (typeof experience.publishStateSnapshot === 'function') {
       experience.publishStateSnapshot('bootstrap');
     }
+    if (typeof bootstrapOverlay !== 'undefined') {
+      if (typeof bootstrapOverlay.setDiagnostic === 'function') {
+        bootstrapOverlay.setDiagnostic('renderer', {
+          status: 'ok',
+          message: 'Renderer ready — press Start Expedition to begin.',
+        });
+        bootstrapOverlay.setDiagnostic('assets', {
+          status: 'pending',
+          message: 'World assets will stream after launch.',
+        });
+      }
+      if (typeof bootstrapOverlay.hide === 'function') {
+        const overlayState = bootstrapOverlay.state ?? {};
+        if (overlayState.mode !== 'error') {
+          bootstrapOverlay.hide({ force: true });
+        }
+      }
+    }
+    if (typeof logDiagnosticsEvent === 'function') {
+      logDiagnosticsEvent('startup', 'Renderer initialised; awaiting player input.', {
+        level: 'success',
+      });
+    }
     if (ui.startButton && !ui.startButton.dataset.simpleExperienceBound) {
       ui.startButton.addEventListener('click', (event) => {
         if (event?.preventDefault) {


### PR DESCRIPTION
## Summary
- hide the bootstrap overlay after the simple renderer initialises so players can reach the Start Expedition prompt
- update diagnostics messaging and logging to reflect renderer readiness prior to gameplay launch

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de836e5bd0832ba6240886ed812598