### PR TITLE
Add asset manifest and enforce deployment coverage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - name: Validate asset manifest coverage
+        run: node scripts/validate-asset-manifest.js
+
       - name: Sync site to S3
         env:
           DEPLOY_BUCKET: ${{ secrets.AWS_S3_BUCKET }}

--- a/README.md
+++ b/README.md
@@ -274,8 +274,11 @@ This repository ships with a GitHub Actions workflow that deploys the static sit
 
 1. Workflow validates that all required AWS secrets exist. Missing secrets trigger an actionable failure with setup steps.
 2. AWS credentials are configured via `aws-actions/configure-aws-credentials`.
-3. Repository contents (excluding version control and workflow files) are synchronised to the target S3 bucket.
-4. The workflow automatically discovers the CloudFront distribution attached to the S3 origin, invalidates its cache, waits for the flush to finish, and exposes both the distribution ID and URL as job outputs. The URL is also written to the run summary for quick access.
+3. `asset-manifest.json` is validated to ensure every required bundle, vendor shim, and GLTF/audio asset exists locally and is covered by the deploy sync rules.
+4. Repository contents (excluding version control and workflow files) are synchronised to the target S3 bucket.
+5. The workflow automatically discovers the CloudFront distribution attached to the S3 origin, invalidates its cache, waits for the flush to finish, and exposes both the distribution ID and URL as job outputs. The URL is also written to the run summary for quick access.
+
+The manifest lives at the repository root (`asset-manifest.json`) and serves as the canonical checklist of production assets. Update it whenever you add or retire a runtime bundle, vendor shim, or static asset that must ship with the experience. The deployment tests and workflow both fail fast if the manifest is missing entries or points at non-existent files.
 
 > **Always invalidate the CDN on every deploy.**
 >

