### PR TITLE
Ensure CloudFront OAI can read audio assets

### DIFF
--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -62,6 +62,7 @@ Resources:
             Resource:
               - !Sub "${AssetsBucket.Arn}/assets/*"
               - !Sub "${AssetsBucket.Arn}/textures/*"
+              - !Sub "${AssetsBucket.Arn}/audio/*"
 
   AssetsDistribution:
     Type: AWS::CloudFront::Distribution


### PR DESCRIPTION
## Summary
- extend the S3 bucket policy to grant the CloudFront origin access identity read access to audio objects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e261ec16c8832bb7ab9eabd8bb8368