### PR TITLE
Ensure renderer failures surface critical overlay logs

### DIFF
--- a/script.js
+++ b/script.js
@@ -3357,21 +3357,18 @@
       }
       lastRendererFailureDetail = detail;
       const failureMessage = formatRendererFailureMessage(detail);
-      bootstrapOverlay.showError({
+      presentCriticalErrorOverlay({
         title: 'Renderer unavailable',
         message: failureMessage,
+        diagnosticScope: 'renderer',
+        diagnosticStatus: 'error',
+        diagnosticMessage: failureMessage,
+        logScope: 'startup',
+        logMessage: failureMessage,
+        logLevel: 'error',
+        detail,
+        timestamp: Number.isFinite(detail?.timestamp) ? detail.timestamp : undefined,
       });
-      bootstrapOverlay.setDiagnostic('renderer', {
-        status: 'error',
-        message: failureMessage,
-      });
-      if (typeof logDiagnosticsEvent === 'function') {
-        logDiagnosticsEvent('startup', failureMessage, {
-          level: 'error',
-          detail,
-          timestamp: Number.isFinite(detail?.timestamp) ? detail.timestamp : undefined,
-        });
-      }
       const activeMode = resolveRendererModeForFallback(detail);
       if (activeMode !== 'simple') {
         const fallbackContext = {


### PR DESCRIPTION
## Summary
- route renderer failure events through the critical error overlay helper so they produce HUD alerts and developer diagnostics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e23c86e6d0832bbc819867f8c2f5a0