### PR TITLE
Ensure How to Play HUD button stays accessible

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3521,6 +3521,20 @@ body.hud-inactive #gameHud .craft-launcher {
   pointer-events: none;
 }
 
+/* Keep the How to Play trigger usable even while the HUD is dimmed for active play. */
+body.hud-inactive #gameHud .hud-card--actions,
+body.hud-inactive #gameHud .hud-card--actions .hud-actions {
+  pointer-events: auto;
+}
+
+body.hud-inactive #gameHud .hud-card--actions .hud-actions button {
+  pointer-events: none;
+}
+
+body.hud-inactive #gameHud #openTutorial {
+  pointer-events: auto;
+}
+
 .victory-banner {
   position: absolute;
   top: 1.5rem;


### PR DESCRIPTION
## Summary
- restore pointer events to the HUD actions card while keeping other quick actions inactive when the HUD is dimmed
- allow the How to Play button to remain clickable so the tutorial can be opened during active play

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e24a339400832b8ed3b2bded8a5740