### PR TITLE
Highlight missing inventory and crafting visuals

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4377,6 +4377,34 @@ body.sidebar-open .player-hint {
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
 }
 
+.inventory-grid__cell {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.inventory-grid__cell[data-visual='missing'],
+.inventory-slot[data-visual='missing'],
+.crafting-inventory__item[data-visual='missing'],
+.crafting-suggestions__item[data-visual='missing'],
+.crafting-search__result[data-visual='missing'] {
+  opacity: 0.55;
+}
+
+.visual-warning {
+  display: block;
+  font-size: 0.65rem;
+  color: rgba(198, 210, 225, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-top: 0.35rem;
+}
+
+.inventory-grid__cell[data-visual='missing'] .visual-warning,
+.inventory-slot[data-visual='missing'] .visual-warning,
+.crafting-inventory__item[data-visual='missing'] .visual-warning {
+  color: rgba(198, 210, 225, 0.9);
+}
+
 .crafting-inventory__item {
   border-radius: 14px;
   border: 1px solid rgba(73, 242, 255, 0.2);

--- a/tests/simple-experience-inventory-flow.test.js
+++ b/tests/simple-experience-inventory-flow.test.js
@@ -347,6 +347,51 @@ describe('simple experience inventory and crafting flows', () => {
     expect(craftingHelperMatchesEl.getAttribute('data-empty')).toBe('false');
   });
 
+  it('greys out inventory entries and recipes when visuals are missing', () => {
+    const inventoryGridEl = document.createElement('div');
+    const craftingInventoryEl = document.createElement('div');
+    const craftSuggestionsEl = document.createElement('ul');
+
+    const experience = createExperience({
+      ui: {
+        inventoryGridEl,
+        craftingInventoryEl,
+        craftSuggestionsEl,
+      },
+    });
+
+    experience.craftingState.unlocked.clear();
+    experience.craftingRecipes.forEach((recipe, key) => {
+      experience.craftingState.unlocked.set(key, recipe);
+    });
+
+    experience.hotbar = experience.hotbar.map(() => ({ item: null, quantity: 0 }));
+    experience.hotbar[0] = { item: 'stone', quantity: 3 };
+    experience.textureFallbackMissingKeys.add('stone');
+
+    experience.updateInventoryModal();
+    expect(inventoryGridEl.children.length).toBeGreaterThan(0);
+    const inventoryCell = inventoryGridEl.children[0];
+    expect(inventoryCell.dataset.visual).toBe('missing');
+    expect(inventoryCell.dataset.visualSummary).toContain('stone');
+    expect(inventoryCell.innerHTML).toContain('Missing');
+
+    experience.updateCraftingInventoryUi();
+    expect(craftingInventoryEl.children.length).toBeGreaterThan(0);
+    const craftingButton = craftingInventoryEl.children[0];
+    expect(craftingButton.dataset.visual).toBe('missing');
+    expect(craftingButton.dataset.visualSummary).toContain('stone');
+    expect(craftingButton.innerHTML).toContain('Missing');
+
+    experience.updateCraftingSuggestions();
+    expect(craftSuggestionsEl.children.length).toBeGreaterThan(0);
+    const suggestionItem = craftSuggestionsEl.children[0];
+    const suggestionButton = suggestionItem.children[0];
+    expect(suggestionButton.dataset.visual).toBe('missing');
+    expect(suggestionButton.dataset.visualSummary).toContain('Missing texture');
+    expect(suggestionButton.textContent).toContain('Missing texture');
+  });
+
   it('dispatches a recipe-crafted event when crafting succeeds', () => {
     const experience = createExperience();
 


### PR DESCRIPTION
## Summary
- track texture and material availability for items and recipes so missing assets are still rendered with clear messaging
- grey out inventory, satchel, and crafting recipe entries when visuals are unavailable and surface accessibility hints
- cover the missing-asset rendering path with a regression test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df856514b4832b808cc2321f80b785