### PR TITLE
Improve HUD vitals markup and bindings

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1268,6 +1268,19 @@ body::after {
   align-items: center;
 }
 
+.hud-bubbles__value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(255, 255, 255, 0.82);
+  text-shadow: 0 0 12px rgba(var(--hud-bubble-color-rgb, 46, 199, 255), 0.45);
+}
+
+.hud-bubbles.is-low .hud-bubbles__value {
+  color: #ffbd5c;
+  text-shadow: 0 0 10px rgba(255, 189, 92, 0.45);
+}
+
 .bubble-indicator {
   width: 18px;
   height: 18px;


### PR DESCRIPTION
## Summary
- restructure the heart HUD markup to expose damage/heal states and max health metadata
- render an animated bubble stack with breath percentage tied to the live player status snapshot
- persist the last player vitals snapshot and refresh HUD bindings alongside updated bubble styling

## Testing
- npm test *(fails: tests/simple-experience-entities.test.js > simple experience entity lifecycle > steers golems using navigation meshes when model upgrades fail)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f14f16b0832b9af7ea4b2d5c0916