### PR TITLE
Ensure bootstrap overlay releases when start button is enabled

### DIFF
--- a/script.js
+++ b/script.js
@@ -8708,6 +8708,7 @@
             delete ui.startButton.dataset.preloadWarning;
           }
         }
+        hideBootstrapOverlay();
       };
       if (ui.startButton) {
         ui.startButton.disabled = true;


### PR DESCRIPTION
## Summary
- hide the bootstrap overlay whenever the start button is released so it no longer blocks automation clicks

## Testing
- npm run test:e2e *(fails: Playwright browser download required)*

------
https://chatgpt.com/codex/tasks/task_e_68e2183e6184832bacb36fec2b7426ea