### PR TITLE
Ensure CloudFront cache invalidation runs after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -403,13 +403,12 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Invalidate CloudFront cache
-        if: steps.ensure_distribution.outputs['distribution-id'] != ''
         env:
-          DISTRIBUTION_ID: ${{ steps.ensure_distribution.outputs.distribution-id }}
+          DISTRIBUTION_ID: ${{ steps.ensure_distribution.outputs.distribution-id || secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID || '' }}
         run: |
           set -euo pipefail
           if [ -z "${DISTRIBUTION_ID}" ]; then
-            echo '::error::CloudFront distribution ID is empty. Check the discovery step output.'
+            echo '::error::CloudFront distribution ID is empty. Set AWS_CLOUDFRONT_DISTRIBUTION_ID or ensure the discovery step locates the distribution before retrying.'
             exit 1
           fi
           MAX_ATTEMPTS=5


### PR DESCRIPTION
## Summary
- ensure the deploy workflow always flushes CloudFront caches by sourcing the distribution ID from the discovery step or repository secret
- improve the failure message when no distribution is available so maintainers know to configure AWS_CLOUDFRONT_DISTRIBUTION_ID or attach the bucket

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e023f12df0832ba2f39d277a4bb480