### PR TITLE
Persist local asset overrides after CDN failover

### DIFF
--- a/script.js
+++ b/script.js
@@ -3309,6 +3309,13 @@ function applyManifestFailoverOverride(scope, context = {}) {
     }
   }
   clearPersistedAssetRootOverrides(scope);
+  if (context?.status === 403 && shouldPersistLocalAssetOverride(scope, configFallbackRoot)) {
+    try {
+      persistAssetRootOverride(scope, configFallbackRoot);
+    } catch (error) {
+      // Ignore persistence failures when recording CDN overrides.
+    }
+  }
   try {
     const logMessage = preferProductionFallback
       ? '[InfiniteRails] Skipping remote manifest probes after CDN block.'
@@ -4897,6 +4904,33 @@ function resolveLocalAssetFallback(scope) {
   return DEFAULT_LOCAL_ASSET_ROOT;
 }
 
+function shouldPersistLocalAssetOverride(scope, candidate) {
+  if (!scope || typeof scope !== 'object') {
+    return false;
+  }
+  const normalised = normaliseAssetRootCandidate(candidate, scope);
+  if (!normalised) {
+    return false;
+  }
+  if (normalised === ensureTrailingSlash('./')) {
+    return true;
+  }
+  const location = getBootstrapLocation(scope);
+  const locationOrigin = ensureString(location?.origin).trim();
+  if (!locationOrigin) {
+    return false;
+  }
+  const parsed = parseAssetRootUrl(normalised, scope);
+  if (!parsed) {
+    return false;
+  }
+  try {
+    return ensureTrailingSlash(parsed.origin) === ensureTrailingSlash(locationOrigin);
+  } catch (error) {
+    return false;
+  }
+}
+
 function getOrCreateAssetFailoverState(scope) {
   if (!scope || typeof scope !== 'object') {
     return null;
@@ -5097,6 +5131,13 @@ function activateAssetFailover(scope, reason = {}) {
     appConfig.assetBaseUrl = fallbackRoot;
   }
   clearPersistedAssetRootOverrides(scope);
+  if (reason?.status === 403 && shouldPersistLocalAssetOverride(scope, fallbackRoot)) {
+    try {
+      persistAssetRootOverride(scope, fallbackRoot);
+    } catch (error) {
+      // Ignore persistence failures when attempting to cache local overrides.
+    }
+  }
   if (scope.console && typeof scope.console.info === 'function') {
     scope.console.info('[InfiniteRails] Asset CDN unavailable. Falling back to local bundle.', {
       fallbackAssetRoot: fallbackRoot,

--- a/tests/asset-failover.test.js
+++ b/tests/asset-failover.test.js
@@ -48,6 +48,8 @@ describe('asset CDN failover', () => {
     sandbox.window.fetch = fetchMock;
     windowStub.fetch = fetchMock;
 
+    const initialSetCallCount = sandbox.localStorage.setItem.mock.calls.length;
+
     evaluateBootstrapScript(sandbox);
 
     const wrappedFetch = windowStub.fetch;
@@ -61,6 +63,10 @@ describe('asset CDN failover', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(requests[0]).toBe(cdnAssetUrl);
     expect(requests[1]).toBe('./asset-manifest.json?assetVersion=1');
+
+    const newSetCalls = sandbox.localStorage.setItem.mock.calls.slice(initialSetCallCount);
+    const persistedOverride = newSetCalls.filter(([key]) => key === 'infiniteRails.assetRootOverride');
+    expect(persistedOverride.some(([, value]) => value === './')).toBe(true);
 
     const failoverStateBefore = windowStub.__INFINITE_RAILS_TEST_HOOKS__?.getAssetFailoverState?.();
     expect(failoverStateBefore?.failoverActive).toBe(true);
@@ -130,11 +136,17 @@ describe('asset CDN failover', () => {
     windowStub.location.host = 'localhost:3000';
     windowStub.location.hostname = 'localhost';
 
+    const initialSetCallCount = sandbox.localStorage.setItem.mock.calls.length;
+
     sandbox.applyManifestFailoverOverride(windowStub, {
       type: 'http',
       status: 403,
       url: 'https://d3gj6x3ityfh5o.cloudfront.net/scripts/cdn-guard.js',
     });
+
+    const newSetCalls = sandbox.localStorage.setItem.mock.calls.slice(initialSetCallCount);
+    const persistedOverride = newSetCalls.filter(([key]) => key === 'infiniteRails.assetRootOverride');
+    expect(persistedOverride.some(([, value]) => value === 'http://localhost:3000/')).toBe(true);
 
     expect(windowStub.APP_CONFIG.assetRoot).toBe('http://localhost:3000/');
 


### PR DESCRIPTION
## Summary
- persist the resolved local asset root when CDN manifest probes encounter HTTP 403 responses so subsequent reloads stay offline
- add safeguards that only cache same-origin or relative fallbacks when recording failover overrides
- extend asset failover tests to assert that local overrides are persisted after CDN blocks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690b5aa102b88330afaaea96587234a5