### PR TITLE
Document mandatory post-deploy CDN purge

### DIFF
--- a/docs/cdn-permissions-runbook.md
+++ b/docs/cdn-permissions-runbook.md
@@ -110,7 +110,7 @@ When every request to `d3gj6x3ityfh5o.cloudfront.net/*.js` (or other static asse
 ## 6. Redeploy and invalidate
 
 1. After updating policies, wait for CloudFront to propagate the changes (or trigger a distribution update).
-2. Invalidate cached errors:
+2. Invalidate cached errors and always purge the distribution after each deploy so the latest bundles, textures, and GLTFs reach players immediately:
    ```bash
    aws cloudfront create-invalidation --distribution-id E1234567890 --paths "/*"
    ```

--- a/docs/portals-of-dimension-plan.md
+++ b/docs/portals-of-dimension-plan.md
@@ -125,6 +125,7 @@ This document unifies the design brief (“Comprehensive Analysis and Enhancemen
 1. Enhance `.github/workflows/deploy.yml` to validate that textures/GLTF assets exist before syncing.
 2. Add a post-deploy health check that pings the live site, measures frame time via automated browser tooling, and records results in the run summary.
 3. Document troubleshooting steps for missing AWS secrets and CDN cache invalidation failures.
+4. Purge the CloudFront cache after every deploy so new models, textures, and scripts propagate immediately instead of lingering behind stale CDN entries.
 
 ---
 


### PR DESCRIPTION
## Summary
- note in the deployment plan that every release must flush the CloudFront cache so models, textures, and scripts update instantly
- expand the CDN permissions runbook instructions to treat post-deploy invalidations as a standing requirement, not just an error-recovery step

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dfc49ad52c832b8d3f46f21a71dd0b