### PR TITLE
Fix start button readiness when asset preload skipped

### DIFF
--- a/script.js
+++ b/script.js
@@ -8943,6 +8943,7 @@
           }
         });
     } else {
+      releaseStartButton({ delayed: false });
       hideBootstrapOverlay();
     }
     if (typeof logDiagnosticsEvent === 'function') {


### PR DESCRIPTION
## Summary
- ensure the start button is released when critical asset preloading is skipped
- keep the bootstrap overlay dismissal logic for offline/file:// runs

## Testing
- npm run test:e2e *(fails: Playwright browser download required in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e216b8242c832bab92474b811fad68