### PR TITLE
Document mandatory CloudFront flush after deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ The script prints actionable errors when any check fails, including the offendin
 
 > **Always invalidate the CDN on every deploy.**
 >
-> Even when you ship manually (outside the GitHub Actions workflow), run a full CloudFront invalidation right after syncing the latest assets to S3 so browsers stop serving cached bundles. Skipping this step leaves stale JavaScript, CSS, or GLTF files in place and frequently manifests as missing HUD assets or boot-time script errors. Trigger the flush with:
+> Even when you ship manually (outside the GitHub Actions workflow), run a full CloudFront invalidation right after syncing the latest assets to S3 so browsers stop serving cached bundles. Skipping this step leaves stale JavaScript, CSS, or GLTF files in place, and often looks like missing HUD art, half-loaded geometry, or corrupted audio/textures because the browser pulled an outdated bundle from CloudFront. Always flush the distribution immediately after each sync to guarantee players download the refreshed build. Trigger the flush with:
 >
 > ```bash
 > aws cloudfront create-invalidation \

--- a/docs/cdn-permissions-runbook.md
+++ b/docs/cdn-permissions-runbook.md
@@ -112,7 +112,7 @@ When every request to `d3gj6x3ityfh5o.cloudfront.net/*.js` (or other static asse
 ## 6. Redeploy and invalidate
 
 1. After updating policies, wait for CloudFront to propagate the changes (or trigger a distribution update).
-2. Invalidate cached errors and always purge the distribution after each deploy so the latest bundles, textures, and GLTFs reach players immediately:
+2. Invalidate cached errors and always purge the distribution after each deploy so the latest bundles, textures, and GLTFs reach players immediately. Neglecting the flush leaves CloudFront serving stale or partially uploaded bundles, which shows up as missing UI chrome or corrupted geometry/audio on the next load. Trigger a full-path invalidation right after every S3 sync:
    ```bash
    aws cloudfront create-invalidation --distribution-id E1234567890 --paths "/*"
    ```


### PR DESCRIPTION
## Summary
- spell out that skipping the CloudFront invalidation after an S3 sync causes stale, missing, or corrupted bundles
- expand the CDN runbook with remediation guidance that calls for an immediate full-path invalidation

## Testing
- no tests were run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e28166f410832b8ae1d811c747178e