### PR TITLE
Add sandbox self-healing when advanced renderer fails

### DIFF
--- a/tests/renderer-mode-selection.test.js
+++ b/tests/renderer-mode-selection.test.js
@@ -698,7 +698,14 @@ describe('renderer mode selection', () => {
       const result = tryStartSimpleFallback(null, { reason: 'renderer-failure', mode: 'advanced' });
       expect(result).toBe(true);
       expect(showLoading).toHaveBeenCalledWith(
-        expect.objectContaining({ message: expect.stringContaining('simplified renderer fallback') }),
+        expect.objectContaining({ message: expect.stringContaining('sandbox mode') }),
+      );
+      expect(scope.bootstrapOverlay.setDiagnostic).toHaveBeenCalledWith(
+        'renderer',
+        expect.objectContaining({
+          status: 'warning',
+          message: expect.stringContaining('sandbox'),
+        }),
       );
       expect(replaceState).toHaveBeenCalledTimes(1);
       const parsed = new URL(scope.location.href);


### PR DESCRIPTION
## Summary
- centralise simple fallback messaging so advanced renderer failures switch to sandbox mode with diagnostics
- surface sandbox fallback status on the bootstrap overlay and warn when the renderer boundary trips
- adjust renderer mode selection tests to expect the sandbox self-healing copy

## Testing
- npm test -- renderer-mode-selection

------
https://chatgpt.com/codex/tasks/task_e_68e36bda981c832b9f15963d0040810e