### PR TITLE
Improve pointer lock recovery and status messaging

### DIFF
--- a/tests/simple-experience-input-handlers.test.js
+++ b/tests/simple-experience-input-handlers.test.js
@@ -132,4 +132,20 @@ describe('simple experience input handlers', () => {
     expect(mozRequestPointerLock.mock.calls[1].length).toBe(0);
     expect(fallbackSpy).not.toHaveBeenCalled();
   });
+
+  it('attempts to recover pointer lock when Escape is pressed', () => {
+    const { experience } = createInputTestExperience();
+    experience.pointerLocked = false;
+    experience.pointerLockFallbackActive = false;
+    experience.getPointerLockElement = vi.fn(() => null);
+    vi.spyOn(experience, 'toggleCraftingModal').mockImplementation(() => {});
+    vi.spyOn(experience, 'toggleInventoryModal').mockImplementation(() => {});
+    vi.spyOn(experience, 'toggleGuideModal').mockImplementation(() => {});
+    const recoverySpy = vi.spyOn(experience, 'attemptPointerLockRecovery').mockReturnValue(false);
+    const event = { code: 'Escape', preventDefault: vi.fn(), repeat: false };
+
+    experience.handleKeyDown(event);
+
+    expect(recoverySpy).toHaveBeenCalledWith('keyboard-escape');
+  });
 });


### PR DESCRIPTION
## Summary
- add pointer lock release messaging, blocked overlay handling, and pointer hint retry wiring to surface capture failures
- attempt pointer lock recovery from Escape interactions and clear blocked state when other hints appear
- cover the Escape-triggered recovery flow with a new unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e39744de08832baff9448b77ff1776