### PR TITLE
Ensure navmesh requests occur for invalid golem positions

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -13507,11 +13507,11 @@
         return null;
       }
       const chunkKey = this.getChunkKeyForWorldPosition(x, z);
+      const navmesh = this.ensureNavigationMeshForWorldPosition(x, z);
       if (!chunkKey) {
         this.warnAiMovementFailure(actorType, { ...options, chunkKey: null, reason: 'chunk-missing', x, z });
-        return null;
+        return navmesh;
       }
-      const navmesh = this.ensureNavigationMeshForWorldPosition(x, z);
       if (!navmesh || !navmesh.walkableCellCount) {
         this.warnAiMovementFailure(actorType, {
           ...options,


### PR DESCRIPTION
## Summary
- ensure golem navigation mesh requests are issued even when the chunk key is unavailable
- preserve AI movement warnings while returning any navmesh request results

## Testing
- npm test -- tests/simple-experience-entities.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e14ced8bc0832b959a10dbea1c5e45