### PR TITLE
Ensure audio fallback warnings fire for alias resolution

### DIFF
--- a/simple-experience.js
+++ b/simple-experience.js
@@ -28,8 +28,7 @@
             code: 'missing-sample',
             missingSample: true,
             fallbackActive: true,
-          },
-          { emitEvent: typeof audio?._resolve !== 'function' }
+          }
         );
       }
     }

--- a/tests/simple-experience-audio.test.js
+++ b/tests/simple-experience-audio.test.js
@@ -179,6 +179,42 @@ describe('SimpleExperience audio bootstrapping', () => {
 
     dispatchSpy.mockRestore();
   });
+
+  it('dispatches a missing audio warning when the welcome alias resolves to a fallback sample', () => {
+    const experience = prepareExperienceForBoot();
+    const resumeSpy = vi.fn();
+    const playSpy = vi.fn();
+    const hasSpy = vi.fn(() => false);
+    const resolveSpy = vi.fn(() => 'victoryCheer');
+    const windowStub = getWindowStub();
+    const dispatchSpy = vi.spyOn(windowStub, 'dispatchEvent').mockImplementation(() => {});
+
+    experience.audio = {
+      has: hasSpy,
+      play: playSpy,
+      resumeContextIfNeeded: resumeSpy,
+      _resolve: resolveSpy,
+    };
+
+    experience.start();
+
+    const audioErrorEvent = dispatchSpy.mock.calls
+      .map(([event]) => event)
+      .find((event) => event?.type === 'infinite-rails:audio-error');
+
+    expect(audioErrorEvent).toBeDefined();
+    expect(audioErrorEvent.detail).toEqual(
+      expect.objectContaining({
+        requestedName: 'welcome',
+        resolvedName: 'victoryCheer',
+        code: 'missing-sample',
+        missingSample: true,
+        fallbackActive: true,
+      }),
+    );
+
+    dispatchSpy.mockRestore();
+  });
 });
 
 describe('SimpleExperience audio diagnostics', () => {


### PR DESCRIPTION
## Summary
- ensure the welcome audio fallback always emits the audio error event even when an alias resolves to an alternate sample
- add a regression test that confirms the missing audio warning is dispatched when a fallback sample is used

## Testing
- npm test -- tests/simple-experience-audio.test.js *(fails: Illegal return statement raised while loading simple-experience.js in the test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68e55a37428c832bb17e267011418b3c