### PR TITLE
Add mission briefing fallback renderer mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1765,6 +1765,43 @@ body.game-active #gameCanvas {
   opacity: 0.95;
 }
 
+body[data-renderer-mode='briefing'] .primary-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 6vw, 3rem);
+}
+
+body[data-renderer-mode='briefing'] #gameCanvas {
+  display: none;
+}
+
+body[data-renderer-mode='briefing'] .game-briefing {
+  position: relative;
+  left: auto;
+  top: auto;
+  transform: none;
+  opacity: 1;
+  pointer-events: auto;
+  width: min(92%, 560px);
+  margin: clamp(1.5rem, 8vh, 3.5rem) auto;
+}
+
+body[data-renderer-mode='briefing'] .game-briefing.is-visible {
+  transform: none;
+}
+
+.game-briefing__fallback {
+  margin: 0;
+  padding: 0.9rem 1.1rem;
+  border-radius: 18px;
+  border: 1px dashed rgba(73, 242, 255, 0.45);
+  background: rgba(8, 22, 40, 0.72);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
 .first-run-tutorial {
   position: fixed;
   inset: 0;

--- a/tests/mission-briefing-fallback.test.js
+++ b/tests/mission-briefing-fallback.test.js
@@ -1,0 +1,381 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const scriptSource = fs.readFileSync(path.join(repoRoot, 'script.js'), 'utf8');
+
+const ensureSimpleModeStart = scriptSource.indexOf('function ensureSimpleModeQueryParam(');
+const ensureSimpleModeEnd = scriptSource.indexOf('function applyRendererReadyState', ensureSimpleModeStart);
+if (ensureSimpleModeStart === -1 || ensureSimpleModeEnd === -1 || ensureSimpleModeEnd <= ensureSimpleModeStart) {
+  throw new Error('Failed to locate ensureSimpleModeQueryParam definition in script.js');
+}
+const ensureSimpleModeSource = scriptSource.slice(ensureSimpleModeStart, ensureSimpleModeEnd);
+
+const fallbackStart = scriptSource.indexOf('const DEFAULT_RENDERER_START_TIMEOUT_MS =');
+const fallbackEnd = scriptSource.indexOf('function createScoreboardUtilsFallback', fallbackStart);
+if (fallbackStart === -1 || fallbackEnd === -1 || fallbackEnd <= fallbackStart) {
+  throw new Error('Failed to locate simple fallback bootstrap helpers in script.js');
+}
+const fallbackSource = scriptSource.slice(fallbackStart, fallbackEnd);
+
+function instantiateFallback(scope) {
+  const factory = new Function(
+    'scope',
+    "'use strict';" +
+      'const bootstrap = scope.bootstrap;' +
+      'const globalScope = scope;' +
+      'const documentRef = scope.documentRef ?? scope.document ?? null;' +
+      'const bootstrapOverlay = scope.bootstrapOverlay ?? { showLoading: () => {}, showError: () => {}, setDiagnostic: () => {}, setRecoveryAction: () => {} };' +
+      'const isDebugModeEnabled = scope.isDebugModeEnabled ?? (() => false);' +
+      'function setRendererModeIndicator(mode) {' +
+      '  const doc = documentRef ?? null;' +
+      '  if (doc?.documentElement?.setAttribute) {' +
+      "    doc.documentElement.setAttribute('data-renderer-mode', mode);" +
+      '  }' +
+      '  if (doc?.body?.setAttribute) {' +
+      "    doc.body.setAttribute('data-renderer-mode', mode);" +
+      '  }' +
+      '  scope.__INFINITE_RAILS_RENDERER_MODE__ = mode;' +
+      '  scope.InfiniteRails = scope.InfiniteRails || {};' +
+      '  scope.InfiniteRails.rendererMode = mode;' +
+      '}' +
+      ensureSimpleModeSource +
+      fallbackSource +
+      '\nreturn { tryStartSimpleFallback, offerMissionBriefingFallback, activateMissionBriefingFallback };'
+  );
+  return factory(scope);
+}
+
+function createClassList() {
+  return {
+    add: vi.fn(),
+    remove: vi.fn(),
+    contains: vi.fn(() => false),
+  };
+}
+
+function appendChildImpl(node, child) {
+  if (!child || child === node) {
+    return child;
+  }
+  if (!node.children) {
+    node.children = [];
+  }
+  if (child.parentNode && child.parentNode !== node && typeof child.parentNode.removeChild === 'function') {
+    child.parentNode.removeChild(child);
+  }
+  node.children.push(child);
+  child.parentNode = node;
+  if (!child.ownerDocument && node.ownerDocument) {
+    child.ownerDocument = node.ownerDocument;
+  }
+  return child;
+}
+
+function insertBeforeImpl(node, child, reference) {
+  if (!child) {
+    return child;
+  }
+  if (!node.children) {
+    node.children = [];
+  }
+  const index = reference ? node.children.indexOf(reference) : -1;
+  if (index >= 0) {
+    node.children.splice(index, 0, child);
+  } else {
+    node.children.push(child);
+  }
+  child.parentNode = node;
+  if (!child.ownerDocument && node.ownerDocument) {
+    child.ownerDocument = node.ownerDocument;
+  }
+  return child;
+}
+
+function removeChildImpl(node, child) {
+  if (!node.children) {
+    return child;
+  }
+  const index = node.children.indexOf(child);
+  if (index !== -1) {
+    node.children.splice(index, 1);
+    child.parentNode = null;
+  }
+  return child;
+}
+
+function defineChildAccessors(element) {
+  Object.defineProperty(element, 'firstChild', {
+    configurable: true,
+    enumerable: false,
+    get() {
+      return Array.isArray(this.children) && this.children.length ? this.children[0] : null;
+    },
+  });
+  Object.defineProperty(element, 'lastChild', {
+    configurable: true,
+    enumerable: false,
+    get() {
+      return Array.isArray(this.children) && this.children.length ? this.children[this.children.length - 1] : null;
+    },
+  });
+}
+
+function createElement(tagName, doc) {
+  const element = {
+    tagName: String(tagName || '').toUpperCase(),
+    ownerDocument: doc ?? null,
+    parentNode: null,
+    children: [],
+    attributes: {},
+    dataset: {},
+    classList: createClassList(),
+    style: {},
+    hidden: false,
+    textContent: '',
+    appendChild(child) {
+      return appendChildImpl(this, child);
+    },
+    insertBefore(child, reference) {
+      return insertBeforeImpl(this, child, reference);
+    },
+    removeChild(child) {
+      return removeChildImpl(this, child);
+    },
+    remove() {
+      if (this.parentNode?.removeChild) {
+        this.parentNode.removeChild(this);
+      }
+    },
+    setAttribute(name, value) {
+      const key = String(name);
+      this.attributes[key] = String(value);
+      if (key === 'id' && this.ownerDocument?.__elementsById) {
+        this.ownerDocument.__elementsById.set(String(value), this);
+      }
+    },
+    getAttribute(name) {
+      const key = String(name);
+      return Object.prototype.hasOwnProperty.call(this.attributes, key) ? this.attributes[key] : null;
+    },
+    removeAttribute(name) {
+      const key = String(name);
+      if (Object.prototype.hasOwnProperty.call(this.attributes, key)) {
+        const existingValue = this.attributes[key];
+        delete this.attributes[key];
+        if (key === 'id' && this.ownerDocument?.__elementsById && typeof existingValue !== 'undefined') {
+          this.ownerDocument.__elementsById.delete(existingValue);
+        }
+      }
+    },
+    querySelector: vi.fn(() => null),
+  };
+  Object.defineProperty(element, 'id', {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return this.attributes.id ?? '';
+    },
+    set(value) {
+      const stringValue = String(value);
+      if (this.ownerDocument?.__elementsById) {
+        if (typeof this.attributes.id !== 'undefined') {
+          this.ownerDocument.__elementsById.delete(this.attributes.id);
+        }
+        if (stringValue) {
+          this.ownerDocument.__elementsById.set(stringValue, this);
+        }
+      }
+      if (stringValue) {
+        this.attributes.id = stringValue;
+      } else if (typeof this.attributes.id !== 'undefined') {
+        delete this.attributes.id;
+      }
+    },
+  });
+  defineChildAccessors(element);
+  return element;
+}
+
+function createDocumentStub() {
+  const elementsById = new Map();
+  const documentStub = {
+    __elementsById: elementsById,
+    createElement(tag) {
+      const element = createElement(tag, documentStub);
+      return element;
+    },
+    getElementById(id) {
+      return elementsById.get(String(id)) ?? null;
+    },
+  };
+
+  const documentElement = createElement('html', documentStub);
+  documentElement.classList = createClassList();
+  documentElement.setAttribute = function setAttribute(name, value) {
+    this.attributes[String(name)] = String(value);
+    if (String(name) === 'id') {
+      elementsById.set(String(value), this);
+    }
+  };
+  documentStub.documentElement = documentElement;
+
+  const body = createElement('body', documentStub);
+  body.classList = createClassList();
+  body.setAttribute = function setAttribute(name, value) {
+    this.attributes[String(name)] = String(value);
+    if (String(name) === 'id') {
+      elementsById.set(String(value), this);
+    }
+  };
+  body.appendChild = function appendChild(child) {
+    return appendChildImpl(this, child);
+  };
+  documentStub.body = body;
+
+  const briefing = createElement('div', documentStub);
+  briefing.setAttribute('id', 'gameBriefing');
+  briefing.hidden = true;
+
+  const briefingContent = createElement('div', documentStub);
+  briefingContent.classList = createClassList();
+  briefing.appendChild(briefingContent);
+
+  const eyebrow = createElement('p', documentStub);
+  eyebrow.classList = createClassList();
+  eyebrow.textContent = 'Mission Briefing';
+  briefingContent.appendChild(eyebrow);
+
+  const title = createElement('h2', documentStub);
+  title.classList = createClassList();
+  title.textContent = 'Secure the Origin Rail';
+  briefingContent.appendChild(title);
+
+  const steps = createElement('ol', documentStub);
+  steps.setAttribute('id', 'gameBriefingSteps');
+  briefingContent.appendChild(steps);
+
+  briefing.querySelector = (selector) => {
+    if (selector === '.game-briefing__content') {
+      return briefingContent;
+    }
+    if (selector === '.game-briefing__eyebrow') {
+      return eyebrow;
+    }
+    if (selector === '.game-briefing__title') {
+      return title;
+    }
+    return null;
+  };
+
+  const dismissButton = createElement('button', documentStub);
+  dismissButton.setAttribute('id', 'dismissBriefing');
+  dismissButton.textContent = 'Begin the run';
+  dismissButton.addEventListener = vi.fn();
+  dismissButton.removeEventListener = vi.fn();
+
+  const startButton = createElement('button', documentStub);
+  startButton.setAttribute('id', 'startButton');
+  startButton.textContent = 'Start Expedition';
+  startButton.disabled = false;
+  startButton.setAttribute('data-preloading', 'false');
+
+  const canvas = createElement('canvas', documentStub);
+  canvas.setAttribute('id', 'gameCanvas');
+
+  elementsById.set('gameBriefing', briefing);
+  elementsById.set('gameBriefingSteps', steps);
+  elementsById.set('dismissBriefing', dismissButton);
+  elementsById.set('startButton', startButton);
+  elementsById.set('gameCanvas', canvas);
+
+  body.appendChild(briefing);
+  body.appendChild(dismissButton);
+  body.appendChild(startButton);
+  body.appendChild(canvas);
+
+  documentStub.body = body;
+  documentStub.documentElement = documentElement;
+
+  return documentStub;
+}
+
+describe('mission briefing fallback', () => {
+  it('activates mission briefing mode when no recovery action is available', () => {
+    const documentStub = createDocumentStub();
+    const overlay = {
+      showLoading: vi.fn(),
+      showError: vi.fn(),
+      setDiagnostic: vi.fn(),
+      state: { mode: 'error' },
+    };
+    const scope = {
+      APP_CONFIG: {},
+      documentRef: documentStub,
+      document: documentStub,
+      bootstrapOverlay: overlay,
+      console: { warn: () => {}, error: () => {}, debug: () => {} },
+      location: { reload: vi.fn() },
+    };
+    const { tryStartSimpleFallback } = instantiateFallback(scope);
+    const result = tryStartSimpleFallback(new Error('missing-simple'), { reason: 'no-simple' });
+    expect(result).toBe(false);
+    expect(documentStub.body.attributes['data-renderer-mode']).toBe('briefing');
+    expect(documentStub.documentElement.attributes['data-renderer-mode']).toBe('briefing');
+    const briefing = documentStub.getElementById('gameBriefing');
+    expect(briefing.hidden).toBe(false);
+    expect(briefing.classList.add).toHaveBeenCalledWith('is-visible');
+    const fallbackNotice = documentStub.getElementById('gameBriefingFallbackNotice');
+    expect(fallbackNotice).toBeTruthy();
+    expect(fallbackNotice.textContent).toContain('Renderer systems are offline');
+    const startButton = documentStub.getElementById('startButton');
+    expect(startButton.disabled).toBe(true);
+    expect(startButton.dataset.fallbackMode).toBe('briefing');
+    const canvas = documentStub.getElementById('gameCanvas');
+    expect(canvas.style.display).toBe('none');
+    const dismissButton = documentStub.getElementById('dismissBriefing');
+    expect(dismissButton.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(dismissButton.dataset.lowFidelityBound).toBe('true');
+    expect(scope.__MISSION_BRIEFING_FALLBACK_AVAILABLE__).toBe(true);
+    expect(scope.__MISSION_BRIEFING_FALLBACK_ACTIVE__).toBe(true);
+  });
+
+  it('registers a recovery action that triggers the mission briefing fallback', () => {
+    const documentStub = createDocumentStub();
+    const overlay = {
+      showLoading: vi.fn(),
+      showError: vi.fn(),
+      setDiagnostic: vi.fn(),
+      setRecoveryAction: vi.fn(),
+      hide: vi.fn(),
+      state: { mode: 'error' },
+    };
+    const scope = {
+      APP_CONFIG: {},
+      documentRef: documentStub,
+      document: documentStub,
+      bootstrapOverlay: overlay,
+      console: { warn: () => {}, error: () => {}, debug: () => {} },
+      location: { reload: vi.fn() },
+    };
+    const { offerMissionBriefingFallback } = instantiateFallback(scope);
+    const offered = offerMissionBriefingFallback({ reason: 'test-offer', context: { foo: 'bar' } });
+    expect(offered).toBe(true);
+    expect(scope.__MISSION_BRIEFING_FALLBACK_AVAILABLE__).toBe(true);
+    expect(overlay.setRecoveryAction).toHaveBeenCalledTimes(1);
+    const recoveryConfig = overlay.setRecoveryAction.mock.calls[0][0];
+    expect(recoveryConfig.action).toBe('open-mission-briefing');
+    expect(typeof recoveryConfig.onSelect).toBe('function');
+    const briefingBefore = documentStub.getElementById('gameBriefing');
+    expect(briefingBefore.hidden).toBe(true);
+    recoveryConfig.onSelect();
+    const briefing = documentStub.getElementById('gameBriefing');
+    expect(briefing.hidden).toBe(false);
+    expect(scope.__MISSION_BRIEFING_FALLBACK_ACTIVE__).toBe(true);
+    expect(overlay.hide).toHaveBeenCalledWith({ force: true });
+  });
+});

--- a/tests/renderer-mode-selection.test.js
+++ b/tests/renderer-mode-selection.test.js
@@ -810,7 +810,7 @@ describe('renderer mode selection', () => {
     it('returns false when the simple sandbox is unavailable', () => {
       const scope = {
         APP_CONFIG: {},
-        console: { warn: () => {}, error: () => {} },
+        console: { warn: () => {}, error: () => {}, debug: () => {} },
         bootstrap: () => {
           throw new Error('should not be called');
         },
@@ -823,8 +823,26 @@ describe('renderer mode selection', () => {
         },
       };
       const { tryStartSimpleFallback, getAttempted } = instantiateSimpleFallback(scope);
-      expect(tryStartSimpleFallback(new Error('missing'), { reason: 'no-simple' })).toBe(false);
+      const fallbackError = new Error('missing');
+      expect(tryStartSimpleFallback(fallbackError, { reason: 'no-simple' })).toBe(false);
       expect(getAttempted()).toBe(false);
+      expect(scope.bootstrapOverlay.showError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('mission briefing mode'),
+        }),
+      );
+      expect(scope.bootstrapOverlay.setDiagnostic).toHaveBeenCalledWith(
+        'renderer',
+        expect.objectContaining({
+          message: expect.stringContaining('Mission briefing mode'),
+        }),
+      );
+      expect(scope.bootstrapOverlay.setRecoveryAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'open-mission-briefing',
+          label: 'Open Mission Briefing Mode',
+        }),
+      );
     });
 
     it('invokes the fallback bootstrap when a start-error event is emitted', () => {


### PR DESCRIPTION
## Summary
- add a mission briefing fallback flow that activates when both the advanced and sandbox renderers fail and surface it to test hooks
- update styles to present the briefing in a centered layout for low-fidelity mode with a visible fallback notice
- expand renderer selection tests and add new mission briefing fallback tests covering automatic activation and recovery action flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e250170f4c832baf42d1945a3efef6