### PR TITLE
Allow CloudFront OAI read access to assets and textures

### DIFF
--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -60,15 +60,8 @@ Resources:
             Action:
               - s3:GetObject
             Resource:
-              - !Sub "${AssetsBucket.Arn}/assets/*.gltf"
-              - !Sub "${AssetsBucket.Arn}/assets/*.glb"
-              - !Sub "${AssetsBucket.Arn}/assets/*.bin"
-              - !Sub "${AssetsBucket.Arn}/assets/*.png"
-              - !Sub "${AssetsBucket.Arn}/assets/*.jpg"
-              - !Sub "${AssetsBucket.Arn}/assets/*.jpeg"
-              - !Sub "${AssetsBucket.Arn}/assets/*.ktx2"
-              - !Sub "${AssetsBucket.Arn}/assets/*.webp"
-              - !Sub "${AssetsBucket.Arn}/assets/*.basis"
+              - !Sub "${AssetsBucket.Arn}/assets/*"
+              - !Sub "${AssetsBucket.Arn}/textures/*"
 
   AssetsDistribution:
     Type: AWS::CloudFront::Distribution


### PR DESCRIPTION
## Summary
- update the assets bucket policy to permit the CloudFront origin access identity to read any files under the assets and textures prefixes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01f649620832b90f6df749148d518