### PR TITLE
Ensure WebGL fallback sets renderer mode indicator

### DIFF
--- a/script.js
+++ b/script.js
@@ -5515,9 +5515,25 @@
     return Object.keys(detail).length ? detail : null;
   }
 
+  function ensureRendererFallbackIndicator() {
+    try {
+      if (typeof setRendererModeIndicator === 'function') {
+        setRendererModeIndicator('simple');
+      } else if (globalScope) {
+        globalScope.__INFINITE_RAILS_RENDERER_MODE__ = 'simple';
+        if (globalScope.InfiniteRails && typeof globalScope.InfiniteRails === 'object') {
+          globalScope.InfiniteRails.rendererMode = 'simple';
+        }
+      }
+    } catch (error) {
+      globalScope?.console?.debug?.('Failed to update renderer indicator for WebGL fallback.', error);
+    }
+  }
+
   function updateRendererStateForWebglFallback() {
     const state = globalScope?.__INFINITE_RAILS_STATE__;
     if (!state || typeof state !== 'object') {
+      ensureRendererFallbackIndicator();
       return;
     }
     try {
@@ -5527,6 +5543,7 @@
     } catch (error) {
       globalScope?.console?.debug?.('Failed to update renderer state for WebGL fallback.', error);
     }
+    ensureRendererFallbackIndicator();
   }
 
   function applyWebglFallbackConfig(config, probeError) {

--- a/tests/renderer-mode-selection.test.js
+++ b/tests/renderer-mode-selection.test.js
@@ -378,6 +378,7 @@ describe('renderer mode selection', () => {
           'WebGL is unavailable on this device, so the mission briefing view is shown instead of the full 3D renderer.',
       },
     ]);
+    expect(windowStub.__INFINITE_RAILS_RENDERER_MODE__).toBe('simple');
     expect(showError).toHaveBeenCalledTimes(1);
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -485,6 +486,7 @@ describe('renderer mode selection', () => {
           'WebGL is unavailable on this device, so the mission briefing view is shown instead of the full 3D renderer.',
       },
     ]);
+    expect(windowStub.__INFINITE_RAILS_RENDERER_MODE__).toBe('simple');
     expect(showError).toHaveBeenCalledTimes(1);
     expect(setDiagnostic).toHaveBeenCalledWith('renderer', {
       status: 'warning',


### PR DESCRIPTION
## Summary
- ensure the WebGL bootstrap fallback sets the global renderer mode indicator to simple
- extend renderer mode selection tests to cover the new indicator behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e00b462e00832b94c4b9b3c76978c2