### PR TITLE
Add live critical asset availability diagnostics

### DIFF
--- a/tests/simple-experience-asset-availability.test.js
+++ b/tests/simple-experience-asset-availability.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createExperience } from './helpers/simple-experience-test-utils.js';
+
+describe('SimpleExperience critical asset availability', () => {
+  it('reports missing assets when probes fail to resolve sources', async () => {
+    const { experience } = createExperience();
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    experience.collectCriticalTextureKeys = vi.fn(() => ['grass', 'missing-texture']);
+    experience.collectCriticalModelEntries = vi.fn(() => [
+      { key: 'steve', url: 'https://assets.example.com/steve.gltf' },
+    ]);
+
+    const sourceMap = {
+      'texture:grass': ['https://assets.example.com/grass.png'],
+      'texture:missing-texture': ['https://assets.example.com/missing.png'],
+      steve: ['https://assets.example.com/steve.gltf'],
+    };
+
+    experience.resolveAssetSourceCandidates = vi.fn((key) => {
+      const sources = sourceMap[key];
+      return Array.isArray(sources) ? [...sources] : [];
+    });
+
+    const fetchMock = vi.fn((url, init = {}) => {
+      if (url.includes('grass.png')) {
+        return Promise.resolve({ ok: true, status: 200, type: 'basic' });
+      }
+      if (url.includes('missing.png')) {
+        return Promise.resolve({ ok: false, status: 404, type: 'basic' });
+      }
+      if (url.includes('steve.gltf')) {
+        if (init.method === 'HEAD') {
+          return Promise.resolve({ ok: false, status: 405, type: 'basic' });
+        }
+        return Promise.resolve({ ok: true, status: 206, type: 'basic' });
+      }
+      return Promise.resolve({ ok: false, status: 500, type: 'basic' });
+    });
+
+    const summary = await experience.verifyCriticalAssetAvailability({
+      fetch: fetchMock,
+      concurrency: 1,
+      timeoutMs: 50,
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(summary.status).toBe('missing');
+    expect(summary.missing).toContain('texture:missing-texture');
+    expect(summary.reachable).toBeGreaterThanOrEqual(2);
+    expect(consoleWarn).toHaveBeenCalled();
+
+    consoleWarn.mockRestore();
+    consoleInfo.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add a critical asset availability verifier that probes texture and model sources, logging missing assets and updating boot diagnostics
- surface availability results through startup UI, developer event log, and overlay messaging
- add a unit test that exercises missing asset detection with mocked fetch responses

## Testing
- npm test -- tests/simple-experience-asset-availability.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2591e8bac832b83ec2d70a679e3e3