### PR TITLE
Fix start button release when asset preload is skipped

### DIFF
--- a/script.js
+++ b/script.js
@@ -8711,6 +8711,23 @@
         });
       }
     }
+    const releaseStartButton = ({ delayed } = {}) => {
+      if (!ui.startButton) {
+        return;
+      }
+      ui.startButton.disabled = false;
+      if (delayed) {
+        ui.startButton.removeAttribute('data-preloading');
+        ui.startButton.dataset.preloadWarning = 'delayed';
+      } else {
+        ui.startButton.removeAttribute('data-preloading');
+        if (ui.startButton.dataset.preloadWarning) {
+          delete ui.startButton.dataset.preloadWarning;
+        }
+      }
+      suppressAssetLoadingIndicatorOverlay();
+      hideBootstrapOverlay();
+    };
     if (assetPreloadPromise && typeof assetPreloadPromise.then === 'function') {
       let assetPreloadFallbackTimer = null;
       const clearAssetPreloadFallbackTimer = () => {
@@ -8725,23 +8742,6 @@
           }
           assetPreloadFallbackTimer = null;
         }
-      };
-      const releaseStartButton = ({ delayed } = {}) => {
-        if (!ui.startButton) {
-          return;
-        }
-        ui.startButton.disabled = false;
-        if (delayed) {
-          ui.startButton.removeAttribute('data-preloading');
-          ui.startButton.dataset.preloadWarning = 'delayed';
-        } else {
-          ui.startButton.removeAttribute('data-preloading');
-          if (ui.startButton.dataset.preloadWarning) {
-            delete ui.startButton.dataset.preloadWarning;
-          }
-        }
-        suppressAssetLoadingIndicatorOverlay();
-        hideBootstrapOverlay();
       };
       if (ui.startButton) {
         ui.startButton.disabled = true;


### PR DESCRIPTION
## Summary
- define the start button release helper outside the preload branch so it runs even when preloading is skipped
- allow the bootstrap overlay to hide correctly when asset preloading is bypassed (e.g. file:// runs)

## Testing
- npm run test:e2e *(fails: requires playwright browsers to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e21e773c00832b8aaba871e757a40b