### PR TITLE
Add fallback trigger when error boundaries fire in advanced mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -1500,6 +1500,29 @@
       detail,
       timestamp: options.timestamp,
     });
+    if (typeof tryStartSimpleFallback === 'function') {
+      try {
+        const activeMode =
+          typeof resolveRendererModeForFallback === 'function' ? resolveRendererModeForFallback(detail) : null;
+        if (activeMode !== 'simple') {
+          const fallbackReason =
+            typeof detail?.reason === 'string' && detail.reason.trim().length
+              ? detail.reason.trim()
+              : boundaryKey;
+          const fallbackContext = {
+            reason: fallbackReason,
+            boundary: boundaryKey,
+            stage,
+            mode: activeMode || 'unknown',
+            source: 'error-boundary',
+          };
+          const fallbackError = error instanceof Error ? error : new Error(normalised.message);
+          tryStartSimpleFallback(fallbackError, fallbackContext);
+        }
+      } catch (fallbackError) {
+        globalScope?.console?.debug?.('Failed to trigger simple renderer fallback after boundary error.', fallbackError);
+      }
+    }
     markErrorAsHandled(error);
   }
 


### PR DESCRIPTION
## Summary
- trigger the simple renderer fallback from the global error boundary when the advanced renderer fails
- add renderer-mode-selection tests that exercise the new error-boundary fallback behaviour

## Testing
- npm test renderer-mode-selection.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e014d96154832bbc9778b17b4ad7fa