### PR TITLE
Add declarative control map with runtime API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,6 +141,7 @@ jobs:
             --include "test-driver.js" \
             --include "script.js" \
             --include "simple-experience.js" \
+            --include "controls.config.js" \
             --include "portal-mechanics.js" \
             --include "scoreboard-utils.js" \
             --include "assets/**" \

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ Capturing console logs and the exact build SHA alongside these steps will accele
 | Desktop | `WASD` / arrow keys to move, `Space` to jump, `F` interact/use, `Q` place blocks, `R` ignite portal, `E` crafting, `I` inventory, `T` reset position, `V` toggle view, `F1` guide, `F2` settings, `F3` leaderboard, `1–0` hotbar slots |
 | Mobile | Swipe to move between rails, tap/hold to mine or place, tap the action buttons for crafting and portals |
 
-Desktop key bindings now live in a centralised map with sensible defaults (WASD and the arrow keys for movement). Players can remap every control from the in-game **Settings → Key bindings** panel, or you can provide overrides via configuration or at runtime:
+Desktop key bindings now live in the declarative `controls.config.js` file. Edit that config to change the defaults that ship with your build—every action is listed in one place with the same WASD/arrow conventions. Players can still remap controls from the in-game **Settings → Key bindings** panel, and you can override or update the map via configuration or at runtime:
 
 ```html
 <script>
   window.APP_CONFIG = {
-    keyBindings: {
+    controlMap: {
       moveForward: ['KeyI', 'ArrowUp'],
       interact: ['KeyE'],
       hotbar1: ['Digit1', 'Numpad1'],
@@ -161,7 +161,20 @@ experience.setKeyBindings({ moveForward: ['KeyI'], moveBackward: ['KeyK'] });
 experience.resetKeyBindings();
 ```
 
