### PR TITLE
Add automatic simple fallback when renderer start errors occur

### DIFF
--- a/tests/renderer-mode-selection.test.js
+++ b/tests/renderer-mode-selection.test.js
@@ -731,5 +731,10 @@ describe('renderer mode selection', () => {
       expect(tryStartSimpleFallback(new Error('missing'), { reason: 'no-simple' })).toBe(false);
       expect(getAttempted()).toBe(false);
     });
+
+    it('invokes the fallback bootstrap when a start-error event is emitted', () => {
+      const pattern = /addEventListener\('infinite-rails:start-error'[\s\S]*?tryStartSimpleFallback\(/;
+      expect(pattern.test(scriptSource)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a helper to resolve the active renderer mode when preparing fallbacks
- trigger the simple renderer bootstrap when start-error events are emitted by the advanced renderer
- add a regression test that asserts the start-error handler invokes the fallback bootstrap

## Testing
- npm test -- renderer

------
https://chatgpt.com/codex/tasks/task_e_68e00fdeaabc832baf43adfcecb437e1