### PR TITLE
Fix bucket policy generation in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,36 +151,37 @@ jobs:
               --bucket "${DEPLOY_BUCKET}" \
               --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=false,RestrictPublicBuckets=false
 
-            cat >"${POLICY_FILE}" <<POLICY
-            {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Sid": "AllowCloudFrontOAIRead",
-                  "Effect": "Allow",
-                  "Principal": {
-                    "AWS": "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${OAI_ID}"
-                  },
-                  "Action": "s3:GetObject",
-                  "Resource": [
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/index.html",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/styles.css",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/asset-resolver.js",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/audio-aliases.js",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/audio-captions.js",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/combat-utils.js",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/crafting.js",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/portal-mechanics.js",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/scoreboard-utils.js",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/script.js",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/simple-experience.js",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/assets/*",
-                    "arn:aws:s3:::${DEPLOY_BUCKET}/vendor/*"
-                  ]
-                }
-              ]
-            }
-            POLICY
+            jq -n \
+              --arg bucket "${DEPLOY_BUCKET}" \
+              --arg oai "${OAI_ID}" \
+              '{
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Sid: "AllowCloudFrontOAIRead",
+                    Effect: "Allow",
+                    Principal: {
+                      AWS: ("arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity " + $oai)
+                    },
+                    Action: "s3:GetObject",
+                    Resource: [
+                      "arn:aws:s3:::" + $bucket + "/index.html",
+                      "arn:aws:s3:::" + $bucket + "/styles.css",
+                      "arn:aws:s3:::" + $bucket + "/asset-resolver.js",
+                      "arn:aws:s3:::" + $bucket + "/audio-aliases.js",
+                      "arn:aws:s3:::" + $bucket + "/audio-captions.js",
+                      "arn:aws:s3:::" + $bucket + "/combat-utils.js",
+                      "arn:aws:s3:::" + $bucket + "/crafting.js",
+                      "arn:aws:s3:::" + $bucket + "/portal-mechanics.js",
+                      "arn:aws:s3:::" + $bucket + "/scoreboard-utils.js",
+                      "arn:aws:s3:::" + $bucket + "/script.js",
+                      "arn:aws:s3:::" + $bucket + "/simple-experience.js",
+                      "arn:aws:s3:::" + $bucket + "/assets/*",
+                      "arn:aws:s3:::" + $bucket + "/vendor/*"
+                    ]
+                  }
+                ]
+              }' > "${POLICY_FILE}"
 
             ACCESS_MODE="CloudFront OAI (${OAI_ID})"
           else
@@ -189,20 +190,20 @@ jobs:
               --bucket "${DEPLOY_BUCKET}" \
               --public-access-block-configuration BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false
 
-            cat >"${POLICY_FILE}" <<POLICY
-            {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Sid": "AllowPublicRead",
-                  "Effect": "Allow",
-                  "Principal": "*",
-                  "Action": "s3:GetObject",
-                  "Resource": "arn:aws:s3:::${DEPLOY_BUCKET}/*"
-                }
-              ]
-            }
-            POLICY
+            jq -n \
+              --arg bucket "${DEPLOY_BUCKET}" \
+              '{
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Sid: "AllowPublicRead",
+                    Effect: "Allow",
+                    Principal: "*",
+                    Action: "s3:GetObject",
+                    Resource: "arn:aws:s3:::" + $bucket + "/*"
+                  }
+                ]
+              }' > "${POLICY_FILE}"
 
             ACCESS_MODE="Public read"
           fi


### PR DESCRIPTION
## Summary
- replace the heredoc-based S3 bucket policy generation with jq so the deploy workflow no longer terminates with a syntax error when writing the policy file

## Testing
- not run (GitHub Actions workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dec8447e80832bac8824f36e6900ec