### PR TITLE
Improve CDN failover handling after manifest 403s

### DIFF
--- a/script.js
+++ b/script.js
@@ -3337,6 +3337,13 @@ function applyManifestFailoverOverride(scope, context = {}) {
   } catch (error) {
     // ignore console failures during diagnostics failover
   }
+  emitAssetFailoverEvent(scope, {
+    fallbackAssetRoot: configFallbackRoot,
+    previousAssetRoot: previousRoot,
+    status: context?.status ?? null,
+    code: context?.code ?? null,
+    url: context?.url ?? null,
+  });
   return true;
 }
 
@@ -4931,6 +4938,56 @@ function getOrCreateAssetFailoverState(scope) {
   return state;
 }
 
+function emitAssetFailoverEvent(scope, detail = {}) {
+  if (!scope || typeof scope !== 'object') {
+    return null;
+  }
+  const payload = {
+    fallbackAssetRoot:
+      typeof detail?.fallbackAssetRoot === 'string' && detail.fallbackAssetRoot
+        ? detail.fallbackAssetRoot
+        : null,
+    previousAssetRoot:
+      typeof detail?.previousAssetRoot === 'string' && detail.previousAssetRoot
+        ? detail.previousAssetRoot
+        : null,
+    status: typeof detail?.status === 'number' ? detail.status : null,
+    code: detail?.code ?? null,
+    url: detail?.url ?? null,
+  };
+  try {
+    scope.__INFINITE_RAILS_LAST_FAILOVER_EVENT__ = payload;
+  } catch (error) {
+    // ignore assignment failures for diagnostics state
+  }
+  try {
+    const windowRef = scope.window && typeof scope.window === 'object' ? scope.window : null;
+    if (windowRef && windowRef !== scope) {
+      windowRef.__INFINITE_RAILS_LAST_FAILOVER_EVENT__ = payload;
+    }
+  } catch (error) {
+    // ignore assignment failures when mirroring diagnostics state to window
+  }
+  const target =
+    typeof scope.dispatchEvent === 'function'
+      ? scope
+      : typeof scope.window?.dispatchEvent === 'function'
+        ? scope.window
+        : null;
+  const EventCtor = scope.CustomEvent || (typeof CustomEvent !== 'undefined' ? CustomEvent : null);
+  try {
+    if (EventCtor && target) {
+      const event = new EventCtor('infinite-rails:asset-failover-activated', { detail: payload });
+      target.dispatchEvent(event);
+    } else if (target) {
+      target.dispatchEvent({ type: 'infinite-rails:asset-failover-activated', detail: payload });
+    }
+  } catch (error) {
+    // ignore dispatch failures to avoid interrupting failover
+  }
+  return payload;
+}
+
 function initialiseAssetFailover(scope, resolvedRoot) {
   const state = getOrCreateAssetFailoverState(scope);
   if (!state) {
@@ -5046,6 +5103,13 @@ function activateAssetFailover(scope, reason = {}) {
       trigger: state.reason,
     });
   }
+  emitAssetFailoverEvent(scope, {
+    fallbackAssetRoot: fallbackRoot,
+    previousAssetRoot: state.primaryRoot,
+    status: reason?.status ?? null,
+    code: reason?.code ?? null,
+    url: reason?.url ?? null,
+  });
   return true;
 }
 

--- a/scripts/cdn-guard.js
+++ b/scripts/cdn-guard.js
@@ -328,6 +328,26 @@
     rewritePendingScriptsToLocal();
   }
 
+  const handleManifestFailoverActivated = (event) => {
+    try {
+      const detail = event?.detail ?? {};
+      const status = typeof detail?.status === 'number' ? detail.status : 403;
+      const failoverSource = detail?.url || detail?.previousAssetRoot || null;
+      if (failoverSource) {
+        registerFailoverBlock(failoverSource, { status });
+      }
+      clearStoredOverrides();
+      ensureAppConfig();
+      rewritePendingScriptsToLocal();
+    } catch (error) {
+      try {
+        scope.console?.debug?.('CDN guard failover handler error suppressed.', error);
+      } catch (_) {
+        /* ignore console failures */
+      }
+    }
+  };
+
   const resolveOriginalSrc = (element) => {
     if (!element || typeof element.getAttribute !== 'function') {
       return null;
@@ -439,4 +459,5 @@
   };
 
   scope.addEventListener?.('error', recoverFromScriptFailure, true);
+  scope.addEventListener?.('infinite-rails:asset-failover-activated', handleManifestFailoverActivated);
 })(typeof window !== 'undefined' ? window : this);

