### PR TITLE
Prevent guide modal from being aria-hidden while focused

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -3180,14 +3180,36 @@
           focusTarget.focus({ preventScroll: true });
         }
       } else {
+        const doc =
+          (typeof document !== 'undefined' ? document : null) ||
+          this.guideModalEl?.ownerDocument ||
+          null;
+        const restoreCandidate =
+          options?.returnFocus === false ? null : this.lastGuideTrigger || this.openGuideButton;
+        const restore =
+          restoreCandidate &&
+          typeof restoreCandidate.focus === 'function' &&
+          !(typeof this.guideModalEl.contains === 'function' && this.guideModalEl.contains(restoreCandidate))
+            ? restoreCandidate
+            : null;
+        let focusHandled = false;
+        if (doc?.activeElement && this.guideModalEl.contains?.(doc.activeElement)) {
+          if (restore) {
+            restore.focus({ preventScroll: true });
+          } else {
+            this.focusGameViewport();
+          }
+          focusHandled = true;
+        }
         this.guideModalEl.hidden = true;
         setInertState(this.guideModalEl, true);
         this.guideModalEl.setAttribute('aria-hidden', 'true');
-        const restore = options?.returnFocus === false ? null : this.lastGuideTrigger || this.openGuideButton;
-        if (restore && typeof restore.focus === 'function') {
-          restore.focus({ preventScroll: true });
-        } else {
-          this.focusGameViewport();
+        if (!focusHandled) {
+          if (restore) {
+            restore.focus({ preventScroll: true });
+          } else {
+            this.focusGameViewport();
+          }
         }
       }
       this.guideModalVisible = nextVisible;


### PR DESCRIPTION
## Summary
- move focus away from the guide modal before toggling it hidden so aria-hidden is never applied while a child is focused

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfb5d29e98832b95a66c58cc6fae50