### PR TITLE
Add HUD alert banner for critical load failures

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,19 @@
           </div>
         </div>
         <div class="hud-layer" id="gameHud">
+          <div
+            class="hud-alert"
+            id="hudAlert"
+            role="alert"
+            aria-live="assertive"
+            hidden
+          >
+            <span class="hud-alert__icon" aria-hidden="true"></span>
+            <div class="hud-alert__content">
+              <span class="hud-alert__title" id="hudAlertTitle"></span>
+              <span class="hud-alert__message" id="hudAlertMessage"></span>
+            </div>
+          </div>
           <div class="hud-layer__corner hud-layer__corner--top-left">
             <div class="hud-card hud-card--status" data-hint="Monitor vitals and access crafting tools.">
               <div class="hud-status" aria-label="Player vitals" role="group" data-hint="Health, oxygen, and time remainers.">

--- a/styles.css
+++ b/styles.css
@@ -2636,6 +2636,138 @@ body.game-active #gameCanvas {
   z-index: 12;
 }
 
+.hud-alert {
+  position: absolute;
+  top: clamp(0.75rem, 2vw, 1.1rem);
+  left: 50%;
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.8rem 1.2rem;
+  max-width: min(90vw, 32rem);
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(46, 64, 78, 0.92), rgba(28, 40, 48, 0.92));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
+  color: #f5fbff;
+  transform: translate(-50%, -0.5rem) scale(0.97);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  backdrop-filter: blur(9px);
+  -webkit-backdrop-filter: blur(9px);
+  font-size: clamp(0.9rem, 1.8vw, 1rem);
+  line-height: 1.4;
+  z-index: 4;
+}
+
+.hud-alert:not([hidden]) {
+  opacity: 1;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.hud-alert__icon {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  font-size: 1.15rem;
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.14);
+  color: inherit;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.hud-alert__icon::before {
+  content: 'ℹ';
+}
+
+.hud-alert__content {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.hud-alert__title {
+  display: block;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+}
+
+.hud-alert__message {
+  display: block;
+  color: rgba(232, 244, 255, 0.92);
+}
+
+.hud-alert[data-severity='error'] {
+  background: linear-gradient(135deg, rgba(164, 28, 40, 0.95), rgba(92, 6, 19, 0.92));
+  color: #fff5f7;
+  box-shadow: 0 22px 36px rgba(82, 6, 21, 0.58);
+}
+
+.hud-alert[data-severity='error'] .hud-alert__icon {
+  background: rgba(255, 255, 255, 0.15);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28);
+}
+
+.hud-alert[data-severity='error'] .hud-alert__icon::before {
+  content: '!';
+}
+
+.hud-alert[data-severity='warning'] {
+  background: linear-gradient(135deg, rgba(196, 126, 32, 0.94), rgba(120, 68, 10, 0.92));
+  color: #fff6e8;
+  box-shadow: 0 20px 32px rgba(102, 52, 6, 0.55);
+}
+
+.hud-alert[data-severity='warning'] .hud-alert__icon::before {
+  content: '⚠';
+}
+
+.hud-alert[data-severity='success'] {
+  background: linear-gradient(135deg, rgba(30, 140, 92, 0.94), rgba(11, 72, 51, 0.92));
+  color: #e8fff5;
+  box-shadow: 0 20px 32px rgba(8, 64, 46, 0.48);
+}
+
+.hud-alert[data-severity='success'] .hud-alert__icon::before {
+  content: '✓';
+}
+
+.hud-alert[data-severity='success'] .hud-alert__message {
+  color: rgba(229, 253, 242, 0.92);
+}
+
+.hud-alert[data-severity='info'] {
+  background: linear-gradient(135deg, rgba(40, 86, 148, 0.94), rgba(22, 56, 104, 0.94));
+  color: #f0f6ff;
+  box-shadow: 0 20px 32px rgba(16, 38, 86, 0.5);
+}
+
+.hud-alert[data-severity='info'] .hud-alert__icon::before {
+  content: 'ℹ';
+}
+
+.hud-alert[data-severity='info'] .hud-alert__message {
+  color: rgba(224, 236, 255, 0.9);
+}
+
+@media (max-width: 768px) {
+  .hud-alert {
+    top: 0.6rem;
+    padding: 0.65rem 0.9rem;
+    gap: 0.65rem;
+    font-size: 0.85rem;
+  }
+
+  .hud-alert__icon {
+    width: 1.7rem;
+    height: 1.7rem;
+    font-size: 1rem;
+  }
+}
+
 .hud-layer {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- add a reusable HUD alert banner so major asset, model, or script failures surface outside the console
- wire error and recovery events (asset load failures, retries, renderer issues) into the new alert helpers and retain compatibility with the bootstrap overlay
- style the alert for different severities and ensure simple-mode HUD bootstrapping creates the markup when missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df88940538832ba51c8784ae9efc37