### PR TITLE
Add error overlays to zombie and golem fallback models

### DIFF
--- a/tests/simple-experience-loader-fallback.test.js
+++ b/tests/simple-experience-loader-fallback.test.js
@@ -57,5 +57,33 @@ describe('simple experience model loader fallback', () => {
     );
     expect(experience.footerEl.dataset.state).toBe('warning');
   });
+
+  it('adds an error overlay when zombie fallbacks are created after a failure', () => {
+    const { experience } = createExperience();
+    const fallback = experience.createModelFallbackMesh('zombie', { reason: 'failed' });
+    expect(fallback).toBeTruthy();
+    const overlay = fallback.children.find((child) => child?.name === 'ZombieErrorOverlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay.userData).toMatchObject({
+      placeholder: true,
+      placeholderOverlay: true,
+      placeholderKey: 'zombie',
+      placeholderReason: 'failed',
+    });
+  });
+
+  it('adds an error overlay when golem fallbacks are created after a failure', () => {
+    const { experience } = createExperience();
+    const fallback = experience.createModelFallbackMesh('golem', { reason: 'loader-unavailable' });
+    expect(fallback).toBeTruthy();
+    const overlay = fallback.children.find((child) => child?.name === 'GolemErrorOverlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay.userData).toMatchObject({
+      placeholder: true,
+      placeholderOverlay: true,
+      placeholderKey: 'golem',
+      placeholderReason: 'loader-unavailable',
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- add a reusable model fallback error overlay so failed zombie and golem models show a visible warning
- mark sprite-based overlays for cleanup in the dispose helper
- extend loader fallback tests to ensure zombie and golem placeholders receive error overlays

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0d2f10de0832bb12c8ed40c0c3fb8