### PR TITLE
Ensure S3 bucket policy covers 3D model and texture assets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,22 @@ jobs:
                 "Principal": "*",
                 "Action": "s3:GetObject",
                 "Resource": "arn:aws:s3:::${DEPLOY_BUCKET}/*"
+              },
+              {
+                "Sid": "AllowPublicReadModelsAndTextures",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": [
+                  "arn:aws:s3:::${DEPLOY_BUCKET}/assets/*.gltf",
+                  "arn:aws:s3:::${DEPLOY_BUCKET}/assets/*.glb",
+                  "arn:aws:s3:::${DEPLOY_BUCKET}/assets/*.bin",
+                  "arn:aws:s3:::${DEPLOY_BUCKET}/assets/*/*.gltf",
+                  "arn:aws:s3:::${DEPLOY_BUCKET}/assets/*/*.glb",
+                  "arn:aws:s3:::${DEPLOY_BUCKET}/assets/*/*.bin",
+                  "arn:aws:s3:::${DEPLOY_BUCKET}/assets/textures/*",
+                  "arn:aws:s3:::${DEPLOY_BUCKET}/assets/*/textures/*"
+                ]
               }
             ]
           }

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ If no CloudFront distribution matches the S3 bucket, the workflow fails with ins
 
 ### Static asset permissions
 
-Every file uploaded during the deploy—including JavaScript bundles, GLTF models, textures, ambient audio, and any future additions under `assets/` or `vendor/`—must be readable by CloudFront. The GitHub Actions workflow configures the bucket with a permissive `s3:GetObject` statement by default, but infrastructure teams can swap this for an Origin Access Identity (OAI) or Origin Access Control (OAC) as long as the identity retains read access to the same object prefixes.
+Every file uploaded during the deploy—including JavaScript bundles, GLTF models, textures, ambient audio, and any future additions under `assets/` or `vendor/`—must be readable by CloudFront. The GitHub Actions workflow configures the bucket with a permissive `s3:GetObject` statement by default and now emits an explicit read grant for every GLTF/GLB/BIN model file and texture prefix under `assets/`. Infrastructure teams can swap this for an Origin Access Identity (OAI) or Origin Access Control (OAC) as long as the identity retains read access to the same object prefixes.
 
 To confirm nothing blocks the experience from loading:
 


### PR DESCRIPTION
## Summary
- extend the deploy workflow's bucket policy to explicitly grant read access for GLTF/GLB/BIN models and texture prefixes under assets/
- document the dedicated model/texture grant in the static asset permissions guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dec5529ba4832b9d27bd5d72935b02