### PR TITLE
Validate Steve GLTF load before activating avatar rig

### DIFF
--- a/tests/simple-experience-steve-loader.test.js
+++ b/tests/simple-experience-steve-loader.test.js
@@ -106,6 +106,19 @@ describe('simple experience steve model loading', () => {
     experience.cloneModelScene = vi.fn().mockResolvedValue({
       scene: invalidModel,
       animations: [new THREE.AnimationClip('Jump', -1, [])],
+      metadata: {
+        avatarRig: {
+          valid: true,
+          errors: [],
+          hierarchy: {},
+          meshAssignments: {},
+          meshExpectations: {},
+          meshNameByIndex: {},
+          missingNodes: [],
+          hierarchyIssues: [],
+          meshMismatches: [],
+        },
+      },
     });
 
     try {
@@ -154,10 +167,24 @@ describe('simple experience steve model loading', () => {
 
     const idleClip = new THREE.AnimationClip('Idle', -1, []);
     const walkClip = new THREE.AnimationClip('WalkForward', -1, []);
+    const rigMetadata = {
+      avatarRig: {
+        valid: true,
+        errors: [],
+        hierarchy: {},
+        meshAssignments: {},
+        meshExpectations: {},
+        meshNameByIndex: {},
+        missingNodes: [],
+        hierarchyIssues: [],
+        meshMismatches: [],
+      },
+    };
 
     experience.cloneModelScene = vi.fn().mockResolvedValue({
       scene: model,
       animations: [idleClip, walkClip],
+      metadata: rigMetadata,
     });
 
     try {


### PR DESCRIPTION
## Summary
- ensure the Steve avatar loader validates rig metadata, logs GLTF success, and enforces placeholder fallback when metadata is missing
- track the resolved rig metadata on the experience so later systems can inspect it
- update the Steve loader unit tests with rig metadata fixtures to satisfy the stricter validation

## Testing
- npm test -- tests/simple-experience-steve-loader.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e08b504e98832bbffad1895b660a71