### PR TITLE
Handle hidden start button during E2E automation

### DIFF
--- a/tests/e2e-check.js
+++ b/tests/e2e-check.js
@@ -196,6 +196,11 @@ async function maybeClickStart(page) {
   );
 
   console.info('[E2E][StartButton] Dispatching click.');
+  const readyVisible = await startButton.isVisible().catch(() => false);
+  if (!readyVisible) {
+    console.info('[E2E][StartButton] Start button became hidden before click; assuming renderer progressed.');
+    return;
+  }
   await startButton.click();
   console.info('[E2E][StartButton] Click dispatched.');
 }


### PR DESCRIPTION
## Summary
- skip the scripted click when the start button becomes hidden during automation
- add diagnostic logging to show when the button is hidden before the click

## Testing
- npm run test:e2e *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68e22edaf6cc832b8d2a8ddf0125cd93