### PR TITLE
Add CSP-compliant CDN guard loader

### DIFF
--- a/asset-manifest.json
+++ b/asset-manifest.json
@@ -12,6 +12,7 @@
     "downlevel-polyfills.js?v=2151404cf1c4.ec0befbcb2d5",
     "bootstrap-fallback.js?v=87161f0d5f84.ec0befbcb2d5",
     "boot-recovery.js?v=1a8d1c794902.ec0befbcb2d5",
+    "scripts/cdn-guard-loader.js?v=2d1bb5e67f10.ec0befbcb2d5",
     "scripts/cdn-guard.js?v=6130035b3bdc.ec0befbcb2d5",
     "script.js?v=bc5a275903b6.ec0befbcb2d5",
     "assets/index-latest.js?v=3554a7b2d7bc.ec0befbcb2d5",

--- a/index.html
+++ b/index.html
@@ -1931,6 +1931,7 @@
           "downlevel-polyfills.js?v=2151404cf1c4.ec0befbcb2d5",
           "bootstrap-fallback.js?v=87161f0d5f84.ec0befbcb2d5",
           "boot-recovery.js?v=1a8d1c794902.ec0befbcb2d5",
+          "scripts/cdn-guard-loader.js?v=2d1bb5e67f10.ec0befbcb2d5",
           "scripts/cdn-guard.js?v=6130035b3bdc.ec0befbcb2d5",
           "script.js?v=bc5a275903b6.ec0befbcb2d5",
           "assets/index-latest.js?v=3554a7b2d7bc.ec0befbcb2d5",
@@ -1969,9 +1970,9 @@
       }
     </script>
     <script
-      src="scripts/cdn-guard.js?v=6130035b3bdc.ec0befbcb2d5"
-      data-local-src="./scripts/cdn-guard.js?v=6130035b3bdc.ec0befbcb2d5"
-      onerror="(function(s){if(!s||s.dataset?.cdnRecoveryApplied==='true'){return;}var fallback=s.dataset?.localSrc; if(!fallback){return;} s.dataset.cdnRecoveryApplied='true'; s.onerror=null; s.src=fallback;})(this)"
+      src="scripts/cdn-guard-loader.js?v=2d1bb5e67f10.ec0befbcb2d5"
+      data-script-src="scripts/cdn-guard.js?v=6130035b3bdc.ec0befbcb2d5"
+      data-fallback-src="./scripts/cdn-guard.js?v=6130035b3bdc.ec0befbcb2d5"
     ></script>
     <script
       src="assets/controls.config.js?v=cbd23d5426be.ec0befbcb2d5"

--- a/scripts/cdn-guard-loader.js
+++ b/scripts/cdn-guard-loader.js
@@ -1,0 +1,108 @@
+(function initialiseCdnGuardLoader(globalScope) {
+  const scope =
+    globalScope && typeof globalScope === 'object'
+      ? globalScope
+      : typeof window !== 'undefined'
+        ? window
+        : typeof globalThis !== 'undefined'
+          ? globalThis
+          : null;
+  if (!scope) {
+    return;
+  }
+
+  const documentRef = scope.document || null;
+  if (!documentRef || typeof documentRef.createElement !== 'function') {
+    return;
+  }
+
+  const currentScript = documentRef.currentScript;
+  const loaderScript =
+    currentScript && currentScript.dataset && currentScript.dataset.scriptSrc
+      ? currentScript
+      : documentRef.querySelector('script[data-script-src]');
+  if (!loaderScript) {
+    return;
+  }
+
+  const readAttribute = (name) => {
+    const value = loaderScript.getAttribute(name);
+    return typeof value === 'string' ? value.trim() : '';
+  };
+
+  const scriptSrc =
+    readAttribute('data-script-src') ||
+    readAttribute('data-primary-src') ||
+    readAttribute('data-local-src') ||
+    'scripts/cdn-guard.js';
+  const fallbackSrc = readAttribute('data-fallback-src') || readAttribute('data-local-src') || scriptSrc;
+
+  const parent = loaderScript.parentNode || documentRef.head || documentRef.body || null;
+  if (!parent || typeof parent.insertBefore !== 'function') {
+    return;
+  }
+
+  const resolveUrl = (value) => {
+    if (!value) {
+      return '';
+    }
+    const base = loaderScript.src || scope.location?.href || undefined;
+    try {
+      return new URL(value, base).toString();
+    } catch (error) {
+      try {
+        return new URL(value, scope.location?.href || undefined).toString();
+      } catch (_) {
+        return value;
+      }
+    }
+  };
+
+  const primaryUrl = resolveUrl(scriptSrc);
+  const fallbackUrl = resolveUrl(fallbackSrc);
+  const hasDistinctFallback = Boolean(fallbackSrc) && fallbackSrc !== scriptSrc;
+  if (!primaryUrl) {
+    return;
+  }
+
+  const guardScript = documentRef.createElement('script');
+  guardScript.async = false;
+  guardScript.dataset = guardScript.dataset || {};
+  if (fallbackSrc) {
+    guardScript.dataset.localSrc = fallbackSrc;
+    guardScript.setAttribute('data-local-src', fallbackSrc);
+  }
+
+  let attemptedFallback = false;
+
+  const handleError = () => {
+    if (attemptedFallback || !fallbackUrl || (!hasDistinctFallback && fallbackUrl === guardScript.src)) {
+      attemptedFallback = true;
+      guardScript.removeEventListener('error', handleError);
+      if (scope.console && typeof scope.console.error === 'function') {
+        scope.console.error('[InfiniteRails] Failed to load CDN guard script.', {
+          primary: primaryUrl,
+          fallback: fallbackUrl || null,
+        });
+      }
+      return;
+    }
+    attemptedFallback = true;
+    guardScript.dataset.cdnRecoveryApplied = 'true';
+    guardScript.src = fallbackSrc;
+  };
+
+  const handleLoad = () => {
+    guardScript.removeEventListener('error', handleError);
+  };
+
+  guardScript.addEventListener('error', handleError);
+  guardScript.addEventListener('load', handleLoad, { once: true });
+  guardScript.src = scriptSrc;
+
+  if (loaderScript.nextSibling) {
+    parent.insertBefore(guardScript, loaderScript.nextSibling);
+  } else {
+    parent.appendChild(guardScript);
+  }
+})(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : undefined);


### PR DESCRIPTION
## Summary
- replace the inline CDN guard fallback with a loader script so failover works within the page CSP
- add the new loader asset to both manifests so deployment metadata stays consistent

## Testing
- npm run check:manifest

------
https://chatgpt.com/codex/tasks/task_b_69070f9a4f04832595835d33ff360b5b