### PR TITLE
Add manifest digest sync helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ This repository ships with a GitHub Actions workflow that deploys the static sit
 
 The manifest lives at the repository root (`asset-manifest.json`) and serves as the canonical checklist of production assets. Update it whenever you add or retire a runtime bundle, vendor shim, or static asset that must ship with the experience. The deployment tests and workflow both fail fast if the manifest is missing entries or points at non-existent files.
 
+When you update any bundled asset (for example `script.js` or `simple-experience.js`), run `npm run sync:asset-digests` to regenerate the cache-busting `?v=` values in the manifest. This keeps the asset digests aligned with the on-disk files so the pre-release checks and deploy workflow stay green.
+
 Run `node scripts/validate-asset-manifest.js` before publishing to ensure nothing falls through the cracks. Pass `--base-url https://<domain>/` (or set `ASSET_MANIFEST_BASE_URL`) so the validator can issue anonymous `HEAD` requests against every entry. The command now verifies four buckets:
 
 1. Every manifest entry maps to a file on disk.

--- a/asset-manifest.json
+++ b/asset-manifest.json
@@ -4,9 +4,9 @@
   "assets": [
     "index.html?v=4d386d0878e0",
     "styles.css?v=5cd08e365733",
-    "script.js?v=fb968d683e66",
+    "script.js?v=5d66644c80f6",
     "test-driver.js?v=0074c367d97c",
-    "simple-experience.js?v=16cf347ee035",
+    "simple-experience.js?v=73ab0dbdb8d1",
     "asset-resolver.js?v=388f0ca33542",
     "audio-aliases.js?v=8db3f846ecb9",
     "audio-captions.js?v=101e375dcd9e",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:e2e": "node tests/e2e-check.js",
     "check:manifest": "node scripts/check-manifest.js",
     "check:assets": "node scripts/validate-asset-manifest.js",
+    "sync:asset-digests": "node scripts/update-asset-digests.js",
     "build:vendor:three": "node scripts/build-three.js",
     "test:unit": "vitest run",
     "test:pre-release": "node scripts/run-pre-release-checks.js",

--- a/scripts/update-asset-digests.js
+++ b/scripts/update-asset-digests.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  loadManifest,
+  computeAssetDigest,
+} = require('./validate-asset-manifest.js');
+
+const repoRoot = path.resolve(__dirname, '..');
+const manifestPath = path.join(repoRoot, 'asset-manifest.json');
+
+function rewriteAssetReference(entry, digest) {
+  const params = new URLSearchParams(entry.query || '');
+  params.delete('v');
+  params.append('v', digest);
+  const query = params.toString();
+  return query ? `${entry.path}?${query}` : entry.path;
+}
+
+function ensureManifestDigests() {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const { entries } = loadManifest();
+
+  const updates = [];
+  entries.forEach((entry, index) => {
+    const fullPath = path.join(repoRoot, entry.path);
+    let stats;
+    try {
+      stats = fs.statSync(fullPath);
+    } catch (error) {
+      return;
+    }
+
+    if (!stats.isFile()) {
+      return;
+    }
+
+    const digest = computeAssetDigest(fullPath);
+    if (entry.version === digest) {
+      return;
+    }
+
+    const originalVersion = entry.version;
+    manifest.assets[index] = rewriteAssetReference(entry, digest);
+    updates.push({
+      asset: entry.path,
+      from: originalVersion,
+      to: digest,
+    });
+  });
+
+  if (updates.length === 0) {
+    console.log('asset-manifest.json digests already match on-disk assets.');
+    return;
+  }
+
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  console.log('Updated asset-manifest.json digests:');
+  for (const update of updates) {
+    const fromValue = update.from ? `v=${update.from}` : 'missing digest';
+    console.log(` • ${update.asset}: ${fromValue} → v=${update.to}`);
+  }
+
+  console.log('\nReview and commit asset-manifest.json before publishing.');
+}
+
+function main() {
+  try {
+    ensureManifestDigests();
+  } catch (error) {
+    console.error(error.message || error);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { ensureManifestDigests };

--- a/scripts/validate-asset-manifest.js
+++ b/scripts/validate-asset-manifest.js
@@ -707,7 +707,9 @@ async function main() {
           }
         })
         .join('; ');
-      issues.push(`Manifest asset hashes are outdated: ${formatted}`);
+      issues.push(
+        `Manifest asset hashes are outdated: ${formatted}. Run \`npm run sync:asset-digests\` to refresh the digests.`,
+      );
     }
     if (headValidationBase && headFailures.length > 0) {
       const formatted = headFailures
@@ -762,4 +764,6 @@ module.exports = {
   listUncoveredAssets,
   resolveBaseUrl,
   listFailedHeadRequests,
+  computeAssetDigest,
+  parseManifestAsset,
 };


### PR DESCRIPTION
## Summary
- add a CLI helper to recalculate asset-manifest digests and expose it via `npm run sync:asset-digests`
- surface guidance in the README and asset validator when digests drift
- refresh the manifest with the latest script bundle hashes

## Testing
- npm run sync:asset-digests
- npm run test:pre-release *(fails: Vitest suite still reports missing Three.js/web assets in the headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3427dbd10832bbbe84b9e73732705