### PR TITLE
Add renderer startup circuit breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Touch-first devices automatically fall back to the sandbox renderer unless you e
 The sandbox keeps the portal-building brief front-and-centre while the production renderer continues to mature. Flip the flags
 above whenever you want to regression-test the work-in-progress advanced build without losing the reliable sandbox.
 
+An automatic “safe mode” circuit breaker now guards the boot sequence: if the advanced renderer fails to emit its start signal within five seconds, the watchdog logs the timeout and relaunches the simplified sandbox. Overriding `APP_CONFIG.rendererStartTimeoutMs` still allows deployments to extend or reduce that window when necessary.
+
 ### Troubleshooting
 
 #### White screen or blank viewport

--- a/script.js
+++ b/script.js
@@ -11220,7 +11220,7 @@
     }
   }
 
-  const DEFAULT_RENDERER_START_TIMEOUT_MS = 12000;
+  const DEFAULT_RENDERER_START_TIMEOUT_MS = 5000;
   let simpleFallbackAttempted = false;
   let rendererStartWatchdogHandle = null;
   let rendererStartWatchdogMode = null;
@@ -11566,7 +11566,7 @@
         return;
       }
       const warningMessage =
-        'Advanced renderer start timed out — switching to the simplified sandbox.';
+        'Advanced renderer start timed out — enabling safe mode (simplified sandbox).';
       if (globalScope?.console?.warn) {
         globalScope.console.warn(warningMessage);
       }


### PR DESCRIPTION
## Summary
- shorten the renderer watchdog default to five seconds so the sandbox safe mode auto-launches on stalled boots
- update the watchdog warning message to call out safe mode activation
- document the new circuit breaker behaviour in the renderer selection guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e32d1d2934832b94826bd8a213ecce