### PR TITLE
Improve HUD and tutorial responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,10 @@
   --hud-score-text: #f6fbe9;
   --hud-progress-track: rgba(116, 195, 101, 0.28);
   --hud-progress-glow: rgba(210, 255, 168, 0.55);
+  --hud-scale: 1;
+  --hud-spacing: clamp(0.75rem, 2vw, 1.1rem);
+  --hud-margin: clamp(1rem, 2.2vw, 1.5rem);
+  --hud-bottom-gap: clamp(0.6rem, 1.2vw, 0.9rem);
   font-size: 16px;
 }
 
@@ -1515,6 +1519,11 @@ body.game-active .main-layout {
   height: 100vh;
 }
 
+body.first-run-tutorial-active {
+  overflow: hidden;
+  touch-action: none;
+}
+
 body.game-active .primary-panel {
   border-radius: 0;
   box-shadow: none;
@@ -1763,6 +1772,15 @@ body.game-active #gameCanvas {
   border: 1px solid rgba(94, 181, 255, 0.35);
   box-shadow: 0 26px 60px rgba(6, 14, 32, 0.5);
   color: #f4f9ff;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  max-height: min(90vh, 720px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable both-edges;
+  -webkit-overflow-scrolling: touch;
+  box-sizing: border-box;
 }
 
 .first-run-tutorial__close {
@@ -1799,16 +1817,17 @@ body.game-active #gameCanvas {
 }
 
 .first-run-tutorial__title {
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
-  margin: 12px 0 16px;
+  font-size: clamp(1.65rem, 5.6vw, 2.4rem);
+  margin: 0;
   font-family: 'Chakra Petch', 'Exo 2', sans-serif;
   letter-spacing: 0.02em;
+  line-height: 1.15;
 }
 
 .first-run-tutorial__summary {
-  margin: 0 0 20px;
+  margin: 0;
   color: rgba(216, 231, 255, 0.92);
-  font-size: 1.05rem;
+  font-size: clamp(1rem, 3.2vw, 1.1rem);
   line-height: 1.6;
 }
 