--- a/tests/asset-failover.test.js
+++ b/tests/asset-failover.test.js
@@ -403,8 +403,7 @@ describe('asset CDN failover', () => {
 
     const fetchMock = vi.fn((resource, init = {}) => {
       const url = typeof resource === 'string' ? resource : resource?.url ?? '';
-      const method = typeof init?.method === 'string' ? init.method.toUpperCase() : 'GET';
-      if (url.includes('d3gj6x3ityfh5o.cloudfront.net') && method === 'HEAD') {
+      if (url.includes('d3gj6x3ityfh5o.cloudfront.net')) {
         return Promise.resolve(createResponse({ ok: false, status: 403, statusText: 'Forbidden' }));
       }
       return Promise.resolve(createResponse({ ok: true, status: 200, statusText: 'OK' }));
@@ -432,6 +431,50 @@ describe('asset CDN failover', () => {
     expect(secondProbe.reason).toBe('head-probe-ignored');
     expect(secondProbe.cached).toBe(true);
     expect(fetchMock.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('dispatches a failover event when manifest probes trigger the CDN fallback', async () => {
+    const { sandbox, windowStub } = createBootstrapSandbox({
+      appConfig: { assetRoot: 'https://d3gj6x3ityfh5o.cloudfront.net/' },
+    });
+
+    const manifestElement = windowStub.document.createElement('script');
+    manifestElement.setAttribute('id', 'assetManifest');
+    manifestElement.type = 'application/json';
+    manifestElement.textContent = JSON.stringify({
+      version: 1,
+      assetBaseUrl: 'https://d3gj6x3ityfh5o.cloudfront.net/',
+      assets: ['downlevel-polyfills.js'],
+    });
+    windowStub.document.body.appendChild(manifestElement);
+
+    const fetchMock = vi.fn((resource, init = {}) => {
+      const url = typeof resource === 'string' ? resource : resource?.url ?? '';
+      if (url.includes('d3gj6x3ityfh5o.cloudfront.net')) {
+        return Promise.resolve(createResponse({ ok: false, status: 403, statusText: 'Forbidden' }));
+      }
+      return Promise.resolve(createResponse({ ok: true, status: 200, statusText: 'OK' }));
+    });
+
+    sandbox.fetch = fetchMock;
+    sandbox.window.fetch = fetchMock;
+    windowStub.fetch = fetchMock;
+
+    evaluateBootstrapScript(sandbox);
+
+    const result = await sandbox.startManifestIntegrityVerification({
+      source: 'test',
+      scope: windowStub,
+    });
+
+    expect(result?.ok).toBe(true);
+    expect(windowStub.APP_CONFIG.assetRoot).toBe('./');
+    expect(windowStub.APP_CONFIG.assetBaseUrl).toBe('./');
+    const failoverDetail =
+      windowStub.__INFINITE_RAILS_LAST_FAILOVER_EVENT__ ?? sandbox.__INFINITE_RAILS_LAST_FAILOVER_EVENT__;
+    expect(failoverDetail).toEqual(
+      expect.objectContaining({ fallbackAssetRoot: './', previousAssetRoot: expect.any(String), status: 403 }),
+    );
   });
 
   it('ignores blocked CDN asset roots during bootstrap', () => {

--- a/tests/cdn-guard-failover.test.js
+++ b/tests/cdn-guard-failover.test.js
@@ -1,0 +1,135 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const cdnGuardSource = fs.readFileSync(path.join(repoRoot, 'scripts/cdn-guard.js'), 'utf8');
+
+function runCdnGuard(windowStub) {
+  const executor = new Function(
+    'window',
+    'globalThis',
+    'self',
+    "'use strict';" + cdnGuardSource,
+  );
+  executor(windowStub, windowStub, windowStub);
+}
+
+describe('CDN guard manifest failover integration', () => {
+  it('rewrites CDN script elements when the asset failover event is dispatched', () => {
+    const listeners = new Map();
+    const storage = new Map();
+    const localStorageStub = {
+      getItem: vi.fn((key) => (storage.has(key) ? storage.get(key) : null)),
+      setItem: vi.fn((key, value) => {
+        storage.set(key, value);
+      }),
+      removeItem: vi.fn((key) => {
+        storage.delete(key);
+      }),
+    };
+
+    const scriptElement = {
+      _src: 'https://d3gj6x3ityfh5o.cloudfront.net/script.js',
+      _attributes: new Map([['src', 'https://d3gj6x3ityfh5o.cloudfront.net/script.js']]),
+      dataset: { localSrc: 'script.js' },
+      parentNode: { insertBefore: vi.fn(), removeChild: vi.fn() },
+      set src(value) {
+        this._src = value;
+        this._attributes.set('src', value);
+      },
+      get src() {
+        return this._src;
+      },
+      setAttribute(name, value) {
+        this._attributes.set(name, value);
+        if (name === 'src') {
+          this.src = value;
+        }
+      },
+      getAttribute(name) {
+        return this._attributes.get(name) ?? null;
+      },
+    };
+
+    const documentStub = {
+      head: {},
+      body: {},
+      currentScript: null,
+      querySelectorAll(selector) {
+        if (selector === 'script[data-local-src]' || selector === 'script[src]') {
+          return [scriptElement];
+        }
+        return [];
+      },
+      createElement: vi.fn(() => ({
+        dataset: {},
+        setAttribute: vi.fn(),
+      })),
+    };
+
+    const windowStub = {
+      document: documentStub,
+      location: {
+        href: 'https://d3gj6x3ityfh5o.cloudfront.net/index.html',
+        protocol: 'https:',
+        host: 'd3gj6x3ityfh5o.cloudfront.net',
+        hostname: 'd3gj6x3ityfh5o.cloudfront.net',
+        origin: 'https://d3gj6x3ityfh5o.cloudfront.net',
+        search: '',
+      },
+      localStorage: localStorageStub,
+      APP_CONFIG: {},
+      console: { debug: vi.fn() },
+      addEventListener(type, listener) {
+        const eventType = String(type);
+        if (!listeners.has(eventType)) {
+          listeners.set(eventType, new Set());
+        }
+        listeners.get(eventType).add(listener);
+      },
+      removeEventListener(type, listener) {
+        const eventType = String(type);
+        const existing = listeners.get(eventType);
+        if (!existing) {
+          return;
+        }
+        existing.delete(listener);
+      },
+      dispatchEvent(event) {
+        const handlers = listeners.get(event.type);
+        if (!handlers) {
+          return true;
+        }
+        handlers.forEach((handler) => handler.call(windowStub, event));
+        return true;
+      },
+    };
+
+    runCdnGuard(windowStub);
+
+    const failoverHandlers = listeners.get('infinite-rails:asset-failover-activated');
+    expect(failoverHandlers?.size ?? 0).toBeGreaterThan(0);
+
+    const event = {
+      type: 'infinite-rails:asset-failover-activated',
+      detail: {
+        fallbackAssetRoot: './',
+        previousAssetRoot: 'https://d3gj6x3ityfh5o.cloudfront.net/',
+        status: 403,
+      },
+    };
+
+    failoverHandlers.forEach((handler) => handler.call(windowStub, event));
+
+    expect(scriptElement.src).toBe('script.js');
+    expect(scriptElement.dataset.cdnRecoveryApplied).toBe('true');
+    expect(localStorageStub.setItem).toHaveBeenCalledWith(
+      'InfiniteRails.assetRootFailoverBlock',
+      expect.stringContaining('d3gj6x3ityfh5o.cloudfront.net'),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- emit a dedicated asset failover event from the bootstrap when CDN manifest probes return 403 responses
- let the CDN guard listen for the new event and immediately rewrite script tags to the local bundle while recording the block
- cover the new behaviour with targeted asset failover and CDN guard tests

## Testing
- npm test -- tests/asset-failover.test.js tests/cdn-guard-failover.test.js

------
https://chatgpt.com/codex/tasks/task_e_690addc0f41883308b86d0ceccaef8b6