### PR TITLE
Ensure idle animations start on avatar spawn

### DIFF
--- a/tests/simple-experience-steve-loader.test.js
+++ b/tests/simple-experience-steve-loader.test.js
@@ -130,8 +130,14 @@ describe('simple experience steve model loading', () => {
       expect(experience.playerAvatar).toBeTruthy();
       expect(experience.playerAvatar.userData?.placeholder).toBe(true);
       expect(experience.playerAvatar.userData?.placeholderSource).toBe('missing-animations');
-      expect(experience.playerAnimationRig).toBeNull();
-      expect(experience.playerMixer).toBeNull();
+      expect(experience.playerAnimationRig).toBeTruthy();
+      expect(experience.playerAnimationRig.state).toBe('idle');
+      expect(experience.playerAnimationRig.baseState).toBe('idle');
+      expect(experience.playerAnimationRig.actions?.idle).toBeTruthy();
+      expect(experience.playerAnimationRig.actions?.walk).toBeTruthy();
+      expect(experience.playerAnimationRig.actions.idle.isRunning()).toBe(true);
+      expect(experience.playerAnimationRig.actions.walk.isRunning()).toBe(true);
+      expect(experience.playerMixer).toBeTruthy();
     } finally {
       errorSpy.mockRestore();
       warnSpy.mockRestore();


### PR DESCRIPTION
## Summary
- add a helper to configure the player animation rig so idle/walk clips always start when a model is attached
- initialise the placeholder avatar with an idle mixer and reuse it when animation data is missing
- update the player loader tests to assert the placeholder rig remains animated when clips are unavailable

## Testing
- npm test -- tests/simple-experience-steve-loader.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e08c872d4c832bbbaa73bc6e7e3a78