### PR TITLE
Support CloudFront OAC bucket policies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,6 +163,9 @@ jobs:
           ORIGIN_REGIONAL="${DEPLOY_BUCKET}.s3.${AWS_REGION}.amazonaws.com"
           ORIGIN_WEBSITE="${DEPLOY_BUCKET}.s3-website-${AWS_REGION}.amazonaws.com"
           OAI_ID=""
+          OAC_ID=""
+          DISTRIBUTION_ID=""
+          DISTRIBUTION_ARN=""
 
           MATCH=$(aws cloudfront list-distributions --query "DistributionList.Items[?Origins.Items[?DomainName=='${ORIGIN_CLASSIC}' || DomainName=='${ORIGIN_REGIONAL}' || DomainName=='${ORIGIN_WEBSITE}']]|[0]")
           if [ -n "${MATCH}" ] && [ "${MATCH}" != "null" ]; then
@@ -174,22 +177,31 @@ jobs:
             if [ -n "${OAI_PATH}" ] && [ "${OAI_PATH}" != "null" ]; then
               OAI_ID="${OAI_PATH##*/}"
             fi
+            OAC_ID=$(echo "${MATCH}" | jq -r \
+              --arg classic "${ORIGIN_CLASSIC}" \
+              --arg regional "${ORIGIN_REGIONAL}" \
+              --arg website "${ORIGIN_WEBSITE}" \
+              '.Origins.Items[] | select(.DomainName == $classic or .DomainName == $regional or .DomainName == $website) | .OriginAccessControlId // empty' | head -n 1)
+            if [ -n "${OAC_ID}" ] && [ "${OAC_ID}" != "null" ]; then
+              DISTRIBUTION_ID=$(echo "${MATCH}" | jq -r '.Id // empty')
+              DISTRIBUTION_ARN=$(echo "${MATCH}" | jq -r '.ARN // empty')
+            fi
           fi
 
           POLICY_FILE=$(mktemp)
 
