### PR TITLE
Enforce asset base alignment across bootstrap and manifest

### DIFF
--- a/asset-manifest.json
+++ b/asset-manifest.json
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "assetBaseUrl": "https://d3gj6x3ityfh5o.cloudfront.net/",
   "assets": [
     "index.html?v=4d386d0878e0",
     "styles.css?v=5cd08e365733",


### PR DESCRIPTION
## Summary
- add the production CloudFront asset base URL to asset-manifest.json
- validate that the manifest asset base matches the bootstrap constant and provided HEAD targets
- extend the deployment workflow tests to assert manifest/bootstrap asset base alignment

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e28d6ad540832b8b5eeb098626014b