### PR TITLE
Auto-sync asset digests during pre-release checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ This repository ships with a GitHub Actions workflow that deploys the static sit
 
 The manifest lives at the repository root (`asset-manifest.json`) and serves as the canonical checklist of production assets. Update it whenever you add or retire a runtime bundle, vendor shim, or static asset that must ship with the experience. The deployment tests and workflow both fail fast if the manifest is missing entries or points at non-existent files.
 
-When you update any bundled asset (for example `script.js` or `simple-experience.js`), run `npm run sync:asset-digests` to regenerate the cache-busting `?v=` values in the manifest. This keeps the asset digests aligned with the on-disk files so the pre-release checks and deploy workflow stay green.
+When you update any bundled asset (for example `script.js` or `simple-experience.js`), run `npm run sync:asset-digests` to regenerate the cache-busting `?v=` values in the manifest. The pre-release gate (`npm run test:pre-release`) now runs this sync automatically before validating the manifest, so you can simply execute the gate and commit the refreshed manifest alongside your asset changes.
 
 Run `node scripts/validate-asset-manifest.js` before publishing to ensure nothing falls through the cracks. Pass `--base-url https://<domain>/` (or set `ASSET_MANIFEST_BASE_URL`) so the validator can issue anonymous `HEAD` requests against every entry. The command now verifies four buckets:
 

--- a/asset-manifest.json
+++ b/asset-manifest.json
@@ -4,7 +4,7 @@
   "assets": [
     "index.html?v=4d386d0878e0",
     "styles.css?v=5cd08e365733",
-    "script.js?v=5d66644c80f6",
+    "script.js?v=f5960159752b",
     "test-driver.js?v=0074c367d97c",
     "simple-experience.js?v=73ab0dbdb8d1",
     "asset-resolver.js?v=388f0ca33542",

--- a/scripts/run-pre-release-checks.js
+++ b/scripts/run-pre-release-checks.js
@@ -8,6 +8,11 @@ const { spawnSync } = require('node:child_process');
 
 const checks = [
   {
+    label: 'Asset digest sync',
+    command: 'npm',
+    args: ['run', 'sync:asset-digests'],
+  },
+  {
     label: 'Asset manifest validation',
     command: 'npm',
     args: ['run', 'check:assets'],


### PR DESCRIPTION
## Summary
- run the asset digest synchronisation script before manifest validation in the pre-release gate
- document that npm run test:pre-release now refreshes manifest digests automatically
- update asset-manifest.json with the latest script.js hash

## Testing
- npm run test:pre-release

------
https://chatgpt.com/codex/tasks/task_e_68e34995e3f8832b869c726321a7e121