### PR TITLE
Ensure renderer falls back to simple mode on initialisation failure

### DIFF
--- a/script.js
+++ b/script.js
@@ -2623,6 +2623,29 @@
         detail,
         timestamp: Number.isFinite(detail?.timestamp) ? detail.timestamp : undefined,
       });
+      const activeMode = resolveRendererModeForFallback(detail);
+      if (activeMode !== 'simple') {
+        const fallbackContext = { reason: 'initialisation-error', mode: activeMode || 'unknown' };
+        if (stage) {
+          fallbackContext.stage = stage;
+        }
+        let fallbackError = null;
+        if (detail?.error instanceof Error) {
+          fallbackError = detail.error;
+        } else {
+          const fallbackMessage =
+            reportedErrorMessage ||
+            (typeof detail?.message === 'string' && detail.message.trim().length ? detail.message.trim() : null) ||
+            diagnosticMessage;
+          if (fallbackMessage) {
+            fallbackError = new Error(fallbackMessage);
+            if (errorName) {
+              fallbackError.name = errorName;
+            }
+          }
+        }
+        tryStartSimpleFallback(fallbackError, fallbackContext);
+      }
     });
     globalScope.addEventListener('infinite-rails:score-sync-offline', (event) => {
       const detail = event?.detail && typeof event.detail === 'object' ? event.detail : {};

--- a/tests/renderer-mode-selection.test.js
+++ b/tests/renderer-mode-selection.test.js
@@ -736,5 +736,10 @@ describe('renderer mode selection', () => {
       const pattern = /addEventListener\('infinite-rails:start-error'[\s\S]*?tryStartSimpleFallback\(/;
       expect(pattern.test(scriptSource)).toBe(true);
     });
+
+    it('invokes the fallback bootstrap when an initialisation-error event is emitted', () => {
+      const pattern = /addEventListener\('infinite-rails:initialisation-error'[\s\S]*?tryStartSimpleFallback\(/;
+      expect(pattern.test(scriptSource)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add automatic simple-mode fallback when `infinite-rails:initialisation-error` fires so advanced failures navigate to the sandbox experience
- build a regression test that ensures the fallback bootstrap is wired to the new event

## Testing
- npm test -- renderer-mode-selection

------
https://chatgpt.com/codex/tasks/task_e_68e012448fc0832bbe254bb0592478aa