### PR TITLE
Add inactivity monitor overlay and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -1617,6 +1617,42 @@
 
     <div
       class="compose-overlay compose-overlay--global"
+      id="inactivityOverlay"
+      hidden
+      inert
+      data-mode="idle"
+      aria-live="assertive"
+    >
+      <div
+        class="compose-overlay__dialog"
+        id="inactivityOverlayDialog"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby="inactivityOverlayTitle"
+        aria-describedby="inactivityOverlayMessage"
+      >
+        <div class="compose-overlay__body">
+          <h3 class="compose-overlay__title" id="inactivityOverlayTitle">Still exploring?</h3>
+          <p class="compose-overlay__message" id="inactivityOverlayMessage">
+            You have been idle for a while. The world will refresh in
+            <span id="inactivityOverlayCountdown" aria-live="polite">0</span>
+            seconds to keep the rails stable.
+          </p>
+          <div class="compose-overlay__actions">
+            <button type="button" class="ghost compose-overlay__action" id="inactivityStayButton">
+              Continue Playing
+            </button>
+            <button type="button" class="accent compose-overlay__action" id="inactivityRefreshButton">
+              Refresh World
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      class="compose-overlay compose-overlay--global"
       id="globalOverlay"
       hidden
       inert

--- a/styles.css
+++ b/styles.css
@@ -4446,6 +4446,13 @@ body.sidebar-open .player-hint {
   color: var(--text-secondary);
 }
 
+#inactivityOverlayCountdown {
+  display: inline-block;
+  min-width: 1.5ch;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
 .bootstrap-status {
   width: 100%;
   border-radius: 12px;

--- a/tests/bootstrap-inactivity-monitor.test.js
+++ b/tests/bootstrap-inactivity-monitor.test.js
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createBootstrapSandbox, evaluateBootstrapScript } from './helpers/bootstrap-test-utils.js';
+
+function runTimer(timers, id) {
+  const handler = timers.get(id);
+  expect(typeof handler).toBe('function');
+  timers.delete(id);
+  handler();
+}
+
+describe('bootstrap inactivity monitor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prompts after inactivity and dismisses when activity resumes', () => {
+    const { sandbox, windowStub, documentStub, timers } = createBootstrapSandbox();
+    windowStub.__INFINITE_RAILS_TEST_SKIP_BOOTSTRAP__ = true;
+    evaluateBootstrapScript(sandbox);
+
+    const hooks = windowStub.__INFINITE_RAILS_TEST_HOOKS__;
+    hooks.setupInactivityOverlay();
+    hooks.configureInactivityMonitor({ idleThresholdMs: 1000, refreshCountdownMs: 5000, checkIntervalMs: 200 });
+
+    const overlay = documentStub.getElementById('inactivityOverlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay.hidden).toBe(true);
+
+    hooks.setInactivityLastActivity(Date.now() - 1100);
+    let state = hooks.getInactivityMonitorState();
+    if (state.checkHandle) {
+      runTimer(timers, state.checkHandle);
+      state = hooks.getInactivityMonitorState();
+    }
+
+    expect(overlay.hidden).toBe(false);
+    expect(overlay.getAttribute('data-mode')).toBe('prompt');
+    expect(documentStub.body.classList.add).toHaveBeenCalledWith('hud-inactive');
+
+    const countdown = documentStub.getElementById('inactivityOverlayCountdown');
+    expect(countdown.textContent).toBe('5');
+
+    const stayButton = documentStub.getElementById('inactivityStayButton');
+    const stayCall = stayButton.addEventListener.mock.calls.find(([type]) => type === 'click');
+    expect(stayCall).toBeDefined();
+    const stayHandler = stayCall[1];
+    stayHandler({ preventDefault: vi.fn() });
+
+    expect(overlay.hidden).toBe(true);
+    expect(documentStub.body.classList.remove).toHaveBeenCalledWith('hud-inactive');
+
+    // run any pending timers to ensure they are cleared
+    state = hooks.getInactivityMonitorState();
+    if (state.countdownHandle) {
+      timers.delete(state.countdownHandle);
+    }
+  });
+
+  it('refreshes the renderer when the inactivity countdown elapses', () => {
+    const { sandbox, windowStub, documentStub, timers } = createBootstrapSandbox();
+    windowStub.__INFINITE_RAILS_TEST_SKIP_BOOTSTRAP__ = true;
+    evaluateBootstrapScript(sandbox);
+
+    const hooks = windowStub.__INFINITE_RAILS_TEST_HOOKS__;
+    hooks.setupInactivityOverlay();
+    const reloadSpy = vi
+      .spyOn(windowStub.InfiniteRails.renderers, 'reloadActive')
+      .mockResolvedValue(undefined);
+
+    hooks.configureInactivityMonitor({
+      idleThresholdMs: 1500,
+      refreshCountdownMs: 1000,
+      checkIntervalMs: 200,
+    });
+    hooks.setInactivityLastActivity(Date.now() - 5000);
+    let state = hooks.getInactivityMonitorState();
+    if (state.checkHandle) {
+      runTimer(timers, state.checkHandle);
+      state = hooks.getInactivityMonitorState();
+    }
+
+    const overlay = documentStub.getElementById('inactivityOverlay');
+    expect(overlay.hidden).toBe(false);
+    expect(state.countdownHandle).toBeTruthy();
+
+    const previousActivity = state.lastActivityAt;
+    hooks.forceInactivityRefresh('test');
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledWith({ reason: 'inactivity-test' });
+    expect(overlay.hidden).toBe(true);
+    expect(documentStub.body.classList.remove).toHaveBeenCalledWith('hud-inactive');
+    const finalState = hooks.getInactivityMonitorState();
+    expect(finalState.promptVisible).toBe(false);
+    expect(finalState.lastActivityAt).toBeGreaterThan(previousActivity);
+  });
+});

