### PR TITLE
Validate crafting inputs before enabling actions

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -20227,7 +20227,7 @@
 
     handleCraftButton() {
       const craftedSequence = this.craftingState.sequence.slice();
-      const validation = this.validateCraftingSequence();
+      const validation = this.updateCraftButtonState(this.validateCraftingSequence());
       if (!validation.valid) {
         this.showHint(validation.message || 'Sequence unstable.');
         this.announceCraftingValidation(validation);
@@ -20510,16 +20510,29 @@
       this.craftSuggestionsEl.appendChild(fragment);
     }
 
-    updateCraftButtonState() {
-      if (!this.craftButton) return;
-      const validation = this.validateCraftingSequence();
+    updateCraftButtonState(presetValidation = null) {
+      if (!this.craftButton) return presetValidation;
+      const validation = presetValidation || this.validateCraftingSequence();
+      this.craftingState.lastValidation = validation;
       const enabled = validation.valid === true;
       this.craftButton.disabled = !enabled;
+      this.craftButton.dataset.eligible = enabled ? 'true' : 'false';
       if (validation.reason) {
         this.craftButton.dataset.validationState = enabled ? 'ready' : validation.reason;
       } else {
         delete this.craftButton.dataset.validationState;
       }
+      const hintMessage = enabled
+        ? validation.recipe
+          ? `Ready to craft ${validation.recipe.label}.`
+          : 'Ready to craft.'
+        : validation.message || 'Sequence unstable.';
+      if (hintMessage) {
+        this.craftButton.setAttribute('data-hint', hintMessage);
+      } else {
+        this.craftButton.removeAttribute('data-hint');
+      }
+      return validation;
     }
 
     buildIngredientCount(parts = []) {

--- a/styles.css
+++ b/styles.css
@@ -4703,6 +4703,25 @@ body.sidebar-open .player-hint {
   opacity: 0.55;
 }
 
+.crafting-actions .primary[disabled],
+.crafting-actions .primary[aria-disabled='true'] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.crafting-suggestions__item[aria-disabled='true'],
+.crafting-search__result[aria-disabled='true'],
+.crafting-suggestions li[data-status='missing'] > .crafting-suggestions__item,
+.crafting-suggestions li[data-status='locked'] > .crafting-suggestions__item,
+.crafting-suggestions li[data-status='unavailable'] > .crafting-suggestions__item,
+.crafting-search-panel__results li[data-status='missing'] > .crafting-search__result,
+.crafting-search-panel__results li[data-status='locked'] > .crafting-search__result,
+.crafting-search-panel__results li[data-status='unavailable'] > .crafting-search__result {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+
 .visual-warning {
   display: block;
   font-size: 0.65rem;


### PR DESCRIPTION
## Summary
- revalidate crafting sequences on submit while caching the latest validation result for UI feedback
- flag the craft button with validation metadata and hints so invalid recipes stay disabled
- grey out disabled craft actions and suggestions to show when recipes cannot be crafted

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e0cdf4e15c832baf8e7fb794610c6a