### PR TITLE
Guard dimension travel scoring on successful portal transitions

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -12153,6 +12153,7 @@
       let pointsAwarded = 5;
       let portalLog = '';
       let transitionResult = null;
+      let dimensionTravelSucceeded = true;
       const previousSettings = this.dimensionSettings;
       const rulesSummary = this.buildDimensionRuleSummary(nextSettings);
       if (this.portalMechanics?.enterPortal) {
@@ -12173,6 +12174,12 @@
           if (transitionResult?.log) {
             portalLog = transitionResult.log;
           }
+          const teleportOutsideTrigger =
+            transitionResult?.teleportOutsideTriggers === true ||
+            transitionResult?.teleportOutsideTrigger === true ||
+            transitionResult?.teleportedOutsideTrigger === true;
+          dimensionTravelSucceeded =
+            !teleportOutsideTrigger && transitionResult?.dimensionChanged !== false;
         } catch (error) {
           console.warn('Portal transition mechanics failed', error);
         }
@@ -12209,7 +12216,7 @@
         nextDimension: this.dimensionSettings,
         transition: transitionResult,
       });
-      if (Number.isFinite(pointsAwarded)) {
+      if (dimensionTravelSucceeded && Number.isFinite(pointsAwarded)) {
         this.score += pointsAwarded;
         this.addScoreBreakdown('dimensions', pointsAwarded);
       }

--- a/tests/simple-experience-dimension-travel-score.test.js
+++ b/tests/simple-experience-dimension-travel-score.test.js
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createExperience, ensureSimpleExperienceLoaded } from './helpers/simple-experience-test-utils.js';
+
+function prepareExperienceForAdvance(experience) {
+  const themes = window.SimpleExperience.dimensionThemes;
+  experience.portalActivated = true;
+  experience.portalState = { active: true };
+  experience.victoryAchieved = false;
+  experience.currentDimensionIndex = 0;
+  experience.dimensionSettings = themes[0] ?? { id: 'origin', name: 'Origin' };
+  experience.audio = { play: vi.fn() };
+  experience.notifyScoreEvent = vi.fn();
+  vi.spyOn(experience, 'buildTerrain').mockImplementation(() => {});
+  vi.spyOn(experience, 'buildRails').mockImplementation(() => {});
+  vi.spyOn(experience, 'spawnDimensionChests').mockImplementation(() => {});
+  vi.spyOn(experience, 'refreshPortalState').mockImplementation(() => {});
+  vi.spyOn(experience, 'revealDimensionIntro').mockImplementation(() => {});
+  vi.spyOn(experience, 'rebindDimensionContext').mockImplementation(() => {});
+  vi.spyOn(experience, 'updateHud').mockImplementation(() => {});
+  vi.spyOn(experience, 'scheduleScoreSync').mockImplementation(() => {});
+  vi.spyOn(experience, 'showHint').mockImplementation(() => {});
+  vi.spyOn(experience, 'runDimensionExitHooks').mockResolvedValue();
+  vi.spyOn(experience, 'runDimensionEnterHooks').mockResolvedValue();
+  vi.spyOn(experience, 'applyDimensionSettings').mockImplementation(function mockApply(index) {
+    this.currentDimensionIndex = index;
+    this.dimensionSettings = themes[index] ?? { id: `dimension-${index}`, name: `Dimension ${index + 1}` };
+  });
+}
+
+describe('simple experience dimension travel scoring', () => {
+  beforeEach(() => {
+    ensureSimpleExperienceLoaded();
+  });
+
+  it('awards points when the portal transition changes dimensions', async () => {
+    const { experience } = createExperience();
+    prepareExperienceForAdvance(experience);
+    const startScore = experience.score;
+    const addScoreSpy = vi.spyOn(experience, 'addScoreBreakdown');
+
+    experience.portalMechanics = { ...experience.portalMechanics };
+    experience.portalMechanics.enterPortal = vi.fn(() => ({
+      pointsAwarded: 9,
+      dimensionChanged: true,
+      log: 'Entering Rock Dimension — Gravity ×1.50 — Heavier world with dense ore clusters.',
+    }));
+
+    await experience.advanceDimension();
+
+    expect(experience.portalMechanics.enterPortal).toHaveBeenCalled();
+    expect(experience.score).toBe(startScore + 9);
+    expect(addScoreSpy).toHaveBeenCalledWith('dimensions', 9);
+  });
+
+  it('does not award points when the transition reports no dimension change', async () => {
+    const { experience } = createExperience();
+    prepareExperienceForAdvance(experience);
+    const startScore = experience.score;
+    const addScoreSpy = vi.spyOn(experience, 'addScoreBreakdown');
+
+    experience.portalMechanics = { ...experience.portalMechanics };
+    experience.portalMechanics.enterPortal = vi.fn(() => ({
+      pointsAwarded: 12,
+      dimensionChanged: false,
+    }));
+
+    await experience.advanceDimension();
+
+    expect(experience.portalMechanics.enterPortal).toHaveBeenCalled();
+    expect(experience.score).toBe(startScore);
+    expect(addScoreSpy).not.toHaveBeenCalledWith('dimensions', expect.any(Number));
+  });
+});


### PR DESCRIPTION
## Summary
- skip portal travel score awards when the transition reports no dimension change or teleports outside the trigger
- ensure the score bonus still applies on successful dimension advances and cover both flows with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfa805a868832ba96c7f01c19bfd67