### PR TITLE
Ensure navmesh rebuilds on world reload and warn on AI movement failure

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -149,6 +149,7 @@
   }
 
   const WORLD_SIZE = 64;
+  const NAVMESH_RELOAD_REASONS = new Set(['world-load', 'world-reload']);
   const DEFAULT_PROCEDURAL_VOXEL_PALETTE = {
     base: '#6fbf73',
     highlight: '#e5f7ff',
@@ -11863,8 +11864,8 @@
       const navmeshReason =
         navmeshReasonRaw.length > 0
           ? navmeshReasonRaw
-          : buildReason === 'world-load'
-            ? 'world-load'
+          : NAVMESH_RELOAD_REASONS.has(buildReason)
+            ? buildReason
             : `${buildReason}-navmesh`;
       this.ensureWorldRootGroups();
       const resetTerrainState = () => {

--- a/tests/simple-experience-entities.test.js
+++ b/tests/simple-experience-entities.test.js
@@ -561,6 +561,29 @@ describe('simple experience entity lifecycle', () => {
     }
   });
 
+  it('warns when AI movement cannot resolve a navigation chunk', () => {
+    const { experience } = createExperienceForTest();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      experience.ensureNavigationMeshForActorPosition('zombie', Number.NaN, 0, {
+        stage: 'unit-test',
+        throttleMs: 0,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'AI movement failure detected. Verify navigation mesh rebuild scheduling and terrain coverage.',
+        expect.objectContaining({
+          actorType: 'zombie',
+          stage: 'unit-test',
+          reason: 'position-invalid',
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('spawns golems with fallback materials when MeshStandardMaterial is unavailable', async () => {
     const { experience } = createExperienceForTest();
 

--- a/tests/simple-experience-terrain.test.js
+++ b/tests/simple-experience-terrain.test.js
@@ -624,4 +624,35 @@ describe('simple experience terrain generation', () => {
       vi.useRealTimers();
     }
   });
+
+  it('rebuilds navigation meshes whenever the world reloads', () => {
+    const canvas = {
+      width: 512,
+      height: 512,
+      clientWidth: 512,
+      clientHeight: 512,
+      getContext: () => null,
+    };
+
+    const experience = window.SimpleExperience.create({ canvas, ui: {} });
+    experience.scene = new THREE.Scene();
+    experience.terrainGroup = new THREE.Group();
+    experience.terrainChunkGroups = [];
+    experience.terrainChunkMap = new Map();
+    experience.dirtyTerrainChunks = new Set();
+
+    experience.buildTerrain();
+
+    const initialBuildCount = experience.navigationMeshBuildCounter;
+    const initialGeneration = experience.navigationMeshGeneration;
+
+    experience.buildTerrain({ reason: 'world-reload' });
+
+    expect(experience.navigationMeshSummary).toBeTruthy();
+    expect(experience.navigationMeshBuildCounter).toBeGreaterThan(initialBuildCount);
+    expect(experience.navigationMeshGeneration).toBeGreaterThan(initialGeneration);
+    expect(experience.navigationMeshSummary.reason).toBe('world-reload');
+    expect(experience.navigationMeshSummary.chunkCount).toBeGreaterThan(0);
+    expect(experience.navigationMeshSummary.walkableCells).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure world reloads use the same navmesh boot reason so chunk meshes rebuild immediately after terrain refreshes
- add a regression test that exercises buildTerrain on a world reload and verifies the navmesh summary updates
- add an entity test that asserts a console warning fires when AI movement cannot determine a navigation chunk

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0e5daffd4832b82e7fa1f00ec5cad