### PR TITLE
Add ES module defaults for runtime bundles

### DIFF
--- a/asset-resolver.js
+++ b/asset-resolver.js
@@ -161,5 +161,21 @@
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = resolver;
+    if (typeof Object.defineProperty === 'function') {
+      Object.defineProperty(module.exports, 'default', {
+        value: resolver,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(module.exports, '__esModule', {
+        value: true,
+        enumerable: false,
+        configurable: true,
+      });
+    } else {
+      module.exports.default = resolver;
+      module.exports.__esModule = true;
+    }
   }
 })();

--- a/audio-aliases.js
+++ b/audio-aliases.js
@@ -24,5 +24,21 @@
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = aliasConfig;
+    if (typeof Object.defineProperty === 'function') {
+      Object.defineProperty(module.exports, 'default', {
+        value: aliasConfig,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(module.exports, '__esModule', {
+        value: true,
+        enumerable: false,
+        configurable: true,
+      });
+    } else {
+      module.exports.default = aliasConfig;
+      module.exports.__esModule = true;
+    }
   }
 })();

--- a/audio-captions.js
+++ b/audio-captions.js
@@ -27,5 +27,21 @@
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = captions;
+    if (typeof Object.defineProperty === 'function') {
+      Object.defineProperty(module.exports, 'default', {
+        value: captions,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(module.exports, '__esModule', {
+        value: true,
+        enumerable: false,
+        configurable: true,
+      });
+    } else {
+      module.exports.default = captions;
+      module.exports.__esModule = true;
+    }
   }
 })();

--- a/combat-utils.js
+++ b/combat-utils.js
@@ -1,6 +1,23 @@
 (function (globalScope, factory) {
   if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory();
+    const exported = factory();
+    module.exports = exported;
+    if (typeof Object.defineProperty === 'function') {
+      Object.defineProperty(module.exports, 'default', {
+        value: exported,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(module.exports, '__esModule', {
+        value: true,
+        enumerable: false,
+        configurable: true,
+      });
+    } else {
+      module.exports.default = exported;
+      module.exports.__esModule = true;
+    }
   } else {
     const target = globalScope || (typeof globalThis !== 'undefined' ? globalThis : {});
     target.CombatUtils = factory();

--- a/crafting.js
+++ b/crafting.js
@@ -369,3 +369,19 @@ module.exports = {
   validateCraftAttempt,
   searchRecipes,
 };
+if (typeof Object.defineProperty === 'function') {
+  Object.defineProperty(module.exports, 'default', {
+    value: module.exports,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(module.exports, '__esModule', {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+} else {
+  module.exports.default = module.exports;
+  module.exports.__esModule = true;
+}

--- a/portal-mechanics.js
+++ b/portal-mechanics.js
@@ -301,6 +301,22 @@ const api = {
 
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports = api;
+  if (typeof Object.defineProperty === 'function') {
+    Object.defineProperty(module.exports, 'default', {
+      value: api,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(module.exports, '__esModule', {
+      value: true,
+      enumerable: false,
+      configurable: true,
+    });
+  } else {
+    module.exports.default = api;
+    module.exports.__esModule = true;
+  }
 }
 
 const globalScope =

--- a/scoreboard-utils.js
+++ b/scoreboard-utils.js
@@ -1,6 +1,23 @@
 (function (globalFactory) {
   if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = globalFactory();
+    const exported = globalFactory();
+    module.exports = exported;
+    if (typeof Object.defineProperty === 'function') {
+      Object.defineProperty(module.exports, 'default', {
+        value: exported,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(module.exports, '__esModule', {
+        value: true,
+        enumerable: false,
+        configurable: true,
+      });
+    } else {
+      module.exports.default = exported;
+      module.exports.__esModule = true;
+    }
   } else {
     const globalScope = typeof window !== 'undefined' ? window : globalThis;
     globalScope.ScoreboardUtils = globalFactory();

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -20106,6 +20106,30 @@
   };
 
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports.SimpleExperience = window.SimpleExperience;
+    const exported = window.SimpleExperience;
+    module.exports = exported;
+    if (typeof Object.defineProperty === 'function') {
+      Object.defineProperty(module.exports, 'default', {
+        value: exported,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(module.exports, '__esModule', {
+        value: true,
+        enumerable: false,
+        configurable: true,
+      });
+      Object.defineProperty(module.exports, 'SimpleExperience', {
+        value: exported,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      module.exports.default = exported;
+      module.exports.__esModule = true;
+      module.exports.SimpleExperience = exported;
+    }
   }
 })();


### PR DESCRIPTION
## Summary
- expose default exports and __esModule flags on asset helpers so bundlers resolve the same folder layout referenced in the app
- update global utilities (combat, crafting, portal mechanics, scoreboard, simple experience) to provide default exports while keeping existing globals intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfc748bb54832bbdd047808c2712da