### PR TITLE
Sanitize scoreboard fallbacks and refresh HUD after score events

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -16525,24 +16525,29 @@
       }
       const targets = this.scoreMetricElements || {};
       const element = targets[normalizedKey];
-      if (!element) {
-        return;
-      }
-      const timers = this.scoreMetricFlashTimers || (this.scoreMetricFlashTimers = new Map());
-      if (timers.has(element)) {
-        clearTimeout(timers.get(element));
-        timers.delete(element);
-      }
-      element.classList.remove('score-overlay__metric-value--flash');
-      void element.offsetWidth;
-      element.classList.add('score-overlay__metric-value--flash');
-      element.dataset.delta = `+${this.formatPointValue(amount)} pts`;
-      const timer = setTimeout(() => {
+      if (element) {
+        const timers = this.scoreMetricFlashTimers || (this.scoreMetricFlashTimers = new Map());
+        if (timers.has(element)) {
+          clearTimeout(timers.get(element));
+          timers.delete(element);
+        }
         element.classList.remove('score-overlay__metric-value--flash');
-        delete element.dataset.delta;
-        timers.delete(element);
-      }, 900);
-      timers.set(element, timer);
+        void element.offsetWidth;
+        element.classList.add('score-overlay__metric-value--flash');
+        element.dataset.delta = `+${this.formatPointValue(amount)} pts`;
+        const timer = setTimeout(() => {
+          element.classList.remove('score-overlay__metric-value--flash');
+          delete element.dataset.delta;
+          timers.delete(element);
+        }, 900);
+        timers.set(element, timer);
+      }
+      if (typeof this.updateHud === 'function') {
+        this.updateHud();
+      }
+      if (typeof this.publishStateSnapshot === 'function') {
+        this.publishStateSnapshot('score-event');
+      }
     }
 
     formatPointValue(value) {


### PR DESCRIPTION
## Summary
- sanitize scoreboard normalization so identifiers, labels, and timestamps never fall back to blank or "undefined" strings
- ensure score events always refresh the HUD and publish a state snapshot even when metric elements are missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df7468d8cc832bbce9b236e916904c