-The advanced renderer exposes the same helpers on `window.InfiniteRails` once `script.js` boots. Call them at runtime to tweak bindings without reloading:
+At runtime you can also swap the declarative map without reloading. The bootstrapper exposes a shared API on `window.InfiniteRailsControls` (mirrored on `window.SimpleExperience.controlMap`) so hotkey changes propagate immediately to both renderers:
+
+```js
+// Merge in an alternate map and refresh active experiences
+window.InfiniteRailsControls.apply({
+  moveForward: ['ArrowUp'],
+  moveBackward: ['ArrowDown'],
+});
+
+// Reset to the defaults from controls.config.js
+window.InfiniteRailsControls.reset();
+```
+
+The advanced renderer exposes the existing instance helpers on `window.InfiniteRails` once `script.js` boots. Use either the per-instance methods or the global control-map API to tweak bindings without reloading:
 
 ```js
 window.InfiniteRails.setKeyBinding('interact', ['KeyG']);

--- a/asset-manifest.json
+++ b/asset-manifest.json
@@ -4,6 +4,7 @@
   "assets": [
     "index.html?v=4d386d0878e0",
     "styles.css?v=5cd08e365733",
+    "controls.config.js?v=1",
     "script.js?v=f5960159752b",
     "test-driver.js?v=0074c367d97c",
     "simple-experience.js?v=73ab0dbdb8d1",

--- a/controls.config.js
+++ b/controls.config.js
@@ -1,0 +1,172 @@
+(function initialiseDeclarativeControlMap(scope) {
+  const CONTROL_MAP_GLOBAL_KEY = '__INFINITE_RAILS_CONTROL_MAP__';
+  const CONTROL_MAP_READY_EVENT = 'infinite-rails:control-map-ready';
+  const CONTROL_MAP_CHANGED_EVENT = 'infinite-rails:control-map-changed';
+
+  if (!scope) {
+    return;
+  }
+
+  function createDefaultControlMap() {
+    const map = {
+      moveForward: ['KeyW', 'ArrowUp'],
+      moveBackward: ['KeyS', 'ArrowDown'],
+      moveLeft: ['KeyA', 'ArrowLeft'],
+      moveRight: ['KeyD', 'ArrowRight'],
+      jump: ['Space'],
+      interact: ['KeyF'],
+      buildPortal: ['KeyR'],
+      resetPosition: ['KeyT'],
+      placeBlock: ['KeyQ'],
+      toggleCameraPerspective: ['KeyV'],
+      toggleCrafting: ['KeyE'],
+      toggleInventory: ['KeyI'],
+      openGuide: ['F1'],
+      toggleTutorial: ['Slash', 'F4'],
+      toggleDeveloperOverlay: ['Backquote', 'F8'],
+      openSettings: ['F2'],
+      openLeaderboard: ['F3'],
+      closeMenus: ['Escape'],
+    };
+    for (let slot = 1; slot <= 10; slot += 1) {
+      const digit = slot % 10;
+      map[`hotbar${slot}`] = [`Digit${digit}`, `Numpad${digit}`];
+    }
+    return map;
+  }
+
+  function cloneControlMap(source = {}) {
+    const clone = {};
+    Object.entries(source).forEach(([action, keys]) => {
+      if (!Array.isArray(keys)) {
+        return;
+      }
+      clone[action] = keys.map((value) => (typeof value === 'string' ? value : String(value ?? '').trim()))
+        .filter((value) => value && typeof value === 'string');
+    });
+    return clone;
+  }
+
+  function normaliseKeyBindingValue(value) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed ? [trimmed] : [];
+    }
+    if (Array.isArray(value)) {
+      const seen = new Set();
+      const result = [];
+      value.forEach((entry) => {
+        if (typeof entry !== 'string') {
+          return;
+        }
+        const trimmed = entry.trim();
+        if (!trimmed || seen.has(trimmed)) {
+          return;
+        }
+        seen.add(trimmed);
+        result.push(trimmed);
+      });
+      return result;
+    }
+    return [];
+  }
+
+  function normaliseControlMap(source) {
+    if (!source || typeof source !== 'object') {
+      return null;
+    }
+    const result = {};
+    Object.entries(source).forEach(([action, value]) => {
+      const keys = normaliseKeyBindingValue(value);
+      if (keys.length) {
+        result[action] = keys;
+      }
+    });
+    return Object.keys(result).length ? result : null;
+  }
+
+  function ensureAppConfig(target) {
+    if (!target) {
+      return null;
+    }
+    if (target.APP_CONFIG && typeof target.APP_CONFIG === 'object') {
+      return target.APP_CONFIG;
+    }
+    if (target.APP_CONFIG === undefined) {
+      try {
+        target.APP_CONFIG = {};
+        return target.APP_CONFIG;
+      } catch (error) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  function dispatchControlMapEvent(type, map) {
+    if (typeof scope.dispatchEvent !== 'function') {
+      return;
+    }
+    const EventCtor =
+      typeof scope.CustomEvent === 'function'
+        ? scope.CustomEvent
+        : typeof CustomEvent === 'function'
+          ? CustomEvent
+          : null;
+    if (!EventCtor) {
+      return;
+    }
+    try {
+      scope.dispatchEvent(new EventCtor(type, { detail: { map: cloneControlMap(map) } }));
+    } catch (error) {
+      // Ignore dispatch failures in non-DOM environments.
+    }
+  }
+
+  const existing =
+    normaliseControlMap(scope[CONTROL_MAP_GLOBAL_KEY]) ||
+    normaliseControlMap(scope.APP_CONFIG && scope.APP_CONFIG.controlMap) ||
+    normaliseControlMap(scope.APP_CONFIG && scope.APP_CONFIG.keyBindings);
+
+  const initialMap = cloneControlMap(existing || createDefaultControlMap());
+  scope[CONTROL_MAP_GLOBAL_KEY] = initialMap;
+  const appConfig = ensureAppConfig(scope);
+  if (appConfig) {
+    appConfig.controlMap = initialMap;
+  }
+
+  dispatchControlMapEvent(CONTROL_MAP_READY_EVENT, initialMap);
+
+  function applyControlMap(update, options = {}) {
+    const { merge = true, notify = true } = options ?? {};
+    const normalised = normaliseControlMap(update);
+    if (!normalised) {
+      return null;
+    }
+    const base = merge ? cloneControlMap(scope[CONTROL_MAP_GLOBAL_KEY] || initialMap) : {};
+    Object.entries(normalised).forEach(([action, keys]) => {
+      base[action] = [...keys];
+    });
+    scope[CONTROL_MAP_GLOBAL_KEY] = base;
+    if (appConfig) {
+      appConfig.controlMap = base;
+    }
+    if (notify) {
+      dispatchControlMapEvent(CONTROL_MAP_CHANGED_EVENT, base);
+    }
+    return cloneControlMap(base);
+  }
+
+  const api = {
+    get: () => cloneControlMap(scope[CONTROL_MAP_GLOBAL_KEY] || initialMap),
+    apply: (map, options) => applyControlMap(map, options),
+    reset: (options = {}) => applyControlMap(createDefaultControlMap(), { ...options, merge: false }),
+    defaults: () => cloneControlMap(createDefaultControlMap()),
+  };
+
+  if (!scope.InfiniteRailsControls || typeof scope.InfiniteRailsControls !== 'object') {
+    scope.InfiniteRailsControls = api;
+  } else {
+    Object.assign(scope.InfiniteRailsControls, api);
+  }
+})(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null);

--- a/index.html
+++ b/index.html
@@ -1672,6 +1672,7 @@
       </div>
     </div>
 
+    <script src="controls.config.js"></script>
     <script>
       (function setupBootstrapFallback() {
         var doc = document;

--- a/tests/keybindings-defaults.test.js
+++ b/tests/keybindings-defaults.test.js
@@ -245,6 +245,24 @@ describe('simple experience key remapping', () => {
       experience.destroy();
     }
   });
+
+  it('applies declarative control map updates at runtime', () => {
+    const { experience } = createSimpleExperienceInstance();
+    expect(experience.getKeyBindings().jump).toEqual(['Space']);
+
+    const applied = window.SimpleExperience.controlMap.apply({ jump: ['KeyJ'] });
+    expect(applied).not.toBeNull();
+    expect(window.SimpleExperience.controlMap.get().jump).toEqual(['KeyJ']);
+    expect(experience.getKeyBindings().jump).toEqual(['KeyJ']);
+
+    window.SimpleExperience.controlMap.reset();
+    expect(window.SimpleExperience.controlMap.get().jump).toEqual(['Space']);
+    expect(experience.getKeyBindings().jump).toEqual(['Space']);
+
+    if (typeof experience.destroy === 'function') {
+      experience.destroy();
+    }
+  });
 });
 
 afterAll(() => {


### PR DESCRIPTION
## Summary
- add a declarative controls.config.js bootstrap that seeds and exposes the global control map API
- update SimpleExperience/script bootstrap to consume the shared map, notify listeners, and surface runtime update helpers
- document the workflow, include the new asset in deployment manifests, and cover runtime map updates in tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3a1b44c20832baf6e2ee3d2ec6692