### PR TITLE
Align event overlay titles with major milestones

### DIFF
--- a/script.js
+++ b/script.js
@@ -5272,9 +5272,11 @@
     const placed = Number.isFinite(detail?.placed) ? detail.placed : null;
     const required = Number.isFinite(detail?.required) ? detail.required : null;
     const progressMessage =
-      placed !== null && required !== null ? `${placed}/${required} obsidian aligned — ignite when ready.` : 'Frame complete — ignite your torch.';
+      placed !== null && required !== null
+        ? `${placed}/${required} obsidian aligned — ignite when ready.`
+        : 'Frame complete — ignite your torch.';
     showEventOverlay({
-      title: 'Portal frame ready',
+      title: 'Portal built',
       message: progressMessage,
       icon: '🌀',
       variant: 'info',
@@ -5310,7 +5312,7 @@
       message += ` (+${formattedScore} pts)`;
     }
     showEventOverlay({
-      title: 'Loot secured',
+      title: 'Loot found',
       message,
       icon: '💎',
       variant: 'success',


### PR DESCRIPTION
## Summary
- rename the portal-ready overlay to "Portal built" so the on-screen copy matches the requested milestone wording
- update the loot overlay title to "Loot found" while preserving existing score and loot detail messaging
- keep the existing asset streaming overlays intact so players continue to see progress and completion status

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2495a83dc832bb22289616635a560