### PR TITLE
Ensure audio asset prefixes remain world-readable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,6 +144,7 @@ jobs:
             --include "portal-mechanics.js" \
             --include "scoreboard-utils.js" \
             --include "assets/**" \
+            --include "audio/**" \
             --include "textures/**" \
             --include "vendor/*"
 
@@ -208,6 +209,7 @@ jobs:
                       ("arn:aws:s3:::" + $bucket + "/script.js"),
                       ("arn:aws:s3:::" + $bucket + "/simple-experience.js"),
                       ("arn:aws:s3:::" + $bucket + "/assets/*"),
+                      ("arn:aws:s3:::" + $bucket + "/audio/*"),
                       ("arn:aws:s3:::" + $bucket + "/textures/*"),
                       ("arn:aws:s3:::" + $bucket + "/vendor/*")
                     ]


### PR DESCRIPTION
## Summary
- ensure the deployment workflow syncs audio/ objects and includes them in the CloudFront OAI bucket policy resources
- add tests that audit world-readable permissions across asset directories and verify the CloudFormation template grants s3:GetObject to the OAI for assets, textures, and audio prefixes

## Testing
- npm run test:pre-release

------
https://chatgpt.com/codex/tasks/task_e_68e263195cec832b879e58688a9d53b1