### PR TITLE
Allow asset retry logs during e2e run

### DIFF
--- a/tests/e2e-check.js
+++ b/tests/e2e-check.js
@@ -12,6 +12,9 @@ const ALLOWED_WARNING_SUBSTRINGS = [
   'Multiple instances of Three.js being imported',
   'Failed to load script',
   'Asset load failure',
+  'Retrying explorer avatar asset',
+  'Retrying first-person hands asset',
+  'Retrying golem armour asset',
 ];
 
 function createConsoleCapture(page) {


### PR DESCRIPTION
## Summary
- allow the e2e console log filter to treat asset retry messages as expected warnings

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e12ee112b0832b9f3e42fd43ebc3bf