### PR TITLE
Enforce APP_CONFIG.assetBaseUrl consistency checks

### DIFF
--- a/tests/asset-base-enforcement.test.js
+++ b/tests/asset-base-enforcement.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { createBootstrapSandbox, evaluateBootstrapScript } from './helpers/bootstrap-test-utils.js';
+
+describe('asset base enforcement', () => {
+  it('throws when APP_CONFIG.assetBaseUrl disagrees with the derived deployment root', () => {
+    const { sandbox } = createBootstrapSandbox({
+      appConfig: { assetBaseUrl: 'https://cdn.example.com/bundles/' },
+    });
+
+    expect(() => evaluateBootstrapScript(sandbox)).toThrowError(
+      /APP_CONFIG\.assetBaseUrl mismatch detected between bundle metadata, asset-manifest\.json, and the active deployment/,
+    );
+  });
+
+  it('accepts matching asset bases after normalisation', () => {
+    const { sandbox, windowStub } = createBootstrapSandbox({
+      appConfig: { assetBaseUrl: 'https://example.com' },
+    });
+
+    expect(() => evaluateBootstrapScript(sandbox)).not.toThrow();
+    expect(windowStub.APP_CONFIG.assetBaseUrl).toBe('https://example.com/');
+  });
+});


### PR DESCRIPTION
## Summary
- abort bootstrap when APP_CONFIG.assetBaseUrl disagrees with the derived or production asset base, logging detailed context before throwing
- extend the asset base test suite to cover both mismatch enforcement and successful normalisation

## Testing
- npm test -- asset-base-enforcement

------
https://chatgpt.com/codex/tasks/task_e_68e2869a7b10832ba16ad88f2251b916