### PR TITLE
Handle pending auto-start state for E2E stability

### DIFF
--- a/tests/e2e-check.js
+++ b/tests/e2e-check.js
@@ -201,14 +201,16 @@ async function maybeClickStart(page) {
     console.info('[E2E][StartButton] Start button became hidden before click; assuming renderer progressed.');
     return;
   }
-  const handledByAutomation = await page
+  const automationState = await page
     .evaluate(() => {
       const button = document.querySelector('#startButton');
-      return button?.dataset?.simpleExperienceAutoStart === 'true';
+      return button?.dataset?.simpleExperienceAutoStart ?? null;
     })
-    .catch(() => false);
-  if (handledByAutomation) {
-    console.info('[E2E][StartButton] Automation flagged auto-start; skipping manual click.');
+    .catch(() => null);
+  if (automationState === 'true' || automationState === 'pending') {
+    console.info(
+      `[E2E][StartButton] Automation flagged auto-start (${automationState}); skipping manual click.`,
+    );
     return;
   }
   await startButton.click();


### PR DESCRIPTION
## Summary
- ensure the automation flow marks the Start button as pending before dispatching the synthetic click
- allow automated runs to retry after failures by restoring the pending state
- update the E2E helper to recognise the pending state and skip redundant clicks

## Testing
- npm run test:e2e *(fails: requires Playwright browser download in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e238e1ae30832ba424e662e223b5df