### PR TITLE
Add regression coverage for asset permissions and manifest availability

### DIFF
--- a/scripts/validate-asset-manifest.js
+++ b/scripts/validate-asset-manifest.js
@@ -755,6 +755,8 @@ if (require.main === module) {
 
 module.exports = {
   loadManifest,
+  loadTemplateDocument,
+  describeBucketPolicyIssues,
   ensureUniqueAssets,
   listMissingFiles,
   listPermissionIssues,

--- a/tests/asset-permission-audit.test.js
+++ b/tests/asset-permission-audit.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const repoRoot = path.resolve(__dirname, '..');
+const require = createRequire(import.meta.url);
+
+const {
+  loadManifest,
+  listPermissionIssues,
+  listAssetDirectoryPermissionIssues,
+  loadTemplateDocument,
+  describeBucketPolicyIssues,
+} = require('../scripts/validate-asset-manifest.js');
+
+describe('S3/CloudFront asset permission audit', () => {
+  const manifest = loadManifest();
+  const manifestAssetPaths = manifest.entries.map((entry) => entry.path);
+
+  it('ensures manifest assets are world-readable without stray permissions', () => {
+    expect(listPermissionIssues(manifestAssetPaths)).toEqual([]);
+  });
+
+  it('ensures all assets, textures, and audio directories are world-readable', () => {
+    expect(listAssetDirectoryPermissionIssues()).toEqual([]);
+  });
+
+  it('ensures the CloudFormation bucket policy only grants s3:GetObject to the CloudFront OAI', () => {
+    const templateDocument = loadTemplateDocument();
+    expect(describeBucketPolicyIssues(templateDocument)).toEqual([]);
+  });
+});

--- a/tests/manifest-availability-check.test.js
+++ b/tests/manifest-availability-check.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(__dirname, '..');
+const scriptSource = fs.readFileSync(path.join(repoRoot, 'script.js'), 'utf8');
+const indexHtml = fs.readFileSync(path.join(repoRoot, 'index.html'), 'utf8');
+
+describe('Manifest asset availability diagnostics', () => {
+  it('performs HEAD requests when probing manifest assets', () => {
+    const headProbePattern = /fetchWithTimeout\(asset\.url,\s*\{[^}]*method:\s*'HEAD'/;
+    expect(headProbePattern.test(scriptSource)).toBe(true);
+  });
+
+  it('renders missing manifest assets in the boot diagnostics UI', () => {
+    expect(scriptSource.includes('Manifest check missing')).toBe(true);
+    expect(indexHtml.includes('bootDiagnosticsAssetsList')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- expose the asset manifest validator helpers so tests can assert the CloudFront OAI bucket policy and world-readable prefixes
- add regression tests that audit the assets/, textures/, and audio/ trees plus manifest HEAD probing and diagnostics messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5cb312d28832bb8924aa2ea2ff787