### PR TITLE
Add configurable signed URL expiry monitoring window

### DIFF
--- a/asset-resolver.js
+++ b/asset-resolver.js
@@ -15,7 +15,7 @@
   const assetWarningDeduper = new Set();
   const signedUrlExpiryChecks = new Set();
 
-  const SIGNED_URL_IMMINENT_EXPIRY_WINDOW_MS = 24 * 60 * 60 * 1000;
+  const DEFAULT_SIGNED_URL_WARNING_WINDOW_MS = 24 * 60 * 60 * 1000;
   const SIGNED_URL_ALERT_EVENT = 'infinite-rails:signed-url-expiry';
 
   const DEFAULT_ASSET_VERSION_TAG = '1';
@@ -355,11 +355,15 @@
       return;
     }
 
+    const warningWindowMs = resolveSignedUrlWarningWindowMs();
+
     const context = {
       assetBaseUrl: typeof rawBaseUrl === 'string' ? rawBaseUrl : null,
       candidateUrl: typeof resolvedUrl === 'string' ? resolvedUrl : parsed.href,
       relativePath: relativePath ?? null,
+      warningWindowMs,
       expiresAtIso: Number.isFinite(analysis.expiresAt) ? new Date(analysis.expiresAt).toISOString() : null,
+      expiresAtEpochMs: Number.isFinite(analysis.expiresAt) ? analysis.expiresAt : null,
       expirySource: analysis.expirySource,
     };
 
@@ -388,7 +392,7 @@
       return;
     }
 
-    if (remainingMs <= SIGNED_URL_IMMINENT_EXPIRY_WINDOW_MS) {
+    if (remainingMs <= warningWindowMs) {
       context.severity = 'warning';
       logAssetIssue(
         'Signed asset URL expires soon; rotate credentials or refresh APP_CONFIG.assetBaseUrl to avoid CDN outages.',
@@ -564,4 +568,26 @@
       module.exports.__esModule = true;
     }
   }
+  function resolveSignedUrlWarningWindowMs() {
+    const config = scope?.APP_CONFIG && typeof scope.APP_CONFIG === 'object' ? scope.APP_CONFIG : null;
+    const rawValue = config ? config.signedUrlWarningWindowMs : undefined;
+    if (rawValue === null || rawValue === undefined) {
+      return DEFAULT_SIGNED_URL_WARNING_WINDOW_MS;
+    }
+
+    const numeric = Number(rawValue);
+    if (Number.isFinite(numeric) && numeric > 0) {
+      return numeric;
+    }
+
+    logAssetIssue(
+      'Invalid signed URL warning window configuration; falling back to default (24h). Provide APP_CONFIG.signedUrlWarningWindowMs as a positive millisecond duration.',
+      null,
+      { configuredValue: rawValue },
+    );
+
+    return DEFAULT_SIGNED_URL_WARNING_WINDOW_MS;
+  }
+
 })();
+


### PR DESCRIPTION
## Summary
- extend signed URL monitoring context to include expiry timestamps and configurable warning window metadata
- expose a configurable `APP_CONFIG.signedUrlWarningWindowMs` override with validation in both resolver builds
- update signed URL monitoring tests to assert event payload details and custom window handling

## Testing
- npm test -- signed-url-expiry-monitoring
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2a45e5014832bbba7b5564ae59f5d