@@ -1817,13 +1836,13 @@ body.game-active #gameCanvas {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 16px;
+  gap: clamp(0.85rem, 2.4vw, 1.2rem);
 }
 
 .first-run-tutorial__list li {
   display: grid;
   gap: 4px;
-  padding: 14px 16px;
+  padding: clamp(12px, 3.2vw, 16px) clamp(14px, 3.8vw, 18px);
   border-radius: 16px;
   background: linear-gradient(135deg, rgba(35, 59, 119, 0.55), rgba(22, 38, 82, 0.55));
   border: 1px solid rgba(114, 176, 255, 0.28);
@@ -1831,8 +1850,8 @@ body.game-active #gameCanvas {
 }
 
 .first-run-tutorial__issues {
-  margin-top: 24px;
-  padding: 16px 18px;
+  margin: 0;
+  padding: clamp(14px, 4vw, 18px);
   border-radius: 16px;
   border: 1px solid rgba(214, 104, 141, 0.4);
   background: linear-gradient(135deg, rgba(85, 37, 67, 0.55), rgba(48, 20, 39, 0.7));
@@ -1846,8 +1865,8 @@ body.game-active #gameCanvas {
 }
 
 .first-run-tutorial__issues-title {
-  margin: 0 0 10px;
-  font-size: 0.95rem;
+  margin: 0 0 0.75rem;
+  font-size: clamp(0.85rem, 2.6vw, 0.95rem);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: rgba(255, 189, 214, 0.92);
@@ -1864,7 +1883,7 @@ body.game-active #gameCanvas {
 .first-run-tutorial__issues-list li {
   position: relative;
   padding-left: 22px;
-  font-size: 0.95rem;
+  font-size: clamp(0.9rem, 2.8vw, 1rem);
   line-height: 1.5;
   color: rgba(255, 232, 240, 0.92);
 }
@@ -1882,64 +1901,104 @@ body.game-active #gameCanvas {
   font-weight: 600;
   color: rgba(180, 216, 255, 0.94);
   text-transform: uppercase;
-  font-size: 0.82rem;
+  font-size: clamp(0.78rem, 2.4vw, 0.85rem);
   letter-spacing: 0.12em;
 }
 
 .first-run-tutorial__step-detail {
-  font-size: 0.95rem;
-  line-height: 1.5;
+  font-size: clamp(0.95rem, 3vw, 1.05rem);
+  line-height: 1.55;
   color: rgba(228, 238, 255, 0.94);
 }
 
 .first-run-tutorial__note {
-  margin: 24px 0 0;
-  font-size: 0.95rem;
+  margin: 0;
+  font-size: clamp(0.9rem, 2.8vw, 0.95rem);
   color: rgba(164, 209, 255, 0.82);
 }
 
 .first-run-tutorial__actions {
-  margin-top: 24px;
+  margin-top: 0;
   display: flex;
   justify-content: flex-end;
 }
 
 .first-run-tutorial__actions .primary {
-  min-width: 160px;
-  font-size: 1rem;
-  padding: 12px 18px;
+  min-width: clamp(140px, 38vw, 180px);
+  font-size: clamp(0.95rem, 3vw, 1rem);
+  padding: clamp(10px, 3vw, 12px) clamp(16px, 5vw, 20px);
 }
 
 @media (max-width: 640px) {
   .first-run-tutorial__panel {
     border-radius: 18px;
-    padding: 24px 20px 28px;
+    padding: clamp(20px, 6vw, 28px);
+    gap: clamp(0.85rem, 3vw, 1.25rem);
   }
 
   .first-run-tutorial__close {
-    top: 12px;
-    right: 12px;
+    top: 10px;
+    right: 10px;
+    width: 34px;
+    height: 34px;
   }
 
   .first-run-tutorial__list li {
-    padding: 12px 14px;
+    padding: clamp(12px, 4vw, 16px) clamp(12px, 5vw, 16px);
   }
 
   .first-run-tutorial__issues {
-    margin-top: 20px;
-    padding: 14px 16px;
+    padding: clamp(12px, 4.5vw, 16px);
   }
 
   .first-run-tutorial__issues-title {
-    font-size: 0.9rem;
+    font-size: clamp(0.82rem, 2.8vw, 0.9rem);
   }
 
   .first-run-tutorial__issues-list li {
-    font-size: 0.9rem;
+    font-size: clamp(0.88rem, 3vw, 0.95rem);
   }
 
   .first-run-tutorial__note {
-    font-size: 0.9rem;
+    font-size: clamp(0.88rem, 3vw, 0.94rem);
+  }
+}
+
+@media (max-width: 480px) {
+  .first-run-tutorial__panel {
+    max-width: min(92vw, 480px);
+    max-height: min(88vh, 620px);
+    padding: clamp(18px, 7vw, 24px);
+    border-radius: 16px;
+    gap: clamp(0.75rem, 4vw, 1.1rem);
+  }
+
+  .first-run-tutorial__title {
+    font-size: clamp(1.5rem, 8vw, 2rem);
+  }
+
+  .first-run-tutorial__summary {
+    font-size: clamp(0.95rem, 4vw, 1.05rem);
+  }
+
+  .first-run-tutorial__list li {
+    gap: 6px;
+  }
+
+  .first-run-tutorial__step-label {
+    font-size: clamp(0.76rem, 3.6vw, 0.82rem);
+  }
+
+  .first-run-tutorial__step-detail {
+    font-size: clamp(0.92rem, 3.6vw, 1.02rem);
+  }
+
+  .first-run-tutorial__actions {
+    justify-content: center;
+  }
+
+  .first-run-tutorial__actions .primary {
+    width: 100%;
   }
 }
 
@@ -3016,6 +3075,8 @@ body.game-active #gameCanvas {
   position: relative;
   width: 100%;
   height: 100%;
+  transform: scale(var(--hud-scale));
+  transform-origin: top center;
   transition: transform 0.35s ease;
 }
 
@@ -3023,19 +3084,19 @@ body.game-active #gameCanvas {
   position: absolute;
   display: flex;
   flex-direction: column;
-  gap: clamp(0.75rem, 2vw, 1.1rem);
+  gap: var(--hud-spacing);
   pointer-events: none;
 }
 
 .hud-layer__corner--top-left {
-  top: calc(clamp(1rem, 2.2vw, 1.5rem) + env(safe-area-inset-top, 0px));
-  left: clamp(1rem, 2.2vw, 1.5rem);
+  top: calc(var(--hud-margin) + env(safe-area-inset-top, 0px));
+  left: var(--hud-margin);
   align-items: flex-start;
 }
 
 .hud-layer__corner--top-right {
-  top: calc(clamp(1rem, 2.2vw, 1.5rem) + env(safe-area-inset-top, 0px));
-  right: clamp(1rem, 2.2vw, 1.5rem);
+  top: calc(var(--hud-margin) + env(safe-area-inset-top, 0px));
+  right: var(--hud-margin);
   align-items: flex-end;
 }
 
@@ -3043,41 +3104,61 @@ body.game-active #gameCanvas {
   position: absolute;
   left: 0;
   right: 0;