--- a/tests/helpers/bootstrap-test-utils.js
+++ b/tests/helpers/bootstrap-test-utils.js
@@ -170,6 +170,49 @@ export function createBootstrapSandbox(options = {}) {
   inputOverlay.setAttribute('id', 'inputOverlay');
   documentStub.body.appendChild(inputOverlay);
 
+  const inactivityOverlay = createElement('div', { ownerDocument: documentStub });
+  inactivityOverlay.className = 'compose-overlay compose-overlay--global';
+  inactivityOverlay.setAttribute('id', 'inactivityOverlay');
+  inactivityOverlay.setAttribute('data-mode', 'idle');
+  inactivityOverlay.setAttribute('hidden', '');
+  inactivityOverlay.hidden = true;
+
+  const inactivityDialog = createElement('div', { ownerDocument: documentStub });
+  inactivityDialog.className = 'compose-overlay__dialog';
+  inactivityDialog.setAttribute('id', 'inactivityOverlayDialog');
+  const inactivityBody = createElement('div', { ownerDocument: documentStub });
+  inactivityBody.className = 'compose-overlay__body';
+
+  const inactivityTitle = createElement('h3', { ownerDocument: documentStub });
+  inactivityTitle.className = 'compose-overlay__title';
+  inactivityTitle.setAttribute('id', 'inactivityOverlayTitle');
+  inactivityBody.appendChild(inactivityTitle);
+
+  const inactivityMessage = createElement('p', { ownerDocument: documentStub });
+  inactivityMessage.className = 'compose-overlay__message';
+  inactivityMessage.setAttribute('id', 'inactivityOverlayMessage');
+  const countdownValue = createElement('span', { ownerDocument: documentStub });
+  countdownValue.setAttribute('id', 'inactivityOverlayCountdown');
+  countdownValue.textContent = '0';
+  inactivityMessage.appendChild(countdownValue);
+  inactivityBody.appendChild(inactivityMessage);
+
+  const inactivityActions = createElement('div', { ownerDocument: documentStub });
+  inactivityActions.className = 'compose-overlay__actions';
+  const stayButton = createElement('button', { ownerDocument: documentStub });
+  stayButton.setAttribute('id', 'inactivityStayButton');
+  stayButton.textContent = 'Continue';
+  const refreshButton = createElement('button', { ownerDocument: documentStub });
+  refreshButton.setAttribute('id', 'inactivityRefreshButton');
+  refreshButton.textContent = 'Refresh';
+  inactivityActions.appendChild(stayButton);
+  inactivityActions.appendChild(refreshButton);
+  inactivityBody.appendChild(inactivityActions);
+
+  inactivityDialog.appendChild(inactivityBody);
+  inactivityOverlay.appendChild(inactivityDialog);
+  documentStub.body.appendChild(inactivityOverlay);
+
   let timerCounter = 1;
   const timers = new Map();
   const setTimeoutStub = vi.fn((handler) => {


### PR DESCRIPTION
## Summary
- implement an inactivity monitor that shows an AFK overlay, counts down, and refreshes the renderer when idle
- add markup and styling for the inactivity overlay and expose test hooks
- extend the bootstrap test sandbox and add a focused inactivity monitor test suite

## Testing
- npx vitest run tests/bootstrap-inactivity-monitor.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e48a79bc64832b864667831fd47211