### PR TITLE
Fix legacy keyboard handling and pointer lock fallback

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -55,6 +55,24 @@
   const SCORE_SYNC_QUEUE_LIMIT = 25;
   const FIRST_RUN_TUTORIAL_STORAGE_KEY = 'infinite-rails-first-run-tutorial';
   const MOVEMENT_ACTIONS = ['moveForward', 'moveBackward', 'moveLeft', 'moveRight'];
+  const LEGACY_KEYBOARD_CODE_MAP = Object.freeze({
+    ArrowUp: 'ArrowUp',
+    ArrowDown: 'ArrowDown',
+    ArrowLeft: 'ArrowLeft',
+    ArrowRight: 'ArrowRight',
+    Up: 'ArrowUp',
+    Down: 'ArrowDown',
+    Left: 'ArrowLeft',
+    Right: 'ArrowRight',
+    Escape: 'Escape',
+    Esc: 'Escape',
+    Spacebar: 'Space',
+    Space: 'Space',
+    ' ': 'Space',
+    Enter: 'Enter',
+    Return: 'Enter',
+    Tab: 'Tab',
+  });
   const DEFAULT_KEY_BINDINGS = (() => {
     const map = {
       moveForward: ['KeyW', 'ArrowUp'],
@@ -439,6 +457,43 @@
       });
     });
     return merged;
+  }
+
+  function normalizeKeyboardEventCode(event) {
+    if (!event) {
+      return '';
+    }
+    const code = typeof event.code === 'string' ? event.code : '';
+    if (code) {
+      return code;
+    }
+    const rawKey = typeof event.key === 'string' ? event.key : '';
+    if (!rawKey) {
+      return '';
+    }
+    if (LEGACY_KEYBOARD_CODE_MAP[rawKey]) {
+      return LEGACY_KEYBOARD_CODE_MAP[rawKey];
+    }
+    const trimmed = rawKey.trim();
+    if (LEGACY_KEYBOARD_CODE_MAP[trimmed]) {
+      return LEGACY_KEYBOARD_CODE_MAP[trimmed];
+    }
+    if (!trimmed) {
+      return '';
+    }
+    if (/^[a-z]$/i.test(trimmed)) {
+      return `Key${trimmed.toUpperCase()}`;
+    }
+    if (/^[0-9]$/.test(trimmed)) {
+      return `Digit${trimmed}`;
+    }
+    if (/^F[0-9]{1,2}$/i.test(trimmed)) {
+      return trimmed.toUpperCase();
+    }
+    if (/^Numpad[0-9]$/i.test(trimmed)) {
+      return `Numpad${trimmed.slice(-1)}`;
+    }
+    return '';
   }
 
   function formatKeyLabel(code) {
@@ -12454,7 +12509,7 @@
         event.__infiniteRailsHandled = true;
       }
       this.markInteraction();
-      const code = typeof event.code === 'string' ? event.code : '';
+      const code = normalizeKeyboardEventCode(event);
       if (code) {
         this.keys.add(code);
       }
@@ -12528,7 +12583,7 @@
         event.__infiniteRailsHandled = true;
       }
       this.markInteraction();
-      const code = typeof event.code === 'string' ? event.code : '';
+      const code = normalizeKeyboardEventCode(event);
       if (code) {
         this.keys.delete(code);
       }

--- a/tests/simple-experience-input-handlers.test.js
+++ b/tests/simple-experience-input-handlers.test.js
@@ -71,4 +71,65 @@ describe('simple experience input handlers', () => {
     expect(placeSpy).toHaveBeenCalledTimes(1);
     expect(event.preventDefault).toHaveBeenCalled();
   });
+
+  it('normalises letter movement keys when KeyboardEvent.code is unavailable', () => {
+    const { experience } = createInputTestExperience();
+    experience.pointerLocked = true;
+    vi.spyOn(experience, 'queueMovementBindingValidation').mockImplementation(() => {});
+    const event = {
+      key: 'w',
+      preventDefault: vi.fn(),
+      repeat: false,
+    };
+
+    experience.handleKeyDown(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(experience.keys.has('KeyW')).toBe(true);
+    expect(experience.isActionActive('moveForward')).toBe(true);
+  });
+
+  it('normalises legacy arrow keys when KeyboardEvent.code is unavailable', () => {
+    const { experience } = createInputTestExperience();
+    experience.pointerLocked = true;
+    vi.spyOn(experience, 'queueMovementBindingValidation').mockImplementation(() => {});
+    const event = {
+      key: 'Up',
+      preventDefault: vi.fn(),
+      repeat: false,
+    };
+
+    experience.handleKeyDown(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(experience.keys.has('ArrowUp')).toBe(true);
+
+    experience.handleKeyUp({ key: 'Up' });
+    expect(experience.keys.has('ArrowUp')).toBe(false);
+  });
+
+  it('falls back to vendor-prefixed pointer lock requests when options are unsupported', () => {
+    const { experience, canvas } = createInputTestExperience();
+    const prototype = Object.getPrototypeOf(experience);
+    experience.attemptPointerLock = prototype.attemptPointerLock.bind(experience);
+    experience.pointerLocked = false;
+    experience.getPointerLockElement = vi.fn(() => null);
+    const fallbackSpy = vi.spyOn(experience, 'enablePointerLockFallback');
+    delete canvas.requestPointerLock;
+    delete experience.canvas.requestPointerLock;
+    const mozRequestPointerLock = vi.fn(function (options) {
+      if (options) {
+        throw new TypeError('unadjustedMovement unsupported');
+      }
+      return { catch: () => {} };
+    });
+    canvas.mozRequestPointerLock = mozRequestPointerLock;
+    experience.canvas.mozRequestPointerLock = mozRequestPointerLock;
+
+    experience.attemptPointerLock();
+
+    expect(mozRequestPointerLock).toHaveBeenCalledTimes(2);
+    expect(mozRequestPointerLock.mock.calls[0][0]).toEqual({ unadjustedMovement: true });
+    expect(mozRequestPointerLock.mock.calls[1].length).toBe(0);
+    expect(fallbackSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- normalize keyboard events so legacy browsers map WASD and arrow bindings correctly
- cover pointer lock fallback behavior with additional unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8b6d20ec832b8a0e6261b9949ba9