### PR TITLE
Adjust e2e navigation wait strategy

### DIFF
--- a/tests/e2e-check.js
+++ b/tests/e2e-check.js
@@ -142,7 +142,9 @@ async function runAdvancedScenario(browser) {
   });
 
   try {
-    await page.goto('file://' + process.cwd() + '/index.html');
+    await page.goto('file://' + process.cwd() + '/index.html', {
+      waitUntil: 'domcontentloaded',
+    });
     await maybeClickStart(page);
     await page.waitForFunction(() => document.body.classList.contains('game-active'), {
       timeout: 15000,
@@ -201,7 +203,9 @@ async function runSimpleScenario(browser) {
   });
 
   try {
-    await page.goto('file://' + process.cwd() + '/index.html?mode=simple');
+    await page.goto('file://' + process.cwd() + '/index.html?mode=simple', {
+      waitUntil: 'domcontentloaded',
+    });
     await maybeClickStart(page);
     await page.waitForTimeout(1500);
     const introVisible = await page.isVisible('#introModal').catch(() => false);


### PR DESCRIPTION
## Summary
- make the Playwright navigation in the E2E helper wait for DOMContentLoaded so file-based loads resolve reliably

## Testing
- npm run test:e2e *(fails: system dependencies for Playwright browsers are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e150ca9eac832b8db94a0f7e52fe5a