### PR TITLE
Link player physics body with rig

### DIFF
--- a/tests/simple-experience-entities.test.js
+++ b/tests/simple-experience-entities.test.js
@@ -446,7 +446,7 @@ describe('simple experience entity lifecycle', () => {
     ensureWorldSpy.mockClear();
 
     const playerPosition = new experience.THREE.Vector3(3, 0, 3);
-    vi.spyOn(experience, 'getCameraWorldPosition').mockImplementation(function (target) {
+    vi.spyOn(experience, 'getPlayerWorldPosition').mockImplementation(function (target) {
       if (target?.copy) {
         target.copy(playerPosition);
         return target;
@@ -774,14 +774,14 @@ describe('simple experience entity lifecycle', () => {
 
     const farPosition = new THREE.Vector3(6, 1.6, 6);
     const nearPosition = new THREE.Vector3(0.4, 1.6, 0.4);
-    vi.spyOn(experience, 'getCameraWorldPosition').mockImplementation((target) => target.copy(farPosition));
+    vi.spyOn(experience, 'getPlayerWorldPosition').mockImplementation((target) => target.copy(farPosition));
 
     const baseScale = mesh.scale.x;
     experience.updateLootChests(0.016);
     const farDeviation = Math.abs(mesh.scale.x - baseScale);
     const farGlow = glowMaterial.emissiveIntensity;
 
-    experience.getCameraWorldPosition.mockImplementation((target) => target.copy(nearPosition));
+    experience.getPlayerWorldPosition.mockImplementation((target) => target.copy(nearPosition));
     experience.updateLootChests(0.2);
 
     const nearDeviation = Math.abs(mesh.scale.x - baseScale);


### PR DESCRIPTION
## Summary
- add an invisible physics body that stays parented to the player rig and exposes helper accessors
- switch collision and interaction systems to read the physics body's world position instead of the camera transform
- extend movement diagnostics and entity tests to cover the new physics bindings

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68df91df1140832bafc1d6b116f67b2e