### PR TITLE
Improve audio boot diagnostics and fallbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1514,6 +1514,10 @@
                 <span class="diagnostic-list__label">Assets</span>
                 <span class="diagnostic-list__status" id="globalOverlayAssetsStatus">Streaming core assets…</span>
               </li>
+              <li class="diagnostic-list__item" data-diagnostic="audio" data-status="pending">
+                <span class="diagnostic-list__label">Audio</span>
+                <span class="diagnostic-list__status" id="globalOverlayAudioStatus">Initialising audio engine…</span>
+              </li>
               <li class="diagnostic-list__item" data-diagnostic="backend" data-status="pending">
                 <span class="diagnostic-list__label">Backend</span>
                 <span class="diagnostic-list__status" id="globalOverlayBackendStatus">Checking leaderboard service…</span>


### PR DESCRIPTION
## Summary
- add an audio diagnostic row to the bootstrap overlay and surface audio boot status events in the UI
- enhance the audio controller to normalise sample names, guarantee fallback availability, and dispatch boot status diagnostics
- expand the audio test suite to cover boot status events and fallback behaviour

## Testing
- npm test -- simple-experience-audio.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e0bbeb3de4832b9ea150e5c6f4eb4c