-  bottom: calc(clamp(1rem, 2.2vw, 1.5rem) + env(safe-area-inset-bottom, 0px));
+  bottom: calc(var(--hud-margin) + env(safe-area-inset-bottom, 0px));
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: clamp(0.6rem, 1.2vw, 0.9rem);
+  gap: var(--hud-bottom-gap);
   justify-content: center;
   pointer-events: none;
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
+@media (max-width: 1280px) {
+  :root {
+    --hud-scale: 0.94;
+  }
+}
+
+@media (max-width: 1024px) {
+  :root {
+    --hud-scale: 0.9;
+  }
+}
+
+@media (max-width: 900px) {
+  :root {
+    --hud-scale: 0.86;
+    --hud-spacing: clamp(0.65rem, 2.6vw, 1rem);
+    --hud-margin: clamp(0.85rem, 3vw, 1.25rem);
+    --hud-bottom-gap: clamp(0.55rem, 2vw, 0.8rem);
+  }
+}
+
 @media (max-width: 768px) {
-  .hud-layer {
-    transform: scale(0.8);
-    transform-origin: top center;
+  :root {
+    --hud-scale: 0.82;
+    --hud-spacing: clamp(0.55rem, 3vw, 0.9rem);
+    --hud-margin: clamp(0.75rem, 4vw, 1.1rem);
+    --hud-bottom-gap: clamp(0.5rem, 2.5vw, 0.75rem);
   }
+}
 
-  .hud-layer__corner {
-    gap: 0.6rem;
+@media (max-width: 600px) {
+  :root {
+    --hud-scale: 0.78;
+    --hud-spacing: clamp(0.5rem, 4vw, 0.8rem);
+    --hud-margin: clamp(0.65rem, 5vw, 1rem);
+    --hud-bottom-gap: clamp(0.45rem, 3vw, 0.7rem);
   }
+}
 
-  .hud-layer__corner--top-left,
-  .hud-layer__corner--top-right {
-    top: calc(0.85rem + env(safe-area-inset-top, 0px));
-  }
-
-  .hud-layer__corner--top-left {
-    left: 0.85rem;
-  }
-
-  .hud-layer__corner--top-right {
-    right: 0.85rem;
-  }
-
-  .hud-layer__bottom {
-    bottom: calc(0.85rem + env(safe-area-inset-bottom, 0px));
+@media (max-width: 480px) {
+  :root {
+    --hud-scale: 0.72;
+    --hud-spacing: clamp(0.45rem, 5vw, 0.7rem);
+    --hud-margin: clamp(0.55rem, 6vw, 0.85rem);
+    --hud-bottom-gap: clamp(0.4rem, 3.5vw, 0.65rem);
   }
 }
 
@@ -7832,14 +7913,7 @@ body.colorblind-assist .subtitle-overlay {
     border-radius: 20px;
   }
 
-  .hud-layer__corner--top-left {
-    left: clamp(0.75rem, 4vw, 1.1rem);
-    top: clamp(0.75rem, 4vw, 1.1rem);
-  }
-
   .hud-layer__corner--top-right {
-    right: clamp(0.75rem, 4vw, 1.1rem);
-    top: clamp(0.75rem, 4vw, 1.1rem);
     align-items: stretch;
   }
 
@@ -7874,10 +7948,6 @@ body.colorblind-assist .subtitle-overlay {
 
   #gameHud .user-identity {
     text-align: left;
-  }
-
-  .hud-layer__bottom {
-    bottom: clamp(0.85rem, 4vw, 1.25rem);
   }
 
   .portal-progress {
@@ -8043,31 +8113,6 @@ body.colorblind-assist .subtitle-overlay {
   .mobile-controls__cluster--actions {
     justify-content: center;
   }
-
-  .hud-layer {
-    transform: scale(0.74);
-  }
-
-  .hud-layer__corner {
-    gap: 0.5rem;
-  }
-
-  .hud-layer__corner--top-left,
-  .hud-layer__corner--top-right {
-    top: calc(0.75rem + env(safe-area-inset-top, 0px));
-  }
-
-  .hud-layer__corner--top-left {
-    left: clamp(0.65rem, 6vw, 1rem);
-  }
-
-  .hud-layer__corner--top-right {
-    right: clamp(0.65rem, 6vw, 1rem);
-  }
-
-  .hud-layer__bottom {
-    bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
-  }
 }
 
 @media (max-width: 480px) {
@@ -8077,14 +8122,6 @@ body.colorblind-assist .subtitle-overlay {
 
   .virtual-joystick__thumb {
     --joystick-thumb: clamp(36px, 20vw, 48px);
-  }
-
-  .hud-layer {
-    transform: scale(0.7);
-  }
-
-  .hud-layer__corner {
-    gap: 0.45rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add HUD scale, spacing, and margin variables with responsive breakpoints to keep panels positioned on smaller screens
- update the HUD layout to consume the new variables instead of hard-coded transforms for consistent scaling on desktop and mobile
- rework the first-run tutorial overlay spacing so it scrolls, flexes, and scales cleanly on narrow viewports while locking the page background

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e13baada8c832bbcbdc6c8b9250538