### PR TITLE
Fix modal accessibility to use inert for hidden overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,7 +570,7 @@
           class="victory-celebration"
           id="victoryCelebration"
           hidden
-          aria-hidden="true"
+          inert
           data-hint="Animated celebration with stats and share tools."
         >
           <div class="victory-celebration__backdrop" aria-hidden="true"></div>
@@ -617,8 +617,8 @@
         <div
           class="defeat-overlay"
           id="defeatOverlay"
-          aria-hidden="true"
           tabindex="-1"
+          inert
         >
           <div
             class="defeat-overlay__content"
@@ -639,7 +639,7 @@
           </div>
         </div>
       </section>
-      <aside class="side-panel" id="sidePanel" tabindex="-1" aria-hidden="true">
+      <aside class="side-panel" id="sidePanel" tabindex="-1" inert>
         <section class="player-panel" aria-label="Player profile">
           <header class="player-panel__header">
             <h2>Player Hub</h2>
@@ -1456,7 +1456,7 @@
           class="compose-overlay"
           id="leaderboardOverlay"
           hidden
-          aria-hidden="true"
+          inert
           data-mode="idle"
         >
           <div
@@ -1553,7 +1553,7 @@
       class="compose-overlay compose-overlay--global"
       id="assetRecoveryOverlay"
       hidden
-      aria-hidden="true"
+      inert
       data-mode="error"
     >
       <div
@@ -1582,7 +1582,7 @@
       class="compose-overlay compose-overlay--global"
       id="globalOverlay"
       hidden
-      aria-hidden="true"
+      inert
       data-mode="idle"
     >
       <div
@@ -1681,7 +1681,8 @@
 
           overlay.hidden = false;
           overlay.removeAttribute('hidden');
-          overlay.setAttribute('aria-hidden', 'false');
+          overlay.removeAttribute('aria-hidden');
+          overlay.removeAttribute('inert');
           overlay.setAttribute('data-mode', 'loading');
           overlay.setAttribute('data-fallback-active', 'true');
 
@@ -1768,9 +1769,10 @@
               }
             }
 
-            overlay.setAttribute('aria-hidden', 'true');
+            overlay.removeAttribute('aria-hidden');
             overlay.setAttribute('data-mode', 'idle');
             overlay.removeAttribute('data-fallback-active');
+            overlay.setAttribute('inert', '');
             overlay.setAttribute('hidden', '');
             overlay.hidden = true;
 

--- a/script.js
+++ b/script.js
@@ -734,12 +734,17 @@
   }
 
   function safelySetAriaHidden(element, hidden, options = {}) {
-    if (!element || typeof element.setAttribute !== 'function') {
+    if (!element) {
       return false;
     }
     const doc = element.ownerDocument || (typeof document !== 'undefined' ? document : null);
     if (!hidden) {
-      element.setAttribute('aria-hidden', 'false');
+      if (options.toggleInert) {
+        setInert(element, false);
+      }
+      if (typeof element.removeAttribute === 'function') {
+        element.removeAttribute('aria-hidden');
+      }
       return true;
     }
     const fallbackFocus = options.fallbackFocus || null;
@@ -747,7 +752,12 @@
     if (!cleared) {
       return false;
     }
-    element.setAttribute('aria-hidden', 'true');
+    if (options.toggleInert) {
+      setInert(element, true);
+    }
+    if (typeof element.removeAttribute === 'function') {
+      element.removeAttribute('aria-hidden');
+    }
     return true;
   }
 

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -635,12 +635,15 @@
   }
 
   function safelySetAriaHidden(element, hidden, options = {}) {
-    if (!element || typeof element.setAttribute !== 'function') {
+    if (!element) {
       return false;
     }
     const doc = element.ownerDocument || (typeof document !== 'undefined' ? document : null);
     if (!hidden) {
-      element.setAttribute('aria-hidden', 'false');
+      if (options.toggleInert) {
+        setInertState(element, false);
+      }
+      element.removeAttribute?.('aria-hidden');
       return true;
     }
     const fallbackFocus = options.fallbackFocus || null;
@@ -648,7 +651,10 @@
     if (!cleared) {
       return false;
     }
-    element.setAttribute('aria-hidden', 'true');
+    if (options.toggleInert) {
+      setInertState(element, true);
+    }
+    element.removeAttribute?.('aria-hidden');
     return true;
   }
 


### PR DESCRIPTION
## Summary
- remove aria-hidden from focusable overlays and add inert so they stay out of the accessibility tree when inactive
- update the bootstrap fallback overlay to toggle inert instead of aria-hidden when showing and hiding
- adjust the shared safelySetAriaHidden helper to stop setting aria-hidden and optionally coordinate inert toggling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0fa6b2d98832ba79afd31eca3b70f