### PR TITLE
Make How to Play tutorial accessible from the HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,7 @@
               ></ul>
             </div>
             <p class="first-run-tutorial__note" id="firstRunTutorialNote">
-              Need a refresher later? Press <strong>?</strong> or tap the <strong>Tutorial</strong> button in the HUD.
+              Need a refresher later? Press <strong>?</strong> or tap the <strong>How to Play</strong> button in the HUD.
             </p>
             <div class="first-run-tutorial__actions">
               <button type="button" class="primary" id="firstRunTutorialBegin">Let's explore</button>
@@ -457,7 +457,12 @@
                   </span>
                   <span class="leaderboard-toggle__label">Leaderboard</span>
                 </button>
-                <button type="button" id="openTutorial" class="ghost" data-hint="Reopen the tutorial overlay for control reminders.">Tutorial</button>
+                <button
+                  type="button"
+                  id="openTutorial"
+                  class="ghost"
+                  data-hint="Reopen the How to Play tutorial for control reminders."
+                >How to Play</button>
                 <button type="button" id="openGuide" class="ghost" data-hint="Open the survival guide.">Game Guide</button>
                 <button
                   type="button"

--- a/simple-experience.js
+++ b/simple-experience.js
@@ -4706,7 +4706,7 @@
             'Tap the <strong>hammer</strong> icon to craft. Place blocks with the <strong>✦</strong> action button while aiming and ignite portals with the <strong>⧉</strong> control.';
         }
         if (noteEl) {
-          noteEl.innerHTML = 'Need a refresher later? Tap the <strong>Tutorial</strong> button in the HUD anytime.';
+          noteEl.innerHTML = 'Need a refresher later? Tap the <strong>How to Play</strong> button in the HUD anytime.';
         }
         this.refreshFirstRunTutorialErrors();
         this.refreshLostGuidanceContent();
@@ -4735,7 +4735,7 @@
         craftDetail.innerHTML = `Tap the <strong>hammer</strong> icon or press <strong>${craftingKeys}</strong> to craft. Place blocks with <strong>${placeKeys}</strong> and ignite portals with <strong>${portalKeys}</strong>.`;
       }
       if (noteEl) {
-        noteEl.innerHTML = `Need a refresher later? Press <strong>${tutorialKeys}</strong> or use the <strong>Tutorial</strong> button in the HUD.`;
+        noteEl.innerHTML = `Need a refresher later? Press <strong>${tutorialKeys}</strong> or use the <strong>How to Play</strong> button in the HUD.`;
       }
       this.refreshFirstRunTutorialErrors();
       this.refreshLostGuidanceContent();


### PR DESCRIPTION
## Summary
- rename the HUD tutorial control to "How to Play" so the landing copy and in-game button stay consistent
- refresh tutorial overlay messaging to direct players to the How to Play button for ongoing guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1487baab4832b82d7c1905d45ca83