### PR TITLE
Ensure player animations validate idle/walk channels

### DIFF
--- a/tests/simple-experience-steve-loader.test.js
+++ b/tests/simple-experience-steve-loader.test.js
@@ -82,5 +82,101 @@ describe('simple experience steve model loading', () => {
       }
     }
   });
+
+  it('falls back to placeholder when idle/walk animation clips are missing', async () => {
+    const { experience } = createExperience();
+    const { THREE } = experience;
+    const originalCloneModelScene = experience.cloneModelScene;
+    const originalApplyCameraPerspective = experience.applyCameraPerspective;
+    const originalEnsurePlayerArmsVisible = experience.ensurePlayerArmsVisible;
+    experience.playerRig = new THREE.Group();
+    experience.cameraBoom = new THREE.Object3D();
+    experience.camera = new THREE.Object3D();
+    experience.cameraBoom.add(experience.camera);
+    experience.playerRig.add(experience.cameraBoom);
+    experience.handGroup = null;
+    experience.ensurePlayerArmsVisible = vi.fn();
+    experience.applyCameraPerspective = vi.fn();
+    experience.activeSessionId = 'test-session';
+
+    const invalidModel = new THREE.Group();
+    invalidModel.name = 'InvalidAvatar';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    experience.cloneModelScene = vi.fn().mockResolvedValue({
+      scene: invalidModel,
+      animations: [new THREE.AnimationClip('Jump', -1, [])],
+    });
+
+    try {
+      await experience.loadPlayerCharacter();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Player model missing animation channel(s): Idle, Walk'),
+      );
+      expect(experience.playerAvatar).toBeTruthy();
+      expect(experience.playerAvatar.userData?.placeholder).toBe(true);
+      expect(experience.playerAvatar.userData?.placeholderSource).toBe('missing-animations');
+      expect(experience.playerAnimationRig).toBeNull();
+      expect(experience.playerMixer).toBeNull();
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      experience.cloneModelScene = originalCloneModelScene;
+      experience.applyCameraPerspective = originalApplyCameraPerspective;
+      experience.ensurePlayerArmsVisible = originalEnsurePlayerArmsVisible;
+    }
+  });
+
+  it('initialises player rig with idle base state and preloaded walk clip', async () => {
+    const { experience } = createExperience();
+    const { THREE } = experience;
+    const originalCloneModelScene = experience.cloneModelScene;
+    const originalApplyCameraPerspective = experience.applyCameraPerspective;
+    const originalEnsurePlayerArmsVisible = experience.ensurePlayerArmsVisible;
+    experience.playerRig = new THREE.Group();
+    experience.cameraBoom = new THREE.Object3D();
+    experience.camera = new THREE.Object3D();
+    experience.cameraBoom.add(experience.camera);
+    experience.playerRig.add(experience.cameraBoom);
+    experience.handGroup = null;
+    experience.ensurePlayerArmsVisible = vi.fn();
+    experience.applyCameraPerspective = vi.fn();
+    experience.activeSessionId = 'rig-session';
+
+    const model = new THREE.Group();
+    const hips = new THREE.Object3D();
+    hips.name = 'Hips';
+    const headPivot = new THREE.Object3D();
+    headPivot.name = 'HeadPivot';
+    hips.add(headPivot);
+    model.add(hips);
+
+    const idleClip = new THREE.AnimationClip('Idle', -1, []);
+    const walkClip = new THREE.AnimationClip('WalkForward', -1, []);
+
+    experience.cloneModelScene = vi.fn().mockResolvedValue({
+      scene: model,
+      animations: [idleClip, walkClip],
+    });
+
+    try {
+      await experience.loadPlayerCharacter();
+
+      expect(experience.playerAnimationRig).toBeTruthy();
+      expect(experience.playerAnimationRig.state).toBe('idle');
+      expect(experience.playerAnimationRig.baseState).toBe('idle');
+      expect(experience.playerAnimationRig.actions?.idle).toBeTruthy();
+      expect(experience.playerAnimationRig.actions?.walk).toBeTruthy();
+      expect(experience.playerAnimationRig.actions.walk.enabled).toBe(true);
+      expect(experience.playerAnimationRig.actions.walk.isRunning()).toBe(true);
+      expect(experience.playerAnimationRig.actions.idle.getEffectiveWeight()).toBeCloseTo(1);
+      expect(experience.playerAnimationRig.actions.walk.getEffectiveWeight()).toBeCloseTo(0);
+    } finally {
+      experience.cloneModelScene = originalCloneModelScene;
+      experience.applyCameraPerspective = originalApplyCameraPerspective;
+      experience.ensurePlayerArmsVisible = originalEnsurePlayerArmsVisible;
+    }
+  });
 });
 


### PR DESCRIPTION
## Summary
- add animation keyword helpers and missing-channel detection before instantiating the player rig
- fall back to the placeholder mesh with a clear error when idle/walk clips are absent and mark the placeholder source
- expand Steve loader tests to cover missing-animation fallback and confirm idle/walk rig setup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df5e197068832bafa1a664896dc215