-          if [ -z "${OAI_ID}" ]; then
-            echo '::error::No CloudFront Origin Access Identity is attached to the distribution.'
-            echo '::error::Attach an OAI to the distribution or create one before rerunning the deploy workflow.'
+          if [ -z "${OAI_ID}" ] && [ -z "${OAC_ID}" ]; then
+            echo '::error::No CloudFront Origin Access Identity or Origin Access Control is attached to the distribution.'
+            echo '::error::Attach an OAI/OAC to the distribution before rerunning the deploy workflow.'
             {
-              echo '### ❌ Missing CloudFront OAI'
+              echo '### ❌ Missing CloudFront OAI/OAC'
               echo ''
-              echo 'The deployment workflow requires a CloudFront Origin Access Identity so the static assets remain private in S3.'
+              echo 'The deployment workflow requires a CloudFront Origin Access Identity (OAI) or Origin Access Control (OAC) so the static assets remain private in S3.'
               echo ''
               echo '#### How to fix'
-              echo '1. Create (or locate) an Origin Access Identity in the CloudFront console.'
-              echo '2. Attach the OAI to the distribution that fronts the `${DEPLOY_BUCKET}` bucket.'
-              echo '3. Re-run this workflow once the distribution uses the OAI.'
+              echo '1. Create (or locate) an Origin Access Identity or Origin Access Control in the CloudFront console.'
+              echo '2. Attach the identity/control to the distribution that fronts the `${DEPLOY_BUCKET}` bucket.'
+              echo '3. Re-run this workflow once the distribution uses the OAI or OAC.'
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
@@ -198,41 +210,86 @@ jobs:
             --bucket "${DEPLOY_BUCKET}" \
             --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=false,RestrictPublicBuckets=false
 
-          jq -n \
-            --arg bucket "${DEPLOY_BUCKET}" \
-            --arg oai "${OAI_ID}" \
-            '{
-              Version: "2012-10-17",
-              Statement: [
-                {
-                  Sid: "AllowCloudFrontOAIRead",
-                  Effect: "Allow",
-                  Principal: {
-                    AWS: ("arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity " + $oai)
-                  },
-                  Action: "s3:GetObject",
-                  Resource: [
-                    ("arn:aws:s3:::" + $bucket + "/index.html"),
-                    ("arn:aws:s3:::" + $bucket + "/styles.css"),
-                    ("arn:aws:s3:::" + $bucket + "/asset-resolver.js"),
-                    ("arn:aws:s3:::" + $bucket + "/audio-aliases.js"),
-                    ("arn:aws:s3:::" + $bucket + "/audio-captions.js"),
-                    ("arn:aws:s3:::" + $bucket + "/combat-utils.js"),
-                    ("arn:aws:s3:::" + $bucket + "/crafting.js"),
-                    ("arn:aws:s3:::" + $bucket + "/portal-mechanics.js"),
-                    ("arn:aws:s3:::" + $bucket + "/scoreboard-utils.js"),
-                    ("arn:aws:s3:::" + $bucket + "/script.js"),
-                    ("arn:aws:s3:::" + $bucket + "/simple-experience.js"),
-                    ("arn:aws:s3:::" + $bucket + "/assets/*"),
-                    ("arn:aws:s3:::" + $bucket + "/audio/*"),
-                    ("arn:aws:s3:::" + $bucket + "/textures/*"),
-                    ("arn:aws:s3:::" + $bucket + "/vendor/*")
-                  ]
-                }
-              ]
-            }' > "${POLICY_FILE}"
-
-          ACCESS_MODE="CloudFront OAI (${OAI_ID})"
+          if [ -n "${OAC_ID}" ]; then
+            if [ -z "${DISTRIBUTION_ARN}" ]; then
+              echo '::error::Failed to resolve the CloudFront distribution ARN required for the OAC policy.'
+              exit 1
+            fi
+            jq -n \
+              --arg bucket "${DEPLOY_BUCKET}" \
+              --arg arn "${DISTRIBUTION_ARN}" \
+              '{
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Sid: "AllowCloudFrontOACRead",
+                    Effect: "Allow",
+                    Principal: {
+                      Service: "cloudfront.amazonaws.com"
+                    },
+                    Action: "s3:GetObject",
+                    Resource: [
+                      ("arn:aws:s3:::" + $bucket + "/index.html"),
+                      ("arn:aws:s3:::" + $bucket + "/styles.css"),
+                      ("arn:aws:s3:::" + $bucket + "/asset-resolver.js"),
+                      ("arn:aws:s3:::" + $bucket + "/audio-aliases.js"),
+                      ("arn:aws:s3:::" + $bucket + "/audio-captions.js"),
+                      ("arn:aws:s3:::" + $bucket + "/combat-utils.js"),
+                      ("arn:aws:s3:::" + $bucket + "/crafting.js"),
+                      ("arn:aws:s3:::" + $bucket + "/portal-mechanics.js"),
+                      ("arn:aws:s3:::" + $bucket + "/scoreboard-utils.js"),
+                      ("arn:aws:s3:::" + $bucket + "/script.js"),
+                      ("arn:aws:s3:::" + $bucket + "/simple-experience.js"),
+                      ("arn:aws:s3:::" + $bucket + "/assets/*"),
+                      ("arn:aws:s3:::" + $bucket + "/audio/*"),
+                      ("arn:aws:s3:::" + $bucket + "/textures/*"),
+                      ("arn:aws:s3:::" + $bucket + "/vendor/*")
+                    ],
+                    Condition: {
+                      StringEquals: {
+                        "AWS:SourceArn": $arn
+                      }
+                    }
+                  }
+                ]
+              }' > "${POLICY_FILE}"
+            ACCESS_MODE="CloudFront OAC (${OAC_ID})"
+          else
+            jq -n \
+              --arg bucket "${DEPLOY_BUCKET}" \
+              --arg oai "${OAI_ID}" \
+              '{
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Sid: "AllowCloudFrontOAIRead",
+                    Effect: "Allow",
+                    Principal: {
+                      AWS: ("arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity " + $oai)
+                    },
+                    Action: "s3:GetObject",
+                    Resource: [
+                      ("arn:aws:s3:::" + $bucket + "/index.html"),
+                      ("arn:aws:s3:::" + $bucket + "/styles.css"),
+                      ("arn:aws:s3:::" + $bucket + "/asset-resolver.js"),
+                      ("arn:aws:s3:::" + $bucket + "/audio-aliases.js"),
+                      ("arn:aws:s3:::" + $bucket + "/audio-captions.js"),
+                      ("arn:aws:s3:::" + $bucket + "/combat-utils.js"),
+                      ("arn:aws:s3:::" + $bucket + "/crafting.js"),
+                      ("arn:aws:s3:::" + $bucket + "/portal-mechanics.js"),
+                      ("arn:aws:s3:::" + $bucket + "/scoreboard-utils.js"),
+                      ("arn:aws:s3:::" + $bucket + "/script.js"),
+                      ("arn:aws:s3:::" + $bucket + "/simple-experience.js"),
+                      ("arn:aws:s3:::" + $bucket + "/assets/*"),
+                      ("arn:aws:s3:::" + $bucket + "/audio/*"),
+                      ("arn:aws:s3:::" + $bucket + "/textures/*"),
+                      ("arn:aws:s3:::" + $bucket + "/vendor/*")
+                    ]
+                  }
+                ]
+              }' > "${POLICY_FILE}"
+            ACCESS_MODE="CloudFront OAI (${OAI_ID})"
+          fi
 
           aws s3api put-bucket-policy --bucket "${DEPLOY_BUCKET}" --policy "file://${POLICY_FILE}"
           rm -f "${POLICY_FILE}"
