### PR TITLE
Wait for start button readiness in E2E checks

### DIFF
--- a/tests/e2e-check.js
+++ b/tests/e2e-check.js
@@ -36,10 +36,27 @@ function findUnexpectedWarnings(warnings) {
 }
 
 async function maybeClickStart(page) {
-  const startButtonVisible = await page.isVisible('#startButton').catch(() => false);
-  if (startButtonVisible) {
-    await page.click('#startButton');
+  const startButton = page.locator('#startButton');
+  if ((await startButton.count()) === 0) {
+    return;
   }
+
+  const visible = await startButton.isVisible().catch(() => false);
+  if (!visible) {
+    return;
+  }
+
+  await page.waitForFunction(
+    () => {
+      const button = document.querySelector('#startButton');
+      if (!button) return false;
+      const stillPreloading = button.getAttribute('data-preloading') === 'true';
+      return !button.disabled && !stillPreloading;
+    },
+    { timeout: 30000 },
+  );
+
+  await startButton.click();
 }
 
 async function ensureGameHudReady(page, { requireNight = false } = {}) {


### PR DESCRIPTION
## Summary
- wait for the landing page start button to become enabled before attempting to click it in the e2e helper
- avoid repeated click retries on a disabled element during the advanced scenario

## Testing
- npm run test:e2e (skipped: Playwright browsers not installed in CI container)


------
https://chatgpt.com/codex/tasks/task_e_68e11f0329c8832bbdee44f73c0d8da2