### PR TITLE
Handle auto-start in e2e start button helper

### DIFF
--- a/tests/e2e-check.js
+++ b/tests/e2e-check.js
@@ -201,6 +201,16 @@ async function maybeClickStart(page) {
     console.info('[E2E][StartButton] Start button became hidden before click; assuming renderer progressed.');
     return;
   }
+  const handledByAutomation = await page
+    .evaluate(() => {
+      const button = document.querySelector('#startButton');
+      return button?.dataset?.simpleExperienceAutoStart === 'true';
+    })
+    .catch(() => false);
+  if (handledByAutomation) {
+    console.info('[E2E][StartButton] Automation flagged auto-start; skipping manual click.');
+    return;
+  }
   await startButton.click();
   console.info('[E2E][StartButton] Click dispatched.');
 }


### PR DESCRIPTION
## Summary
- skip manual start button clicks in the E2E helper when the renderer has already triggered its automation flag

## Testing
- npm run test:e2e *(fails in CI environment without installed Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68e23296cd7c832ba9c8a4649c82affd