@@ -242,6 +299,9 @@ jobs:
             echo ''
             echo "- Bucket: \`${DEPLOY_BUCKET}\`"
             echo "- Access: ${ACCESS_MODE}"
+            if [ -n "${DISTRIBUTION_ID}" ]; then
+              echo "- Distribution: \`${DISTRIBUTION_ID}\`"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Ensure CloudFront distribution

--- a/README.md
+++ b/README.md
@@ -306,11 +306,11 @@ If no CloudFront distribution matches the S3 bucket, the workflow fails with ins
 
 ### Static asset permissions
 
-Every file uploaded during the deploy—including JavaScript bundles, GLTF models, textures, ambient audio, and any future additions under `assets/`, `textures/`, `audio/`, or `vendor/`—must be readable by CloudFront. The deploy workflow now **requires** a CloudFront Origin Access Identity (OAI) and configures the S3 bucket with an `s3:GetObject` grant that is scoped to the identity and the relevant prefixes. Public ACLs and anonymous bucket policies are no longer permitted; the job fails if the distribution does not expose an OAI.
+Every file uploaded during the deploy—including JavaScript bundles, GLTF models, textures, ambient audio, and any future additions under `assets/`, `textures/`, `audio/`, or `vendor/`—must be readable by CloudFront. The deploy workflow now **requires** a CloudFront Origin Access Identity (OAI) or Origin Access Control (OAC) and configures the S3 bucket with an `s3:GetObject` grant that is scoped to the identity/control and the relevant prefixes. Public ACLs and anonymous bucket policies are no longer permitted; the job fails if the distribution does not expose an OAI or OAC.
 
 To confirm nothing blocks the experience from loading:
 
-1. Run `aws s3api get-bucket-policy --bucket <bucket>` and ensure the `Principal` is the CloudFront OAI canonical user (for example `arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity E3ABC123`). The statement must only grant `s3:GetObject` to the explicit site bundles plus `assets/*`, `textures/*`, `audio/*`, and `vendor/*`.
+1. Run `aws s3api get-bucket-policy --bucket <bucket>` and ensure the `Principal` is either the CloudFront OAI canonical user (for example `arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity E3ABC123`) or the CloudFront service principal (`cloudfront.amazonaws.com`) with the expected `AWS:SourceArn` condition if you are using an OAC. The statement must only grant `s3:GetObject` to the explicit site bundles plus `assets/*`, `textures/*`, `audio/*`, and `vendor/*`.
 2. Run `node scripts/validate-asset-manifest.js` locally. The validator fails if any file under `assets/`, `textures/`, or `audio/` lacks world-readable permissions or if the deploy workflow omits a prefix.
 3. Pick a representative asset (for example `assets/steve.gltf` or `assets/audio-samples.json`) and fetch it anonymously through CloudFront: `curl -I https://<distribution-domain>/assets/steve.gltf`. A `200` response confirms CloudFront can reach the object.
 


### PR DESCRIPTION
## Summary
- detect CloudFront Origin Access Controls when configuring the deployment bucket
- generate the matching S3 bucket policy for either an OAC or OAI and surface the distribution in the summary
- document that the deploy workflow accepts an OAI or OAC for CloudFront access

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e26ebf4b44832b81dfdfa5a3eba2b8