### PR TITLE
Fix tests for async bootstrap module loader

### DIFF
--- a/tests/renderer-three-init.test.js
+++ b/tests/renderer-three-init.test.js
@@ -359,7 +359,7 @@ describe('default renderer Three.js bootstrap', () => {
   });
 
   it('awaits ensureThree before bootstrapping the experience', () => {
-    expect(scriptSource).toMatch(/ensureThree\(\)\s*\.then\(\(\) => {\s*bootstrap\(\);\s*}\)/);
+    expect(scriptSource).toMatch(/ensureThree\(\)\s*\.then\(\(\) => {\s*[\s\S]*?bootstrap\(/);
   });
 
   it('simple experience pulls THREE from the guarded global scope', () => {

--- a/tests/simple-experience-terrain.test.js
+++ b/tests/simple-experience-terrain.test.js
@@ -63,6 +63,8 @@ beforeAll(() => {
   };
 
   Object.assign(windowStub, { THREE, THREE_GLOBAL: THREE, document: documentStub });
+  globalThis.THREE_GLOBAL = THREE;
+  globalThis.THREE = THREE;
   windowStub.WebGL2RenderingContext = globalThis.WebGL2RenderingContext;
 
   if (typeof globalThis.CustomEvent !== 'function') {


### PR DESCRIPTION
## Summary
- relax the bootstrap sequencing assertion so it permits async bootstrap helpers
- prime the terrain test harness with THREE globals now that the renderer reads from globalThis
- run the vitest suite to confirm everything passes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e343b8a51c832b8fd7175b41b1c156