### PR TITLE
Ensure backend validation failure forces local mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -7964,9 +7964,6 @@
                 );
               }
             }
-            if (!backendReady && identityState.apiBaseUrl) {
-              backendReady = true;
-            }
             experience.apiBaseUrl = backendReady ? identityState.apiBaseUrl : null;
             const result = experience.start();
             if (result && typeof result.then === 'function') {


### PR DESCRIPTION
## Summary
- remove the fallback that re-enabled the API after a failed backend live-check so gameplay starts in local mode when validation fails

## Testing
- npm test *(fails: tests/simple-experience-entities.test.js > simple experience entity lifecycle > steers golems using navigation meshes when model upgrades fail)*

------
https://chatgpt.com/codex/tasks/task_e_68e114ace6d4832b95a9c351548e8a0e