### PR TITLE
chore: run tests before publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Two automated suites ship with the repository:
 
 1. `npm test` runs the Vitest unit suite that exercises the pure utility modules (scoreboard helpers, portal mechanics, and combat maths).
 2. `npm run test:e2e` launches the Playwright smoke test that boots the sandbox, validates HUD panels, and confirms there are no console regressions.
+3. `npm run test:pre-release` executes both suites sequentially and is wired into the release hooks so `npm version`/`npm publish` fail fast if either suite regresses.
 
 Playwright downloads its browser binaries on demand. If the end-to-end check fails with a message similar to “Executable doesn't exist … run `npx playwright install`”, execute that command once and rerun the test. When the host machine is missing system-level browser dependencies (common inside constrained CI sandboxes), the script now reports the missing packages and exits gracefully so the rest of the toolchain can continue. The download step is skipped automatically in CI because the workflow caches the Playwright bundle.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "test:e2e": "node tests/e2e-check.js",
     "check:manifest": "node scripts/check-manifest.js",
     "check:assets": "node scripts/validate-asset-manifest.js",
-    "build:vendor:three": "node scripts/build-three.js"
+    "build:vendor:three": "node scripts/build-three.js",
+    "test:unit": "vitest run",
+    "test:pre-release": "node scripts/run-pre-release-checks.js",
+    "prepublishOnly": "npm run test:pre-release",
+    "preversion": "npm run test:pre-release"
   },
   "keywords": [],
   "author": "",

--- a/scripts/run-pre-release-checks.js
+++ b/scripts/run-pre-release-checks.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Runs the automated test suites required before publishing a release.
+ * This ensures the Vitest unit tests and Playwright smoke tests both pass
+ * before `npm publish` or an explicit pre-release check.
+ */
+const { spawnSync } = require('node:child_process');
+
+const checks = [
+  {
+    label: 'Vitest unit suite',
+    command: 'npm',
+    args: ['run', 'test'],
+  },
+  {
+    label: 'Playwright E2E suite',
+    command: 'npm',
+    args: ['run', 'test:e2e'],
+  },
+];
+
+for (const { label, command, args } of checks) {
+  console.log(`\n[pre-release] Running ${label}...`);
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.status !== 0) {
+    console.error(`\n[pre-release] ${label} failed. Aborting.`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+console.log('\n[pre-release] All required test suites passed.');


### PR DESCRIPTION
## Summary
- add a pre-release runner that executes the Vitest unit suite and Playwright smoke test
- wire the aggregated check into dedicated npm scripts and the publish/version hooks
- document the combined pre-release command alongside the existing local testing instructions

## Testing
- npm run test:pre-release

------
https://chatgpt.com/codex/tasks/task_e_68dfd44b3038832bb14dc4c3df220496