### PR TITLE
Refresh UI palette for Minecraft-inspired contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,43 +1,43 @@
 :root {
   color-scheme: dark;
-  --bg-primary: #060b18;
-  --bg-secondary: #0e172a;
-  --bg-tertiary: rgba(18, 32, 54, 0.92);
-  --accent: #4da4ff;
-  --accent-strong: #ffb657;
-  --accent-soft: rgba(77, 164, 255, 0.28);
-  --primary: #52e0a3;
-  --bg-dark: #2f4d1b;
-  --glow: 0 0 14px rgba(82, 224, 163, 0.65);
+  --bg-primary: #071019;
+  --bg-secondary: #0f1c25;
+  --bg-tertiary: rgba(16, 34, 25, 0.96);
+  --accent: #48c4ff;
+  --accent-strong: #f3b252;
+  --accent-soft: rgba(72, 196, 255, 0.3);
+  --primary: #56c47b;
+  --bg-dark: #233a1a;
+  --glow: 0 0 14px rgba(86, 196, 123, 0.65);
   --dimension-primary: var(--accent);
-  --dimension-glow: rgba(77, 164, 255, 0.4);
+  --dimension-glow: rgba(72, 196, 255, 0.4);
   --logo-size-min: 36px;
   --logo-size-max: 72px;
   --logo-opacity: 0.85;
-  --tooltip-bg: rgba(5, 12, 28, 0.92);
-  --tooltip-text: #f5f7fb;
-  --text-primary: #f7fbe9;
-  --text-secondary: rgba(233, 245, 220, 0.82);
+  --tooltip-bg: rgba(10, 24, 16, 0.96);
+  --tooltip-text: #f7fbe9;
+  --text-primary: #f6fde7;
+  --text-secondary: rgba(234, 244, 221, 0.88);
   --danger: #ff5b7a;
   --success: #34d399;
-  --grid-line: rgba(77, 164, 255, 0.1);
-  --card-shadow: 0 18px 0 rgba(12, 18, 9, 0.4), 0 28px 56px rgba(5, 10, 6, 0.55);
+  --grid-line: rgba(72, 196, 255, 0.16);
+  --card-shadow: 0 18px 0 rgba(18, 28, 14, 0.4), 0 28px 56px rgba(7, 12, 6, 0.55);
   --manu-logo-max-size: 220px;
   --page-background: linear-gradient(
       180deg,
-      #8fd6ff 0%,
-      #9fe0ff 40%,
-      #cbefff 62%,
-      #7cc769 78%,
-      #4f8a34 88%,
-      #2f4d1b 100%
+      #83d4ff 0%,
+      #8ddcff 36%,
+      #bfeaff 58%,
+      #8bd17a 78%,
+      #5b9539 90%,
+      #365b25 100%
     );
-  --panel-border-outer: #2f4820;
-  --panel-border-highlight: rgba(116, 195, 101, 0.32);
-  --panel-surface: rgba(32, 52, 28, 0.94);
-  --panel-surface-alt: rgba(24, 39, 22, 0.94);
-  --viewport-border: #3d5a27;
-  --viewport-shadow: 0 22px 0 rgba(15, 24, 12, 0.55), 0 30px 64px rgba(10, 16, 9, 0.6);
+  --panel-border-outer: #365329;
+  --panel-border-highlight: rgba(156, 221, 120, 0.45);
+  --panel-surface: rgba(35, 58, 30, 0.98);
+  --panel-surface-alt: rgba(26, 46, 26, 0.98);
+  --viewport-border: #3f6130;
+  --viewport-shadow: 0 22px 0 rgba(18, 28, 15, 0.55), 0 30px 64px rgba(10, 18, 10, 0.6);
   --time-phase: 0;
   --hud-panel-border: rgba(71, 111, 54, 0.75);
   --hud-panel-shadow: 0 14px 0 rgba(18, 26, 14, 0.6), 0 26px 56px rgba(8, 14, 7, 0.6);
@@ -64,111 +64,111 @@ body[data-color-mode='dark'] {
 
 body[data-color-mode='light'] {
   color-scheme: light;
-  --bg-primary: #f6f9ff;
-  --bg-secondary: #e7f1ff;
-  --bg-tertiary: rgba(255, 255, 255, 0.92);
-  --accent: #2d7dd2;
-  --accent-strong: #d28f36;
-  --accent-soft: rgba(45, 125, 210, 0.18);
-  --primary: #1c7c4f;
-  --bg-dark: #f0f6ff;
-  --glow: 0 0 14px rgba(28, 124, 79, 0.35);
-  --dimension-primary: #2d7dd2;
-  --dimension-glow: rgba(45, 125, 210, 0.25);
-  --tooltip-bg: rgba(240, 246, 255, 0.95);
-  --tooltip-text: #182945;
-  --text-primary: #14263d;
-  --text-secondary: rgba(20, 38, 61, 0.8);
+  --bg-primary: #f4fbff;
+  --bg-secondary: #e4f4ff;
+  --bg-tertiary: rgba(255, 255, 255, 0.96);
+  --accent: #2c9ee8;
+  --accent-strong: #d18a32;
+  --accent-soft: rgba(44, 158, 232, 0.22);
+  --primary: #2f8b4c;
+  --bg-dark: #f1f9ff;
+  --glow: 0 0 14px rgba(47, 139, 76, 0.38);
+  --dimension-primary: #2c9ee8;
+  --dimension-glow: rgba(44, 158, 232, 0.28);
+  --tooltip-bg: rgba(244, 252, 240, 0.96);
+  --tooltip-text: #1d3224;
+  --text-primary: #1f2f1c;
+  --text-secondary: rgba(36, 64, 28, 0.78);
   --danger: #c7364b;
-  --success: #2d8d62;
-  --grid-line: rgba(45, 125, 210, 0.16);
-  --card-shadow: 0 18px 0 rgba(195, 211, 255, 0.35), 0 28px 56px rgba(136, 160, 210, 0.3);
+  --success: #2f8d5c;
+  --grid-line: rgba(44, 158, 232, 0.18);
+  --card-shadow: 0 18px 0 rgba(195, 219, 176, 0.35), 0 28px 56px rgba(162, 194, 148, 0.32);
   --page-background: linear-gradient(
       180deg,
-      #f7fbff 0%,
-      #e9f6ff 32%,
-      #f0fff6 60%,
-      #d9f2d3 78%,
-      #c1e1b2 90%,
-      #9fc484 100%
+      #f8fdff 0%,
+      #e9f7ff 28%,
+      #f0fff4 56%,
+      #d7efce 78%,
+      #bddfae 90%,
+      #9bc486 100%
     );
-  --panel-border-outer: #bed6a8;
-  --panel-border-highlight: rgba(116, 195, 101, 0.35);
-  --panel-surface: rgba(244, 252, 238, 0.94);
-  --panel-surface-alt: rgba(234, 247, 226, 0.94);
-  --viewport-border: #b1d59a;
-  --viewport-shadow: 0 22px 0 rgba(182, 206, 168, 0.4), 0 30px 64px rgba(132, 163, 120, 0.45);
-  --hud-panel-border: rgba(163, 196, 145, 0.9);
-  --hud-panel-shadow: 0 14px 0 rgba(167, 189, 151, 0.45), 0 26px 56px rgba(131, 156, 116, 0.4);
-  --hud-panel-bg: rgba(246, 253, 240, 0.94);
-  --hud-panel-bg-alt: rgba(236, 249, 232, 0.94);
+  --panel-border-outer: #b9d6a1;
+  --panel-border-highlight: rgba(148, 214, 122, 0.45);
+  --panel-surface: rgba(248, 255, 244, 0.96);
+  --panel-surface-alt: rgba(236, 249, 232, 0.96);
+  --viewport-border: #a5d090;
+  --viewport-shadow: 0 22px 0 rgba(189, 214, 168, 0.42), 0 30px 64px rgba(136, 168, 124, 0.45);
+  --hud-panel-border: rgba(170, 204, 150, 0.92);
+  --hud-panel-shadow: 0 14px 0 rgba(172, 198, 152, 0.45), 0 26px 56px rgba(134, 162, 120, 0.4);
+  --hud-panel-bg: rgba(250, 255, 244, 0.96);
+  --hud-panel-bg-alt: rgba(240, 250, 236, 0.96);
   --hud-heart-color: #d94d64;
   --hud-heart-glow: rgba(217, 77, 100, 0.35);
-  --hud-bubble-color: #2d7dd2;
-  --hud-bubble-color-rgb: 45, 125, 210;
-  --hud-bubble-highlight: rgba(227, 238, 255, 0.95);
+  --hud-bubble-color: #2c9ee8;
+  --hud-bubble-color-rgb: 44, 158, 232;
+  --hud-bubble-highlight: rgba(227, 242, 255, 0.95);
   --hud-hunger-color: #d68a3a;
   --hud-hunger-color-rgb: 214, 138, 58;
-  --hud-hunger-highlight: rgba(255, 240, 226, 0.92);
-  --hud-score-gradient: linear-gradient(180deg, rgba(248, 253, 244, 0.95), rgba(232, 244, 228, 0.95));
-  --hud-score-text: #1f3526;
-  --hud-progress-track: rgba(116, 195, 101, 0.24);
-  --hud-progress-glow: rgba(107, 182, 90, 0.4);
+  --hud-hunger-highlight: rgba(255, 240, 226, 0.94);
+  --hud-score-gradient: linear-gradient(180deg, rgba(248, 253, 244, 0.95), rgba(230, 244, 228, 0.95));
+  --hud-score-text: #233821;
+  --hud-progress-track: rgba(140, 206, 108, 0.28);
+  --hud-progress-glow: rgba(124, 190, 99, 0.42);
 }
 
 @media (prefers-color-scheme: light) {
   body[data-color-mode-preference='auto'] {
     color-scheme: light;
-    --bg-primary: #f6f9ff;
-    --bg-secondary: #e7f1ff;
-    --bg-tertiary: rgba(255, 255, 255, 0.92);
-    --accent: #2d7dd2;
-    --accent-strong: #d28f36;
-    --accent-soft: rgba(45, 125, 210, 0.18);
-    --primary: #1c7c4f;
-    --bg-dark: #f0f6ff;
-    --glow: 0 0 14px rgba(28, 124, 79, 0.35);
-    --dimension-primary: #2d7dd2;
-    --dimension-glow: rgba(45, 125, 210, 0.25);
-    --tooltip-bg: rgba(240, 246, 255, 0.95);
-    --tooltip-text: #182945;
-    --text-primary: #14263d;
-    --text-secondary: rgba(20, 38, 61, 0.8);
+    --bg-primary: #f4fbff;
+    --bg-secondary: #e4f4ff;
+    --bg-tertiary: rgba(255, 255, 255, 0.96);
+    --accent: #2c9ee8;
+    --accent-strong: #d18a32;
+    --accent-soft: rgba(44, 158, 232, 0.22);
+    --primary: #2f8b4c;
+    --bg-dark: #f1f9ff;
+    --glow: 0 0 14px rgba(47, 139, 76, 0.38);
+    --dimension-primary: #2c9ee8;
+    --dimension-glow: rgba(44, 158, 232, 0.28);
+    --tooltip-bg: rgba(244, 252, 240, 0.96);
+    --tooltip-text: #1d3224;
+    --text-primary: #1f2f1c;
+    --text-secondary: rgba(36, 64, 28, 0.78);
     --danger: #c7364b;
-    --success: #2d8d62;
-    --grid-line: rgba(45, 125, 210, 0.16);
-    --card-shadow: 0 18px 0 rgba(195, 211, 255, 0.35), 0 28px 56px rgba(136, 160, 210, 0.3);
+    --success: #2f8d5c;
+    --grid-line: rgba(44, 158, 232, 0.18);
+    --card-shadow: 0 18px 0 rgba(195, 219, 176, 0.35), 0 28px 56px rgba(162, 194, 148, 0.32);
     --page-background: linear-gradient(
         180deg,
-        #f7fbff 0%,
-        #e9f6ff 32%,
-        #f0fff6 60%,
-        #d9f2d3 78%,
-        #c1e1b2 90%,
-        #9fc484 100%
+        #f8fdff 0%,
+        #e9f7ff 28%,
+        #f0fff4 56%,
+        #d7efce 78%,
+        #bddfae 90%,
+        #9bc486 100%
       );
-    --panel-border-outer: #bed6a8;
-    --panel-border-highlight: rgba(116, 195, 101, 0.35);
-    --panel-surface: rgba(244, 252, 238, 0.94);
-    --panel-surface-alt: rgba(234, 247, 226, 0.94);
-    --viewport-border: #b1d59a;
-    --viewport-shadow: 0 22px 0 rgba(182, 206, 168, 0.4), 0 30px 64px rgba(132, 163, 120, 0.45);
-    --hud-panel-border: rgba(163, 196, 145, 0.9);
-    --hud-panel-shadow: 0 14px 0 rgba(167, 189, 151, 0.45), 0 26px 56px rgba(131, 156, 116, 0.4);
-    --hud-panel-bg: rgba(246, 253, 240, 0.94);
-    --hud-panel-bg-alt: rgba(236, 249, 232, 0.94);
+    --panel-border-outer: #b9d6a1;
+    --panel-border-highlight: rgba(148, 214, 122, 0.45);
+    --panel-surface: rgba(248, 255, 244, 0.96);
+    --panel-surface-alt: rgba(236, 249, 232, 0.96);
+    --viewport-border: #a5d090;
+    --viewport-shadow: 0 22px 0 rgba(189, 214, 168, 0.42), 0 30px 64px rgba(136, 168, 124, 0.45);
+    --hud-panel-border: rgba(170, 204, 150, 0.92);
+    --hud-panel-shadow: 0 14px 0 rgba(172, 198, 152, 0.45), 0 26px 56px rgba(134, 162, 120, 0.4);
+    --hud-panel-bg: rgba(250, 255, 244, 0.96);
+    --hud-panel-bg-alt: rgba(240, 250, 236, 0.96);
     --hud-heart-color: #d94d64;
     --hud-heart-glow: rgba(217, 77, 100, 0.35);
-    --hud-bubble-color: #2d7dd2;
-    --hud-bubble-color-rgb: 45, 125, 210;
-    --hud-bubble-highlight: rgba(227, 238, 255, 0.95);
+    --hud-bubble-color: #2c9ee8;
+    --hud-bubble-color-rgb: 44, 158, 232;
+    --hud-bubble-highlight: rgba(227, 242, 255, 0.95);
     --hud-hunger-color: #d68a3a;
     --hud-hunger-color-rgb: 214, 138, 58;
-    --hud-hunger-highlight: rgba(255, 240, 226, 0.92);
-    --hud-score-gradient: linear-gradient(180deg, rgba(248, 253, 244, 0.95), rgba(232, 244, 228, 0.95));
-    --hud-score-text: #1f3526;
-    --hud-progress-track: rgba(116, 195, 101, 0.24);
-    --hud-progress-glow: rgba(107, 182, 90, 0.4);
+    --hud-hunger-highlight: rgba(255, 240, 226, 0.94);
+    --hud-score-gradient: linear-gradient(180deg, rgba(248, 253, 244, 0.95), rgba(230, 244, 228, 0.95));
+    --hud-score-text: #233821;
+    --hud-progress-track: rgba(140, 206, 108, 0.28);
+    --hud-progress-glow: rgba(124, 190, 99, 0.42);
   }
 }
 
@@ -374,7 +374,7 @@ body:not(.game-active) .manu-logo {
 
 .landing-modal {
   padding: clamp(2rem, 6vw, 4rem);
-  background: radial-gradient(circle at 50% 20%, rgba(73, 242, 255, 0.2), rgba(5, 9, 18, 0.9));
+  background: radial-gradient(circle at 52% 18%, rgba(72, 196, 255, 0.22), rgba(6, 18, 12, 0.9));
   overflow: hidden;
 }
 
@@ -431,8 +431,8 @@ body:not(.game-active) .manu-logo {
   max-width: clamp(720px, 86vw, 980px);
   padding: clamp(2.5rem, 5vw, 3.5rem);
   border-radius: 28px;
-  background: rgba(5, 13, 26, 0.82);
-  border: 1px solid rgba(73, 242, 255, 0.3);
+  background: linear-gradient(160deg, rgba(10, 26, 18, 0.92), rgba(6, 18, 30, 0.9));
+  border: 1px solid rgba(72, 196, 255, 0.35);
   box-shadow: 0 40px 100px rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(20px);
   overflow: hidden;
@@ -466,7 +466,7 @@ body:not(.game-active) .manu-logo {
   text-transform: uppercase;
   letter-spacing: 0.32em;
   font-size: clamp(0.75rem, 1.6vw, 0.85rem);
-  color: rgba(255, 255, 255, 0.75);
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .landing-modal__title {
@@ -484,7 +484,7 @@ body:not(.game-active) .manu-logo {
 
 .landing-modal__tagline {
   max-width: 38ch;
-  color: rgba(242, 245, 250, 0.78);
+  color: rgba(244, 250, 255, 0.9);
   font-size: clamp(1rem, 1.9vw, 1.15rem);
   line-height: 1.6;
 }
@@ -500,21 +500,21 @@ body:not(.game-active) .manu-logo {
 .landing-modal__start {
   font-size: 1rem;
   padding: 0.85rem 1.75rem;
-  box-shadow: 0 18px 40px rgba(73, 242, 255, 0.35);
+  box-shadow: 0 18px 40px rgba(72, 196, 255, 0.35);
 }
 
 .landing-modal__howto {
-  border-color: rgba(73, 242, 255, 0.45);
+  border-color: rgba(72, 196, 255, 0.4);
   color: var(--text-primary);
   padding: 0.85rem 1.75rem;
-  background: rgba(6, 18, 34, 0.6);
+  background: rgba(10, 26, 18, 0.7);
   transition: background 0.3s ease, border-color 0.3s ease;
 }
 
 .landing-modal__howto:hover,
 .landing-modal__howto:focus-visible {
-  background: rgba(73, 242, 255, 0.12);
-  border-color: rgba(247, 183, 51, 0.7);
+  background: rgba(72, 196, 255, 0.16);
+  border-color: rgba(243, 178, 82, 0.75);
 }
 
 .landing-modal__body {
@@ -533,8 +533,8 @@ body:not(.game-active) .manu-logo {
   gap: 0.9rem;
   padding: 1.6rem 1.75rem;
   border-radius: 20px;
-  border: 1px solid rgba(73, 242, 255, 0.18);
-  background: linear-gradient(150deg, rgba(6, 18, 34, 0.85), rgba(6, 18, 34, 0.65));
+  border: 1px solid rgba(86, 196, 123, 0.4);
+  background: linear-gradient(150deg, rgba(18, 40, 26, 0.9), rgba(10, 26, 36, 0.75));
   box-shadow: 0 24px 50px rgba(0, 0, 0, 0.38);
   text-align: left;
 }
@@ -543,7 +543,7 @@ body:not(.game-active) .manu-logo {
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
-  color: rgba(242, 245, 250, 0.78);
+  color: rgba(244, 250, 255, 0.92);
   line-height: 1.6;
   font-size: 0.95rem;
 }
@@ -753,7 +753,7 @@ body::after {
   max-height: calc(100vh - clamp(2rem, 6vh, 3.5rem));
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: rgba(122, 183, 86, 0.55) transparent;
+  scrollbar-color: rgba(148, 214, 122, 0.55) transparent;
 }
 
 .objectives-panel::-webkit-scrollbar {
@@ -761,7 +761,7 @@ body::after {
 }
 
 .objectives-panel::-webkit-scrollbar-thumb {
-  background: rgba(122, 183, 86, 0.55);
+  background: rgba(148, 214, 122, 0.55);
   border-radius: 999px;
 }
 
@@ -783,7 +783,7 @@ body::after {
   font-size: 0.85rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: #f1f6e9;
+  color: #f7fde9;
   text-shadow: 0 0 6px rgba(9, 16, 9, 0.6);
 }
 
@@ -796,30 +796,30 @@ body::after {
 }
 
 .objectives-panel__card {
-  background: linear-gradient(180deg, rgba(42, 68, 36, 0.96), rgba(30, 50, 28, 0.96));
+  background: linear-gradient(180deg, rgba(39, 64, 32, 0.98), rgba(28, 48, 26, 0.98));
   border-radius: 10px;
-  border: 2px solid rgba(71, 111, 54, 0.85);
+  border: 2px solid rgba(132, 198, 96, 0.85);
   padding: 1.1rem 1.25rem;
   box-shadow: 0 10px 0 rgba(15, 25, 12, 0.55);
   backdrop-filter: none;
   display: grid;
   gap: 0.75rem;
-  color: #f6fbe9;
+  color: #f6fde7;
 }
 
 .objectives-panel__card--primer {
   padding: 1.25rem 1.4rem;
-  background: linear-gradient(180deg, rgba(58, 97, 42, 0.96), rgba(40, 67, 32, 0.96));
-  border: 2px solid rgba(112, 168, 79, 0.75);
+  background: linear-gradient(180deg, rgba(52, 88, 36, 0.98), rgba(34, 60, 30, 0.98));
+  border: 2px solid rgba(148, 214, 122, 0.78);
   gap: 1.1rem;
 }
 
 .objectives-panel__card--alert {
-  background: linear-gradient(180deg, rgba(78, 48, 28, 0.96), rgba(56, 34, 20, 0.96));
-  border: 2px solid rgba(255, 180, 127, 0.75);
+  background: linear-gradient(180deg, rgba(104, 54, 28, 0.98), rgba(68, 32, 18, 0.98));
+  border: 2px solid rgba(255, 196, 140, 0.78);
   box-shadow: 0 10px 0 rgba(37, 21, 12, 0.6);
   gap: 0.85rem;
-  color: rgba(255, 240, 226, 0.88);
+  color: rgba(255, 236, 224, 0.92);
 }
 
 .notice-card__title {
@@ -827,18 +827,18 @@ body::after {
   font-size: 0.95rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #ffe9cc;
+  color: #ffe9c8;
 }
 
 .objectives-panel__card--alert p {
   margin: 0;
   line-height: 1.6;
-  color: rgba(255, 232, 216, 0.82);
+  color: rgba(255, 232, 216, 0.9);
 }
 
 .notice-card__tip {
   font-size: 0.85rem;
-  color: rgba(255, 226, 205, 0.72);
+  color: rgba(255, 236, 212, 0.82);
 }
 
 .primer-list {
@@ -862,8 +862,8 @@ body::after {
   width: 2.6rem;
   height: 2.6rem;
   border-radius: 10px;
-  background: rgba(122, 183, 86, 0.22);
-  box-shadow: inset 0 0 0 1px rgba(122, 183, 86, 0.5), 0 8px 18px rgba(18, 28, 14, 0.4);
+  background: rgba(148, 214, 122, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(148, 214, 122, 0.55), 0 8px 18px rgba(18, 28, 14, 0.4);
   color: #ffe28f;
   font-size: 1.35rem;
 }
@@ -880,7 +880,7 @@ body::after {
   margin: 0;
   font-size: 0.9rem;
   line-height: 1.6;
-  color: rgba(245, 255, 231, 0.78);
+  color: rgba(246, 255, 232, 0.9);
 }
 
 .primer-list__content strong {
@@ -1026,8 +1026,8 @@ body::after {
   gap: 0.85rem;
   padding: 0.65rem 1.5rem;
   border-radius: 999px;
-  border: 1px solid rgba(73, 242, 255, 0.35);
-  background: rgba(6, 18, 36, 0.65);
+  border: 1px solid rgba(72, 196, 255, 0.4);
+  background: rgba(10, 28, 18, 0.7);
   color: var(--text-primary);
   font-family: 'Chakra Petch', sans-serif;
   font-size: 0.95rem;
@@ -1466,7 +1466,7 @@ body.game-active #gameCanvas {
   border-radius: 12px;
   overflow: hidden;
   box-shadow: var(--viewport-shadow), inset 0 0 0 3px var(--panel-border-highlight);
-  background: linear-gradient(180deg, rgba(58, 97, 42, 0.94), rgba(28, 47, 26, 0.96));
+  background: linear-gradient(180deg, rgba(52, 88, 36, 0.98), rgba(26, 46, 24, 0.98));
   border: 4px solid var(--viewport-border);
   display: grid;
   grid-template-areas: 'viewport';
@@ -1481,7 +1481,7 @@ body.game-active #gameCanvas {
   width: 100%;
   height: 100%;
   display: block;
-  background: linear-gradient(180deg, rgba(143, 214, 255, 0.95) 0%, rgba(128, 206, 255, 0.88) 36%, rgba(118, 190, 104, 0.95) 76%, rgba(88, 132, 62, 0.98) 100%);
+  background: linear-gradient(180deg, #9bd6ff 0%, #82c9f7 34%, #6fc068 76%, #4c8a34 100%);
   touch-action: none;
 }
 
@@ -1500,10 +1500,10 @@ body.game-active #gameCanvas {
   min-width: 180px;
   padding: 0.55rem 0.75rem 0.7rem;
   border-radius: 12px;
-  border: 1px solid rgba(120, 222, 255, 0.45);
-  background: linear-gradient(180deg, rgba(6, 18, 36, 0.92), rgba(8, 24, 42, 0.88));
+  border: 1px solid rgba(86, 196, 123, 0.45);
+  background: linear-gradient(180deg, rgba(10, 26, 18, 0.95), rgba(14, 32, 28, 0.9));
   box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
-  color: rgba(220, 241, 255, 0.94);
+  color: rgba(226, 255, 240, 0.96);
   pointer-events: none;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
   font-size: 0.8rem;
@@ -1515,7 +1515,7 @@ body.game-active #gameCanvas {
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.22em;
-  color: rgba(144, 231, 255, 0.8);
+  color: rgba(156, 236, 184, 0.82);
 }
 
 .developer-stats__metrics {


### PR DESCRIPTION
## Summary
- retune dark and light theme color tokens toward high-contrast, Minecraft-inspired greens and blues
- refresh landing modal, objectives panel, leaderboard toggle, and developer stats styling for legibility on the updated palette
- update primary viewport gradients to keep the game canvas readable against the new chroma

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68deb59941c0832b9d3d678c792b21e1