### PR TITLE
Add developer performance overlay for FPS and asset counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,33 @@
           aria-label="Game world"
           data-hint="Navigate and interact with the voxel realm here."
         ></canvas>
+        <div
+          class="developer-stats"
+          id="developerStatsPanel"
+          role="status"
+          aria-live="polite"
+          hidden
+        >
+          <p class="developer-stats__title">Developer Stats</p>
+          <dl class="developer-stats__metrics">
+            <div class="developer-stats__metric">
+              <dt>FPS</dt>
+              <dd data-stat="fps">—</dd>
+            </div>
+            <div class="developer-stats__metric">
+              <dt>Models</dt>
+              <dd data-stat="models">—</dd>
+            </div>
+            <div class="developer-stats__metric">
+              <dt>Textures</dt>
+              <dd data-stat="textures">—</dd>
+            </div>
+            <div class="developer-stats__metric">
+              <dt>Audio</dt>
+              <dd data-stat="audio">—</dd>
+            </div>
+          </dl>
+        </div>
         <div class="game-briefing" id="gameBriefing" role="region" aria-live="polite" hidden>
           <div class="game-briefing__content">
             <div class="game-briefing__header">
@@ -574,15 +601,27 @@
         <section class="log-panel" aria-live="polite">
           <header>
             <h2>Event Log</h2>
-            <button
-              type="button"
-              class="ghost small log-panel__debug-toggle"
-              id="debugModeToggle"
-              aria-pressed="false"
-              data-hint="Enable verbose diagnostics"
-            >
-              Enable Debug Mode
-            </button>
+            <div class="log-panel__actions">
+              <button
+                type="button"
+                class="ghost small log-panel__developer-toggle"
+                id="developerStatsToggle"
+                aria-pressed="false"
+                aria-controls="developerStatsPanel"
+                data-hint="Show developer performance metrics"
+              >
+                Show Developer Stats
+              </button>
+              <button
+                type="button"
+                class="ghost small log-panel__debug-toggle"
+                id="debugModeToggle"
+                aria-pressed="false"
+                data-hint="Enable verbose diagnostics"
+              >
+                Enable Debug Mode
+              </button>
+            </div>
           </header>
           <p class="log-panel__debug-status" id="debugModeStatus" role="status" aria-live="polite">
             Standard diagnostics active.

--- a/styles.css
+++ b/styles.css
@@ -1490,6 +1490,59 @@ body.game-active #gameCanvas {
   outline-offset: 2px;
 }
 
+.developer-stats {
+  position: absolute;
+  top: clamp(0.75rem, 2.5vw, 1.5rem);
+  left: clamp(0.75rem, 2.5vw, 1.5rem);
+  z-index: 90;
+  display: grid;
+  gap: 0.4rem;
+  min-width: 180px;
+  padding: 0.55rem 0.75rem 0.7rem;
+  border-radius: 12px;
+  border: 1px solid rgba(120, 222, 255, 0.45);
+  background: linear-gradient(180deg, rgba(6, 18, 36, 0.92), rgba(8, 24, 42, 0.88));
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+  color: rgba(220, 241, 255, 0.94);
+  pointer-events: none;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+}
+
+.developer-stats__title {
+  margin: 0;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: rgba(144, 231, 255, 0.8);
+}
+
+.developer-stats__metrics {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+}
+
+.developer-stats__metric {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.developer-stats__metric dt {
+  font-weight: 600;
+  color: rgba(198, 238, 255, 0.7);
+}
+
+.developer-stats__metric dd {
+  margin: 0;
+  justify-self: end;
+  color: rgba(235, 250, 255, 0.95);
+  font-variant-numeric: tabular-nums;
+}
+
 .game-briefing {
   position: absolute;
   top: clamp(1.5rem, 5vh, 3rem);
@@ -4916,10 +4969,18 @@ body[data-crafting-drag='true'] {
   gap: 0.75rem;
 }
 
+.log-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  justify-content: flex-end;
+}
+
 .log-panel header h2 {
   margin-bottom: 0;
 }
 
+.log-panel__developer-toggle,
 .log-panel__debug-toggle {
   white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- add a developer stats toggle and overlay to surface FPS plus model, texture, and audio counts
- wire the bootstrap UI and exposed API to manage the developer stats state and refresh loop
- extend the renderer to collect frame timing, asset metrics, and audio sample totals for reporting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deabcae930832ba68e106c81042fc0