### PR TITLE
Ensure control defaults mirror declarative config map

### DIFF
--- a/script.js
+++ b/script.js
@@ -9190,12 +9190,18 @@
         moveRight: ['KeyD', 'ArrowRight'],
         jump: ['Space'],
         interact: ['KeyF'],
+        buildPortal: ['KeyR'],
+        resetPosition: ['KeyT'],
         placeBlock: ['KeyQ'],
+        toggleCameraPerspective: ['KeyV'],
         toggleCrafting: ['KeyE'],
+        toggleInventory: ['KeyI'],
         openGuide: ['F1'],
+        toggleTutorial: ['Slash', 'F4'],
+        toggleDeveloperOverlay: ['Backquote', 'F8'],
         openSettings: ['F2'],
         openLeaderboard: ['F3'],
-        buildPortal: ['KeyR'],
+        closeMenus: ['Escape'],
       };
       for (let index = 1; index <= HOTBAR_SLOT_COUNT; index += 1) {
         const digit = index % 10;
@@ -9307,12 +9313,18 @@
       moveRight: ['KeyD', 'ArrowRight'],
       jump: ['Space'],
       interact: ['KeyF'],
+      buildPortal: ['KeyR'],
+      resetPosition: ['KeyT'],
       placeBlock: ['KeyQ'],
+      toggleCameraPerspective: ['KeyV'],
       toggleCrafting: ['KeyE'],
+      toggleInventory: ['KeyI'],
       openGuide: ['F1'],
+      toggleTutorial: ['Slash', 'F4'],
+      toggleDeveloperOverlay: ['Backquote', 'F8'],
       openSettings: ['F2'],
       openLeaderboard: ['F3'],
-      buildPortal: ['KeyR'],
+      closeMenus: ['Escape'],
     };
     for (let index = 1; index <= HOTBAR_SLOT_COUNT; index += 1) {
       const digit = index % 10;


### PR DESCRIPTION
## Summary
- align the bootstrap fallback key bindings with the declarative control map so every action shares the same defaults
- add regression coverage that loads controls.config.js and asserts the simple experience defaults stay synchronised with the shared map

## Testing
- npx vitest run tests/keybindings-defaults.test.js --reporter verbose

------
https://chatgpt.com/codex/tasks/task_e_68e3c3190b40832b98f4a97471aa63b7