### PR TITLE
Add keyboard toggle and diagnostics to developer overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,6 +207,14 @@
               <dt>Audio</dt>
               <dd data-stat="audio">—</dd>
             </div>
+            <div class="developer-stats__metric">
+              <dt>Assets</dt>
+              <dd data-stat="assets">—</dd>
+            </div>
+            <div class="developer-stats__metric">
+              <dt>Scene</dt>
+              <dd data-stat="scene">—</dd>
+            </div>
           </dl>
         </div>
         <div class="game-briefing" id="gameBriefing" role="region" aria-live="polite" hidden>


### PR DESCRIPTION
## Summary
- extend the developer stats overlay with asset recovery and scene graph metrics
- expose the new metrics through the HUD bindings, API, and a keyboard toggle for the developer log overlay

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1182dccd0832b8b4e439322753b4c