### PR TITLE
Increase E2E test runner timeout

### DIFF
--- a/tests/e2e-check.js
+++ b/tests/e2e-check.js
@@ -1,6 +1,6 @@
 const { chromium } = require('playwright');
 
-const MAX_RUN_DURATION_MS = 2 * 60 * 1000;
+const MAX_RUN_DURATION_MS = 5 * 60 * 1000;
 
 function logCheckpoint(scope, message, { elapsedFrom } = {}) {
   const elapsed = elapsedFrom ? ` +${Math.round((Date.now() - elapsedFrom) / 10) / 100}s` : '';


### PR DESCRIPTION
## Summary
- extend the e2e smoke test fail-fast timeout to five minutes so long-running runs are not aborted prematurely

## Testing
- not run (runtime exceeds available window)

------
https://chatgpt.com/codex/tasks/task_e_68e210d165fc832ba5690ead26fca945