### PR TITLE
Improve blank frame detection heuristics for simple renderer

### DIFF
--- a/tests/simple-experience-render-loop.test.js
+++ b/tests/simple-experience-render-loop.test.js
@@ -134,4 +134,86 @@ describe('simple experience render loop resilience', () => {
     expect(experience.rendererUnavailable).toBe(true);
     expect(experience.scheduleNextFrame).not.toHaveBeenCalled();
   });
+
+  describe('blank frame detection resilience', () => {
+    const SAMPLE_RATIOS = [
+      [0.5, 0.5],
+      [0.25, 0.25],
+      [0.75, 0.25],
+      [0.25, 0.75],
+      [0.75, 0.75],
+    ];
+
+    function setupBlankDetection({ overrides = new Map() } = {}) {
+      const experience = createExperience();
+      const canvasWidth = 800;
+      const canvasHeight = 600;
+      const clearColor = { r: 0.25, g: 0.35, b: 0.45 };
+      const defaultPixel = {
+        r: Math.round(clearColor.r * 255),
+        g: Math.round(clearColor.g * 255),
+        b: Math.round(clearColor.b * 255),
+      };
+      const gl = {
+        RGBA: 0x1908,
+        UNSIGNED_BYTE: 0x1401,
+        readPixels: vi.fn((x, y, width, height, format, type, buffer) => {
+          const key = `${x},${y}`;
+          const override = overrides.get(key);
+          const pixel = override || defaultPixel;
+          buffer[0] = pixel.r;
+          buffer[1] = pixel.g;
+          buffer[2] = pixel.b;
+          buffer[3] = 255;
+        }),
+      };
+      experience.renderer = {
+        domElement: { width: canvasWidth, height: canvasHeight },
+        getContext: () => gl,
+        getClearColor: () => clearColor,
+      };
+      experience.presentRendererFailure = vi.fn();
+      experience.emitGameEvent = vi.fn();
+      experience.renderedFrameCount = 20;
+      experience.blankFrameDetectionState = {
+        enabled: true,
+        samples: 0,
+        clearFrameMatches: 0,
+        triggered: false,
+      };
+      const sampleKeys = SAMPLE_RATIOS.map(([rx, ry]) => {
+        const x = Math.max(0, Math.min(canvasWidth - 1, Math.round(canvasWidth * rx)));
+        const y = Math.max(0, Math.min(canvasHeight - 1, Math.round(canvasHeight * ry)));
+        return `${x},${y}`;
+      });
+      return { experience, gl, sampleKeys };
+    }
+
+    it('does not flag blank frames when some samples differ from the clear colour', () => {
+      const overrides = new Map();
+      const { experience, sampleKeys } = setupBlankDetection({ overrides });
+      overrides.set(sampleKeys[1], { r: 0, g: 0, b: 0 });
+
+      for (let i = 0; i < 6; i += 1) {
+        experience.evaluateRendererVisibility();
+      }
+
+      expect(experience.blankFrameDetectionState.triggered).toBe(false);
+      expect(experience.presentRendererFailure).not.toHaveBeenCalled();
+    });
+
+    it('flags blank frames only after consistent matches across all samples', () => {
+      const { experience } = setupBlankDetection();
+
+      for (let i = 0; i < 3; i += 1) {
+        experience.evaluateRendererVisibility();
+      }
+
+      expect(experience.blankFrameDetectionState.triggered).toBe(true);
+      expect(experience.presentRendererFailure).toHaveBeenCalledWith(
+        expect.stringContaining('WebGL output appears blocked'),
+        expect.objectContaining({ stage: 'blank-frame' }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- sample multiple points when checking for blank frames so the renderer only falls back when every probe stays clear
- add regression tests to cover the revised blank-frame detection workflow in the simple experience

## Testing
- npm test -- simple-experience-render-loop.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e003355c94832b858d51692ad6d78b