### PR TITLE
Fix asset recovery control binding order

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -2142,7 +2142,6 @@
       this.aiAttachmentFailureAnnounced = false;
       this.boundEventDisposers = [];
       this.boundEventRecords = [];
-      this.bindAssetRecoveryControls();
       this.onOpenCraftingSearchClick = () => this.toggleCraftingSearch(true);
       this.onCloseCraftingSearchClick = () => this.toggleCraftingSearch(false);
       this.lastHintMessage = '';
@@ -2324,6 +2323,7 @@
         }
         this.handleAssetRecoveryReload();
       };
+      this.bindAssetRecoveryControls();
       this.materials = this.createMaterials();
       this.defaultKeyBindings = cloneKeyBindingMap(DEFAULT_KEY_BINDINGS);
       this.configKeyBindingOverrides = normaliseKeyBindingMap(window.APP_CONFIG?.keyBindings) || null;


### PR DESCRIPTION
## Summary
- ensure the asset recovery control event handlers are registered before binding listeners

## Testing
- npm test -- simple-experience-event-binding.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dfe649d684832ba866b0fa5fd82736