--- a/asset-manifest.json
+++ b/asset-manifest.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "assets": [
+    "index.html",
+    "styles.css",
+    "script.js",
+    "simple-experience.js",
+    "asset-resolver.js",
+    "audio-aliases.js",
+    "audio-captions.js",
+    "combat-utils.js",
+    "crafting.js",
+    "portal-mechanics.js",
+    "scoreboard-utils.js",
+    "assets/offline-assets.js",
+    "assets/audio-samples.json",
+    "assets/favicon.svg",
+    "assets/infinite-dimension-logo.svg",
+    "assets/manu-logo.svg",
+    "assets/arm.gltf",
+    "assets/steve.gltf",
+    "assets/zombie.gltf",
+    "assets/iron_golem.gltf",
+    "vendor/three.min.js",
+    "vendor/GLTFLoader.js",
+    "vendor/howler-stub.js"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "vitest run",
     "test:e2e": "node tests/e2e-check.js",
-    "check:manifest": "node scripts/check-manifest.js"
+    "check:manifest": "node scripts/check-manifest.js",
+    "check:assets": "node scripts/validate-asset-manifest.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/validate-asset-manifest.js
+++ b/scripts/validate-asset-manifest.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const manifestPath = path.join(repoRoot, 'asset-manifest.json');
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'deploy.yml');
+
+function normalisePath(value) {
+  if (!value || typeof value !== 'string') {
+    return '';
+  }
+  return value.replace(/^\.\//, '').split('?')[0];
+}
+
+function extractIncludePatterns(workflow) {
+  const patterns = [];
+  const includeRegex = /--include\s+"([^"]+)"/g;
+  let match;
+  while ((match = includeRegex.exec(workflow)) !== null) {
+    patterns.push(match[1]);
+  }
+  return patterns;
+}
+
+function patternMatchesAsset(pattern, asset) {
+  if (!pattern || !asset) {
+    return false;
+  }
+  if (pattern.includes('*')) {
+    const [prefix] = pattern.split('*', 1);
+    return asset.startsWith(prefix);
+  }
+  return asset === pattern;
+}
+
+function loadManifest() {
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error('asset-manifest.json is missing from the repository root.');
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`asset-manifest.json is not valid JSON: ${error.message}`);
+  }
+
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('asset-manifest.json must export an object.');
+  }
+
+  if (!Array.isArray(raw.assets)) {
+    throw new Error('asset-manifest.json must define an "assets" array.');
+  }
+
+  const assets = raw.assets
+    .map((asset) => normalisePath(asset))
+    .filter((asset) => typeof asset === 'string' && asset.length > 0);
+
+  if (assets.length === 0) {
+    throw new Error('asset-manifest.json must list at least one asset.');
+  }
+
+  return assets;
+}
+
+function ensureUniqueAssets(assets) {
+  const seen = new Set();
+  const duplicates = new Set();
+  assets.forEach((asset) => {
+    if (seen.has(asset)) {
+      duplicates.add(asset);
+    }
+    seen.add(asset);
+  });
+  return Array.from(duplicates);
+}
+
+function listMissingFiles(assets) {
+  return assets.filter((asset) => {
+    const fullPath = path.join(repoRoot, asset);
+    try {
+      const stats = fs.statSync(fullPath);
+      return !stats.isFile();
+    } catch (error) {
+      return true;
+    }
+  });
+}
+
+function listUncoveredAssets(assets, patterns) {
+  return assets.filter((asset) => !patterns.some((pattern) => patternMatchesAsset(pattern, asset)));
+}
+
+function main() {
+  try {
+    const assets = loadManifest();
+    const duplicates = ensureUniqueAssets(assets);
+    const missingFiles = listMissingFiles(assets);
+
+    if (!fs.existsSync(workflowPath)) {
+      throw new Error('Deployment workflow .github/workflows/deploy.yml is missing.');
+    }
+    const workflowContents = fs.readFileSync(workflowPath, 'utf8');
+    const includePatterns = extractIncludePatterns(workflowContents);
+
+    const uncoveredAssets = listUncoveredAssets(assets, includePatterns);
+
+    const issues = [];
+    if (duplicates.length > 0) {
+      issues.push(`Duplicate manifest entries detected: ${duplicates.join(', ')}`);
+    }
+    if (missingFiles.length > 0) {
+      issues.push(`Manifest references files that do not exist or are not files: ${missingFiles.join(', ')}`);
+    }
+    if (uncoveredAssets.length > 0) {
+      issues.push(
+        `Deployment workflow does not sync the following manifest assets: ${uncoveredAssets.join(', ')}`,
+      );
+    }
+
+    if (issues.length > 0) {
+      console.error('\nAsset manifest validation failed:');
+      for (const issue of issues) {
+        console.error(` • ${issue}`);
+      }
+      console.error('\nUpdate asset-manifest.json or the deploy workflow before publishing.');
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log('✅ asset-manifest.json validated – all files exist and deploy workflow covers them.');
+  } catch (error) {
+    console.error(error.message || error);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  loadManifest,
+  ensureUniqueAssets,
+  listMissingFiles,
+  extractIncludePatterns,
+  patternMatchesAsset,
+  listUncoveredAssets,
+};

--- a/tests/deployment-assets.test.js
+++ b/tests/deployment-assets.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 const repoRoot = path.resolve(__dirname, '..');
 const indexHtmlPath = path.join(repoRoot, 'index.html');
 const workflowPath = path.join(repoRoot, '.github', 'workflows', 'deploy.yml');
+const manifestPath = path.join(repoRoot, 'asset-manifest.json');
 
 const indexHtml = fs.readFileSync(indexHtmlPath, 'utf8');
 const workflowContents = fs.readFileSync(workflowPath, 'utf8');
@@ -57,6 +58,9 @@ function extractIncludePatterns(workflow) {
 }
 
 function patternMatchesAsset(pattern, asset) {
+  if (!pattern || !asset) {
+    return false;
+  }
   if (pattern.includes('*')) {
     const [prefix] = pattern.split('*', 1);
     return asset.startsWith(prefix);
@@ -88,53 +92,105 @@ function collectGltfAssets() {
     .map((file) => path.relative(repoRoot, file).split(path.sep).join('/'));
 }
 
+function loadManifestAssets() {
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error('asset-manifest.json is missing from the repository root.');
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`asset-manifest.json is not valid JSON: ${error.message}`);
+  }
+
+  if (!manifest || typeof manifest !== 'object') {
+    throw new Error('asset-manifest.json must export an object.');
+  }
+
+  if (!Array.isArray(manifest.assets)) {
+    throw new Error('asset-manifest.json must define an "assets" array.');
+  }
+
+  return manifest.assets
+    .map((asset) => normalisePath(asset))
+    .filter((asset) => typeof asset === 'string' && asset.length > 0);
+}
+
+const manifestAssets = loadManifestAssets();
+const manifestAssetSet = new Set(manifestAssets);
+
 describe('deployment workflow asset coverage', () => {
-  it('syncs every local asset referenced by index.html', () => {
+  it('lists every local asset referenced by index.html', () => {
     const localAssets = new Set([
       ...extractLocalScriptSources(indexHtml),
       ...extractLocalLinkHrefs(indexHtml),
     ]);
 
-    const includePatterns = extractIncludePatterns(workflowContents);
-
-    const missing = Array.from(localAssets).filter((asset) =>
-      asset && !includePatterns.some((pattern) => patternMatchesAsset(pattern, asset)),
+    const missing = Array.from(localAssets).filter(
+      (asset) => asset && !manifestAssetSet.has(asset),
     );
 
     expect(missing).toEqual([]);
   });
 
-  it('explicitly syncs core runtime modules needed in production', () => {
-    const includePatterns = extractIncludePatterns(workflowContents);
-    const requiredModules = [
+  it('enumerates required runtime bundles and vendor shims', () => {
+    const requiredAssets = [
+      'index.html',
+      'styles.css',
+      'script.js',
+      'simple-experience.js',
       'asset-resolver.js',
       'audio-aliases.js',
+      'audio-captions.js',
       'combat-utils.js',
       'crafting.js',
       'portal-mechanics.js',
       'scoreboard-utils.js',
-      'simple-experience.js',
-      'script.js',
       'assets/offline-assets.js',
+      'assets/audio-samples.json',
       'vendor/three.min.js',
+      'vendor/GLTFLoader.js',
+      'vendor/howler-stub.js',
     ];
 
-    const missing = requiredModules.filter((asset) =>
-      !includePatterns.some((pattern) => patternMatchesAsset(pattern, asset)),
-    );
+    const missing = requiredAssets.filter((asset) => !manifestAssetSet.has(asset));
 
     expect(missing).toEqual([]);
   });
 
-  it('deploys every GLTF model referenced by the experience', () => {
-    const includePatterns = extractIncludePatterns(workflowContents);
+  it('includes every GLTF model referenced by the experience', () => {
     const gltfAssets = collectGltfAssets();
+    const missing = gltfAssets.filter((asset) => !manifestAssetSet.has(asset));
 
-    const missing = gltfAssets.filter(
+    expect(gltfAssets.length).toBeGreaterThan(0);
+    expect(missing).toEqual([]);
+  });
+
+  it('only references assets that exist on disk', () => {
+    const missing = manifestAssets.filter((asset) => {
+      const filePath = path.join(repoRoot, asset);
+      try {
+        return !fs.statSync(filePath).isFile();
+      } catch (error) {
+        return true;
+      }
+    });
+
+    expect(missing).toEqual([]);
+  });
+
+  it('does not include duplicate entries', () => {
+    expect(manifestAssets.length).toBe(manifestAssetSet.size);
+  });
+
+  it('deploy workflow syncs every manifest asset', () => {
+    const includePatterns = extractIncludePatterns(workflowContents);
+    const missing = manifestAssets.filter(
       (asset) => !includePatterns.some((pattern) => patternMatchesAsset(pattern, asset)),
     );
 
-    expect(gltfAssets.length).toBeGreaterThan(0);
+    expect(includePatterns.length).toBeGreaterThan(0);
     expect(missing).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- add a top-level asset-manifest.json enumerating the runtime bundles, vendor shims, and static assets required in production
- introduce scripts/validate-asset-manifest.js and wire it into the GitHub Actions workflow to fail deployments when assets are missing or not synced
- expand deployment-assets Vitest coverage and README documentation so the manifest stays aligned with index.html, GLTF models, and S3 sync rules

## Testing
- npm test
- node scripts/validate-asset-manifest.js

------
https://chatgpt.com/codex/tasks/task_e_68df3ca77a98832b8e16bf75f2563c98